### PR TITLE
銘柄リスティング対応

### DIFF
--- a/async/processor_OrderAgree.py
+++ b/async/processor_OrderAgree.py
@@ -228,16 +228,19 @@ class Processor:
                     if args['price'] > sys.maxsize or args['amount'] > sys.maxsize:
                         pass
                     else:
-                        self.sink.on_new_order(
-                            token_address = args['tokenAddress'],
-                            exchange_address = exchange_contract.address,
-                            order_id = args['orderId'],
-                            account_address = args['accountAddress'],
-                            is_buy = args['isBuy'],
-                            price = args['price'],
-                            amount = args['amount'],
-                            agent_address = args['agentAddress'],
-                        )
+                        available_token = self.db.query(Listing).\
+                            filter(Listing.token_address == args['tokenAddress'])
+                        if available_token is not None:
+                            self.sink.on_new_order(
+                                token_address = args['tokenAddress'],
+                                exchange_address = exchange_contract.address,
+                                order_id = args['orderId'],
+                                account_address = args['accountAddress'],
+                                is_buy = args['isBuy'],
+                                price = args['price'],
+                                amount = args['amount'],
+                                agent_address = args['agentAddress'],
+                            )
             except:
                 pass
 


### PR DESCRIPTION
#218 

①リスティングされた銘柄から発生する注文イベント、約定イベントのみをDBに取り込みするように、機能修正を行なった。
②①の対応により、注文中一覧・決済中一覧・約定一覧にもリスティングされた銘柄に関する情報のみが表示されるようになった。