### PR TITLE
機能追加：通知全件既読API

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -76,6 +76,7 @@ class App(falcon.API):
 
         # 通知一覧
         self.add_route('/v1/Notifications', notification.Notifications())
+        self.add_route('/v1/Notifications/Read', notification.NotificationsRead())
         self.add_route('/v1/NotificationCount', notification.NotificationCount())
 
         # 決済用口座登録状況参照


### PR DESCRIPTION
close #220 

以下の仕様で実装しています。

- 全てX-ibet-Signature をリクエストヘッダに指定する
- /v1/Notifications/Read
- POST
- 入力
    ```
    is_read: boolean;
    ```
- 出力
    ```
    { 
      "meta":{  
        "code":200,
        "message":"OK"
      }
    }
    ```