### PR TITLE
#408 add Stripe constants API

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -68,7 +68,9 @@ OMISE_PUBLIC = os.environ.get('OMISE_PUBLIC')
 
 # stripe setting
 STRIPE_SECRET = os.environ.get('STRIPE_SECRET')
-STRIPE_FEE = os.environ.get('STRIPE_FEE')
+STRIPE_FEE = os.environ.get('STRIPE_FEE') or 0.1
+STRIPE_MINIMUM_VALUE = os.environ.get('STRIPE_MINIMUM_VALUE') or 50
+STRIPE_MAXIMUM_VALUE = os.environ.get('STRIPE_MAXIMUM_VALUE') or 500000
 
 # push notification setting
 SNS_APPLICATION_ARN_IOS = os.environ.get('SNS_APPLICATION_ARN_IOS')

--- a/app/main.py
+++ b/app/main.py
@@ -118,7 +118,7 @@ class App(falcon.API):
         self.add_route('/v1/Stripe/Charge', stripe.Charge())
         self.add_route('/v1/Stripe/AccountStatus', stripe.AccountStatus())
         self.add_route('/v1/Stripe/ChargeStatus', stripe.ChargeStatus())
-        self.add_route('/v1/Stripe/FeeInfo', stripe.FeeInfo())
+        self.add_route('/v1/Stripe/Constants', stripe.Constants())
 
         # push通知デバイス登録
         self.add_route('/v1/Push/UpdateDevice', push.UpdateDevice())

--- a/app/tests/v1_stripe_charge_test.py
+++ b/app/tests/v1_stripe_charge_test.py
@@ -211,6 +211,46 @@ class TestV1StripeCharge:
             'message': 'Invalid Parameter'
         }
 
+    # エラー系3-4
+    # amountの値が小さすぎる
+    def test_stripe_charge_error_3_4(self, client, session):
+        resp = client.simulate_auth_post(
+            self.apiurl,
+            json={
+                "order_id": self.order_id,
+                "agreement_id": self.agreement_id,
+                "amount": 5,
+                "exchange_address": self.exchange_address
+            },
+            private_key=TestV1StripeCharge.private_key_1
+        )
+
+        assert resp.status_code == 400
+        assert resp.json["meta"] == {
+            'code': 88,
+            'message': 'Invalid Parameter'
+        }
+
+    # エラー系3-5
+    # amountの値が大きすぎる
+    def test_stripe_charge_error_3_5(self, client, session):
+        resp = client.simulate_auth_post(
+            self.apiurl,
+            json={
+                "order_id": self.order_id,
+                "agreement_id": self.agreement_id,
+                "amount": 100000000,
+                "exchange_address": self.exchange_address
+            },
+            private_key=TestV1StripeCharge.private_key_1
+        )
+
+        assert resp.status_code == 400
+        assert resp.json["meta"] == {
+            'code': 88,
+            'message': 'Invalid Parameter'
+        }
+
     # ＜エラー系4＞
     # ヘッダー（Signature）なし
     def test_stripe_charge_error_4(self, client, session):

--- a/app/tests/v1_stripe_constants_test.py
+++ b/app/tests/v1_stripe_constants_test.py
@@ -5,21 +5,21 @@ from app import config
 
 
 # 手数料返却API
-# /v1/Stripe/FeeInfo
-class TestV1FeeInfo:
+# /v1/Stripe/Constants
+class TestV1Constants:
 
     # テスト対象API
-    apiurl = '/v1/Stripe/FeeInfo'
+    apiurl = '/v1/Stripe/Constants'
 
     # ＜正常系1＞
     # 通常参照（登録済）
     def test_stripe_feeinfo_normal_1(self, client):
-        assumed_body = { 'stripe':
-                {
+        assumed_body = {
                     'commitment_fee': float(config.STRIPE_FEE),
-                    'fix_fee': 0
+                    'fix_fee': 0,
+                    'minimum_value': int(config.STRIPE_MINIMUM_VALUE), 
+                    'maximum_value': int(config.STRIPE_MAXIMUM_VALUE)
                 }
-            }
 
         resp = client.simulate_get(self.apiurl)
 

--- a/doc/source/api_v1_doc/stripe.md
+++ b/doc/source/api_v1_doc/stripe.md
@@ -1074,13 +1074,13 @@ curl -X POST \
 }
 ```
 
-## GET: /v1/Stripe/FeeInfo
+## GET: /v1/Stripe/Constants
 * stripeを決済手段として利用した際の手数料情報を返却する
 
 ### Sample
 ```sh
 curl -X GET \
-  http://localhost:5000/v1/Stripe/FeeInfo \
+  http://localhost:5000/v1/Stripe/Constants \
   -H 'Content-Type: application/json' \
   -H 'cache-control: no-cache'
 ```
@@ -1097,16 +1097,18 @@ curl -X GET \
         "message": "OK"
     },
     "data": {
-        "stripe": {
-            "commitment_fee": 0.1,
-            "fix_fee": 0
-        }
+        "commitment_fee": 0.1,
+        "fix_fee": 0,
+        "minimum_value": 1000,
+        "maximum_value": 500000
     }
 }
 ```
 * `stripe` : 
     * `commitment_fee` : 決済手数料（率）
     * `fix_fee` : 決済手数料（固定）
+    * `minimum_value` : 最小決済金額（円）
+    * `maximum_value` : 最大決済金額（円）
 
 ## POST: /v1/Stripe/DeleteAccount
 * アドレスにひもづくstripeアカウント情報をクリアする


### PR DESCRIPTION
close #408 

ポイント
- FeeInfo APIをConstantsに命名変更
- 下限値、上限値をconfigにもち、返す
- Charge APIでのチェックを追加（＋テスト）