### PR TITLE
発行済トークン一覧API追加

### DIFF
--- a/app/api/v1/contracts.py
+++ b/app/api/v1/contracts.py
@@ -6,7 +6,7 @@ from web3 import Web3
 
 from app import log
 from app.api.common import BaseResource
-from app.model import Contract
+from app.model import Contract, TokenTemplate
 from app.errors import AppError, InvalidParameterError, DataNotExistsError
 
 LOG = log.get_logger()
@@ -47,6 +47,74 @@ class ContractDeploy(BaseResource):
         validator = Validator({
             'template_id': {'type': 'integer', 'empty': False, 'required': True},
             'raw_tx_hex': {'type': 'string', 'empty': False, 'required': True}
+        })
+
+        if not validator.validate(request_json):
+            raise InvalidParameterError(validator.errors)
+
+        return request_json
+
+
+# ------------------------------
+# 発行済みトークン一覧
+# ------------------------------
+class MyContracts(BaseResource):
+    '''
+    Handle for endpoint: /v1/MyContracts
+    '''
+    def on_post(self, req, res):
+        LOG.info('v1.contracts.MyContracts')
+        session = req.context['session']
+
+        request_json = MyContracts.validate(req)
+        address_tuple = tuple(request_json['address_list'])
+
+        contract_db_list = session.query(Contract).filter(
+            Contract.admin_address.in_(address_tuple)
+        ).all()
+
+        mycontracts = []
+        for contract_db in contract_db_list:
+            row = contract_db.to_dict()
+
+            try:
+                token_template = TokenTemplate.find_one(
+                    session, row['template_id']
+                ).to_dict()
+            except NoResultFound:
+                raise DataNotExistsError()
+
+            web3 = Web3(Web3.HTTPProvider('http://localhost:8545'))
+            token_contract = web3.eth.contract(
+                address=row['contract_address'],
+                abi = token_template['abi'],
+                bytecode = token_template['bytecode'],
+                bytecode_runtime = token_template['bytecode_runtime']
+            )
+            token_name = token_contract.functions.name().call()
+
+            mycontracts.append({
+                'admin_address': row['admin_address'],
+                'contract_address': row['contract_address'],
+                'template_name': token_template['template_name'],
+                'token_name': token_name
+            })
+
+        self.on_success(res, mycontracts)
+
+    @staticmethod
+    def validate(req):
+        request_json = req.context['data']
+        if request_json is None:
+            raise InvalidParameterError
+
+        validator = Validator({
+            'address_list': {
+                'type': 'list',
+                'schema': {'type': 'string'},
+                'empty': False,
+                'required': True
+            }
         })
 
         if not validator.validate(request_json):

--- a/app/main.py
+++ b/app/main.py
@@ -40,8 +40,11 @@ class App(falcon.API):
         # トークン新規発行
         self.add_route('/v1/Contract', contracts.ContractDeploy())
 
+        # 発行済みトークン一覧
+        self.add_route('/v1/MyContracts', contracts.MyContracts())
+
         # 保有トークン一覧
-        self.add_route('/v1/MyTokens/', position.MyTokens())
+        self.add_route('/v1/MyTokens', position.MyTokens())
 
         self.add_error_handler(AppError, AppError.handle)
 


### PR DESCRIPTION
自身が発行したトークンの一覧を照会するためのAPI機能を追加しました。

■入力
　・アカウントアドレスのリスト　※一つのウォレットが複数のアドレスを保有している想定。

```json
{
  "address_list":["0x1e770b6e52ddbee99209db0ef73fe7c18a119ed0","aaaaaa"]
}
```

■出力
　以下のリスト
　・管理者のアドレス
　・コントラクトアドレス
　・商品分類（テンプレート名）
　・トークン名

```json
{
    "meta": {
        "code": 200,
        "message": "OK"
    },
    "data": [
        {
            "admin_address": "0x1e770b6e52ddbee99209db0ef73fe7c18a119ed0",
            "contract_address": "0x02D59c68cd52621Ff0B20CfEcE5e1f937a6f80fC",
            "template_name": "MyToken",
            "token_name": "testcoin"
        }
    ]
}
```