### PR TITLE
[WIP] [Stripe]決済系 エラーハンドリング改善

### DIFF
--- a/app/api/v1/stripe.py
+++ b/app/api/v1/stripe.py
@@ -462,14 +462,6 @@ class Charge(BaseResource):
             # Charge状態を[ERROR]ステータスに更新する
             stripe_charge.status = StripeChargeStatus.ERROR.value
             raise AppError(description='Too many requests hit the API too quickly.')
-        # except stripe.error.ValidationError as e:
-        #     # Charge状態を[ERROR]ステータスに更新する
-        #     stripe_charge.status = StripeChargeStatus.ERROR.value
-        #     raise AppError(description='Errors triggered by our client-side libraries when failing to validate fields')
-        # except stripe.error.Card_Error as e:
-        #     # Charge状態を[ERROR]ステータスに更新する
-        #     stripe_charge.status = StripeChargeStatus.ERROR.value
-        #     raise InvalidParameterError(description=str(e))
         except Exception as err:
             # Charge状態を[ERROR]ステータスに更新する
             stripe_charge.status = StripeChargeStatus.ERROR.value


### PR DESCRIPTION
DBから情報を読み込むときに、
.first()
を用いているため、order_idとagreement_idにユニーク制約をつけないと意図せぬ挙動が起こる問題の対処も含む