### PR TITLE
メモリリーク防止

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 function start () {
     #source .venv/bin/activate
-    gunicorn -b 0.0.0.0:5000 --reload app.main:application --timeout 30 --workers=$WORKER_COUNT
+    gunicorn -b 0.0.0.0:5000 --reload app.main:application --timeout 30 --workers=$WORKER_COUNT --max-requests 500 --max-requests-jitter 200
 }
 
 function stop () {

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,7 @@ semantic-version==2.6.0
 six==1.11.0
 SQLAlchemy==1.2.2
 toolz==0.9.0
-web3==4.2.1
+web3==4.8.2
 websockets==4.0.1
 boto3==1.9.84
 stripe==2.24.1


### PR DESCRIPTION
・Gunicorn起動パラメータに max_requests と max_requests_jitter を追加。
https://qiita.com/ryu22e/items/2668a2243a5191bcdc78
・max_requests -> 500
・max_requests_jitter -> 200
・web3.pyのメモリリーク修正版バージョンへアップデート（https://web3py.readthedocs.io/en/stable/releases.html#v4-8-2）
