### PR TITLE
feat: add token detail api

### DIFF
--- a/app/api/v2/token.py
+++ b/app/api/v2/token.py
@@ -11,7 +11,7 @@ from eth_utils import to_checksum_address
 
 from app import log
 from app.api.common import BaseResource
-from app.errors import InvalidParameterError
+from app.errors import InvalidParameterError, DataNotExistsError
 from app import config
 from app.contracts import Contract
 from app.model import Listing, MembershipToken, CouponToken
@@ -93,7 +93,8 @@ class MembershipTokens(BaseResource):
 
         self.on_success(res, token_list)
 
-    def get_token_detail(self, token_id, token_address, token_template, owner_address, company_list, available_token):
+    @staticmethod
+    def get_token_detail(token_id, token_address, token_template, owner_address, company_list, available_token):
         """
         トークン詳細を取得する。
         取得に失敗した場合はNoneを返す。
@@ -201,6 +202,152 @@ class MembershipTokens(BaseResource):
 
 
 # ------------------------------
+# [会員権]トークン詳細
+# ------------------------------
+class MembershipTokenDetails(BaseResource):
+    """
+    Handle for endpoint: /v2/Token/Membership/{contract_address}
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
+        self.web3.middleware_stack.inject(geth_poa_middleware, layer=0)
+
+    def on_get(self, req, res, contract_address):
+        LOG.info('v2.token.MembershipTokenDetails')
+
+        try:
+            contract_address = to_checksum_address(contract_address)
+            if not Web3.isAddress(contract_address):
+                description = 'invalid contract_address'
+                raise InvalidParameterError(description=description)
+        except:
+            description = 'invalid contract_address'
+            raise InvalidParameterError(description=description)
+
+        session = req.context["session"]
+
+        # TokenList-Contractへの接続
+        ListContract = Contract.get_contract(
+            'TokenList', config.TOKEN_LIST_CONTRACT_ADDRESS)
+
+        # 企業リストの情報を取得する
+        company_list = []
+        try:
+            if config.APP_ENV == 'local':
+                company_list = json.load(open('data/company_list.json', 'r'))
+            else:
+                company_list = \
+                    requests.get(config.COMPANY_LIST_URL, timeout=config.REQUEST_TIMEOUT).json()
+        except Exception as err:
+            LOG.error(err)
+            pass
+
+        # TokenList-Contractからトークンの情報を取得する
+        token_address = to_checksum_address(contract_address)
+        token = ListContract.functions. \
+            getTokenByAddress(token_address).call()
+
+        # 取扱トークン情報を取得
+        listed_token = session.query(Listing).\
+            filter(Listing.token_address == contract_address).first()
+
+        if listed_token is None:
+            raise DataNotExistsError('contract_address: %s' % contract_address)
+
+        token_detail = self.get_token_detail(
+            company_list=company_list,
+            token_address=token[0],
+            token_template=token[1],
+            owner_address=token[2],
+            listed_token=listed_token
+        )
+
+        if token_detail is None:
+            raise DataNotExistsError('contract_address: %s' % contract_address)
+
+        self.on_success(res, token_detail)
+
+    @staticmethod
+    def get_token_detail(token_address, token_template, owner_address, company_list, listed_token):
+        """
+        トークン詳細を取得する。
+        取得に失敗した場合はNoneを返す。
+        """
+
+        if token_template == 'IbetMembership':
+            try:
+                # Token-Contractへの接続
+                TokenContract = Contract.get_contract(
+                    'IbetMembership',
+                    to_checksum_address(token_address)
+                )
+
+                # 取扱停止銘柄はリストに返さない
+                if not TokenContract.functions.status().call():
+                    return None
+
+                # Token-Contractから情報を取得する
+                name = TokenContract.functions.name().call()
+                symbol = TokenContract.functions.symbol().call()
+                total_supply = TokenContract.functions.totalSupply().call()
+                details = TokenContract.functions.details().call()
+                return_details = TokenContract.functions.returnDetails().call()
+                expiration_date = TokenContract.functions.expirationDate().call()
+                memo = TokenContract.functions.memo().call()
+                transferable = TokenContract.functions.transferable().call()
+                status = TokenContract.functions.status().call()
+                image_url_1 = TokenContract.functions.image_urls(0).call()
+                image_url_2 = TokenContract.functions.image_urls(1).call()
+                image_url_3 = TokenContract.functions.image_urls(2).call()
+                initial_offering_status = \
+                    TokenContract.functions.initialOfferingStatus().call()
+                contact_information = TokenContract.functions.contactInformation().call()
+                privacy_policy = TokenContract.functions.privacyPolicy().call()
+
+                # 企業リストから、企業名とRSA鍵を取得する
+                company_name = ''
+                rsa_publickey = ''
+                for company in company_list:
+                    if to_checksum_address(company['address']) == owner_address:
+                        company_name = company['corporate_name']
+                        rsa_publickey = company['rsa_publickey']
+
+                membershiptoken = MembershipToken()
+                membershiptoken.token_address = token_address
+                membershiptoken.token_template = token_template
+                membershiptoken.owner_address = owner_address
+                membershiptoken.company_name = company_name
+                membershiptoken.rsa_publickey = rsa_publickey
+                membershiptoken.name = name
+                membershiptoken.symbol = symbol
+                membershiptoken.total_supply = total_supply
+                membershiptoken.details = details
+                membershiptoken.return_details = return_details
+                membershiptoken.expiration_date = expiration_date
+                membershiptoken.memo = memo
+                membershiptoken.transferable = transferable
+                membershiptoken.status = status
+                membershiptoken.initial_offering_status = initial_offering_status
+                membershiptoken.image_url = [
+                    {'id': 1, 'url': image_url_1},
+                    {'id': 2, 'url': image_url_2},
+                    {'id': 3, 'url': image_url_3},
+                ]
+                membershiptoken.payment_method_credit_card = listed_token.payment_method_credit_card
+                membershiptoken.payment_method_bank = listed_token.payment_method_bank
+                membershiptoken.contact_information = contact_information
+                membershiptoken.privacy_policy = privacy_policy
+                membershiptoken = membershiptoken.__dict__
+
+                return membershiptoken
+            except Exception as e:
+                LOG.error(e)
+                return None
+
+
+# ------------------------------
 # [クーポン]公開中トークン一覧
 # ------------------------------
 class CouponTokens(BaseResource):
@@ -277,7 +424,8 @@ class CouponTokens(BaseResource):
 
         self.on_success(res, token_list)
 
-    def get_token_detail(self, token_id, token_address, token_template,
+    @staticmethod
+    def get_token_detail(token_id, token_address, token_template,
                          owner_address, company_list, available_token):
         """
         トークン詳細を取得する。
@@ -382,3 +530,148 @@ class CouponTokens(BaseResource):
             raise InvalidParameterError(validator.errors)
 
         return validator.document
+
+
+# ------------------------------
+# [クーポン]トークン詳細
+# ------------------------------
+class CouponTokenDetails(BaseResource):
+    """
+    Handle for endpoint: /v2/Token/Coupon/{contract_address}
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
+        self.web3.middleware_stack.inject(geth_poa_middleware, layer=0)
+
+    def on_get(self, req, res, contract_address):
+        LOG.info('v2.token.CouponTokenDetails')
+
+        try:
+            contract_address = to_checksum_address(contract_address)
+            if not Web3.isAddress(contract_address):
+                description = 'invalid contract_address'
+                raise InvalidParameterError(description=description)
+        except:
+            description = 'invalid contract_address'
+            raise InvalidParameterError(description=description)
+
+        session = req.context["session"]
+
+        # TokenList-Contractへの接続
+        ListContract = Contract.get_contract(
+            'TokenList', config.TOKEN_LIST_CONTRACT_ADDRESS)
+
+        # 企業リストの情報を取得する
+        company_list = []
+        try:
+            if config.APP_ENV == 'local':
+                company_list = json.load(open('data/company_list.json', 'r'))
+            else:
+                company_list = \
+                    requests.get(config.COMPANY_LIST_URL, timeout=config.REQUEST_TIMEOUT).json()
+        except Exception as err:
+            LOG.error(err)
+            pass
+
+        # TokenList-Contractからトークンの情報を取得する
+        token_address = to_checksum_address(contract_address)
+        token = ListContract.functions. \
+            getTokenByAddress(token_address).call()
+
+        # 取扱トークン情報を取得
+        listed_token = session.query(Listing). \
+            filter(Listing.token_address == contract_address).first()
+
+        if listed_token is None:
+            raise DataNotExistsError('contract_address: %s' % contract_address)
+
+        token_detail = self.get_token_detail(
+            company_list=company_list,
+            token_address=token[0],
+            token_template=token[1],
+            owner_address=token[2],
+            listed_token=listed_token
+        )
+
+        if token_detail is None:
+            raise DataNotExistsError('contract_address: %s' % contract_address)
+
+        self.on_success(res, token_detail)
+
+    @staticmethod
+    def get_token_detail(token_address, token_template, owner_address, company_list, listed_token):
+        """
+        トークン詳細を取得する。
+        取得に失敗した場合はNoneを返す。
+        """
+
+        if token_template == 'IbetCoupon':
+            try:
+                # Token-Contractへの接続
+                TokenContract = Contract.get_contract(
+                    'IbetCoupon',
+                    to_checksum_address(token_address)
+                )
+
+                # 取扱停止銘柄はリストに返さない
+                if not TokenContract.functions.status().call():
+                    return None
+
+                # Token-Contractから情報を取得する
+                name = TokenContract.functions.name().call()
+                symbol = TokenContract.functions.symbol().call()
+                total_supply = TokenContract.functions.totalSupply().call()
+                details = TokenContract.functions.details().call()
+                return_details = TokenContract.functions.returnDetails().call()
+                expiration_date = TokenContract.functions.expirationDate().call()
+                memo = TokenContract.functions.memo().call()
+                transferable = TokenContract.functions.transferable().call()
+                status = TokenContract.functions.status().call()
+                image_url_1 = TokenContract.functions.image_urls(0).call()
+                image_url_2 = TokenContract.functions.image_urls(1).call()
+                image_url_3 = TokenContract.functions.image_urls(2).call()
+                initial_offering_status = \
+                    TokenContract.functions.initialOfferingStatus().call()
+                contact_information = TokenContract.functions.contactInformation().call()
+                privacy_policy = TokenContract.functions.privacyPolicy().call()
+
+                # 企業リストから、企業名とRSA鍵を取得する
+                company_name = ''
+                rsa_publickey = ''
+                for company in company_list:
+                    if to_checksum_address(company['address']) == owner_address:
+                        company_name = company['corporate_name']
+                        rsa_publickey = company['rsa_publickey']
+                coupontoken = CouponToken()
+                coupontoken.token_address = token_address
+                coupontoken.token_template = token_template
+                coupontoken.owner_address = owner_address
+                coupontoken.company_name = company_name
+                coupontoken.rsa_publickey = rsa_publickey
+                coupontoken.name = name
+                coupontoken.symbol = symbol
+                coupontoken.total_supply = total_supply
+                coupontoken.details = details
+                coupontoken.return_details = return_details
+                coupontoken.expiration_date = expiration_date
+                coupontoken.memo = memo
+                coupontoken.transferable = transferable
+                coupontoken.status = status
+                coupontoken.initial_offering_status = initial_offering_status
+                coupontoken.image_url = [
+                    {'id': 1, 'url': image_url_1},
+                    {'id': 2, 'url': image_url_2},
+                    {'id': 3, 'url': image_url_3},
+                ]
+                coupontoken.payment_method_credit_card = listed_token.payment_method_credit_card
+                coupontoken.payment_method_bank = listed_token.payment_method_bank
+                coupontoken.contact_information = contact_information
+                coupontoken.privacy_policy = privacy_policy
+                coupontoken = coupontoken.__dict__
+
+                return coupontoken
+            except Exception as e:
+                LOG.error(e)
+                return None

--- a/app/main.py
+++ b/app/main.py
@@ -141,6 +141,10 @@ class App(falcon.API):
         self.add_route('/v2/Token/Membership', token.MembershipTokens())
         self.add_route('/v2/Token/Coupon', token.CouponTokens())
 
+        # トークン詳細参照
+        self.add_route('/v2/Token/Membership/{contract_address}', token.MembershipTokenDetails())
+        self.add_route('/v2/Token/Coupon/{contract_address}', token.CouponTokenDetails())
+
         # マーケット情報：オーダーブック
         self.add_route('/v2/Market/OrderBook/Membership', market_information.MembershipOrderBook())
         self.add_route('/v2/Market/OrderBook/Coupon', market_information.CouponOrderBook())

--- a/app/tests/v2_token_coupontokendetails_test.py
+++ b/app/tests/v2_token_coupontokendetails_test.py
@@ -1,0 +1,194 @@
+# -*- coding: utf-8 -*-
+from eth_utils import to_checksum_address
+from web3 import Web3
+from web3.middleware import geth_poa_middleware
+
+from app.model import Listing
+from app import config
+from app.contracts import Contract
+
+from .account_config import eth_account
+from .contract_modules import issue_coupon_token, coupon_register_list, invalidate_coupon_token
+
+web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
+web3.middleware_stack.inject(geth_poa_middleware, layer=0)
+
+
+class TestV2TokenCouponTokenDetails():
+    """
+    Test Case for v2.token.CouponTokenDetails
+    """
+
+    # テスト対象API
+    apiurl_base = '/v2/Token/Coupon/' # {contract_address}
+
+    def token_attribute(exchange_address):
+        attribute = {
+            'name': 'テストクーポン',
+            'symbol': 'COUPON',
+            'totalSupply': 10000,
+            'tradableExchange': exchange_address,
+            'details': 'クーポン詳細',
+            'returnDetails': 'リターン詳細',
+            'memo': 'クーポンメモ欄',
+            'expirationDate': '20191231',
+            'transferable': True,
+            'contactInformation': '問い合わせ先',
+            'privacyPolicy': 'プライバシーポリシー'
+        }
+        return attribute
+
+    @staticmethod
+    def tokenlist_contract():
+        deployer = eth_account['deployer']
+        web3.eth.defaultAccount = deployer['account_address']
+        web3.personal. \
+            unlockAccount(deployer['account_address'], deployer['password'])
+        contract_address, abi = Contract. \
+            deploy_contract('TokenList', [], deployer['account_address'])
+        return {'address': contract_address, 'abi': abi}
+
+    def list_token(session, token):
+        listed_token = Listing()
+        listed_token.token_address = token['address']
+        listed_token.payment_method_credit_card = True
+        listed_token.payment_method_bank = True
+        session.add(listed_token)
+
+    # ＜正常系1＞
+    #   データあり
+    def test_coupondetails_normal_1(self, client, session, shared_contract):
+        # テスト用アカウント
+        issuer = eth_account['issuer']
+
+        # TokenListコントラクト
+        token_list = TestV2TokenCouponTokenDetails.tokenlist_contract()
+        config.TOKEN_LIST_CONTRACT_ADDRESS = token_list['address']
+
+        # データ準備：新規発行
+        exchange_address = \
+            to_checksum_address(
+                shared_contract['IbetCouponExchange']['address'])
+        attribute = TestV2TokenCouponTokenDetails.token_attribute(exchange_address)
+        token = issue_coupon_token(issuer, attribute)
+        coupon_register_list(issuer, token, token_list)
+
+        # 取扱トークンデータ挿入
+        TestV2TokenCouponTokenDetails.list_token(session, token)
+
+        apiurl = self.apiurl_base + token['address']
+        query_string = ''
+        resp = client.simulate_get(apiurl, query_string=query_string)
+
+        assumed_body = {
+            'token_address': token['address'],
+            'token_template': 'IbetCoupon',
+            'owner_address': issuer['account_address'],
+            'company_name': '',
+            'rsa_publickey': '',
+            'name': 'テストクーポン',
+            'symbol': 'COUPON',
+            'total_supply': 10000,
+            'details': 'クーポン詳細',
+            'return_details': 'リターン詳細',
+            'memo': 'クーポンメモ欄',
+            'expiration_date': '20191231',
+            'transferable': True,
+            'status': True,
+            'initial_offering_status': False,
+            'image_url': [
+                {'id': 1, 'url': ''},
+                {'id': 2, 'url': ''},
+                {'id': 3, 'url': ''}
+            ],
+            'payment_method_credit_card': True,
+            'payment_method_bank': True,
+            'contact_information': '問い合わせ先',
+            'privacy_policy': 'プライバシーポリシー'
+        }
+
+        assert resp.status_code == 200
+        assert resp.json['meta'] == {'code': 200, 'message': 'OK'}
+        assert resp.json['data'] == assumed_body
+
+    # ＜エラー系1＞
+    #   無効なコントラクトアドレス
+    #   -> 400エラー
+    def test_coupondetails_error_1(self, client):
+        apiurl = self.apiurl_base + '0xabcd'
+
+        query_string = ''
+        resp = client.simulate_get(apiurl, query_string=query_string)
+
+        assert resp.status_code == 400
+        assert resp.json['meta'] == {
+            'code': 88,
+            'message': 'Invalid Parameter',
+            'description': 'invalid contract_address'
+        }
+
+    # ＜エラー系2＞
+    #   取扱トークン（DB）に情報が存在しない
+    def test_coupondetails_error_2(self, client, shared_contract):
+        # テスト用アカウント
+        issuer = eth_account['issuer']
+
+        # TokenListコントラクト
+        token_list = TestV2TokenCouponTokenDetails.tokenlist_contract()
+        config.TOKEN_LIST_CONTRACT_ADDRESS = token_list['address']
+
+        # データ準備：新規発行
+        exchange_address = \
+            to_checksum_address(
+                shared_contract['IbetCouponExchange']['address'])
+        attribute = TestV2TokenCouponTokenDetails.token_attribute(exchange_address)
+        token = issue_coupon_token(issuer, attribute)
+        coupon_register_list(issuer, token, token_list)
+
+        # NOTE:取扱トークンデータを挿入しない
+
+        apiurl = self.apiurl_base + token['address']
+        query_string = ''
+        resp = client.simulate_get(apiurl, query_string=query_string)
+
+        assert resp.status_code == 404
+        assert resp.json['meta'] == {
+            'code': 30,
+            'message': 'Data Not Exists',
+            'description': 'contract_address: ' + token['address']
+        }
+
+    # ＜エラー系3＞
+    #   トークン無効化（データなし）
+    def test_coupondetails_error_3(self, client, session, shared_contract):
+        # テスト用アカウント
+        issuer = eth_account['issuer']
+
+        # TokenListコントラクト
+        token_list = TestV2TokenCouponTokenDetails.tokenlist_contract()
+        config.TOKEN_LIST_CONTRACT_ADDRESS = token_list['address']
+
+        # データ準備：新規発行
+        exchange_address = \
+            to_checksum_address(
+                shared_contract['IbetCouponExchange']['address'])
+        attribute = TestV2TokenCouponTokenDetails.token_attribute(exchange_address)
+        token = issue_coupon_token(issuer, attribute)
+        coupon_register_list(issuer, token, token_list)
+
+        # 取扱トークンデータ挿入
+        TestV2TokenCouponTokenDetails.list_token(session, token)
+
+        # Tokenの無効化
+        invalidate_coupon_token(issuer, token)
+
+        apiurl = self.apiurl_base + token['address']
+        query_string = ''
+        resp = client.simulate_get(apiurl, query_string=query_string)
+
+        assert resp.status_code == 404
+        assert resp.json['meta'] == {
+            'code': 30,
+            'message': 'Data Not Exists',
+            'description': 'contract_address: ' + token['address']
+        }

--- a/app/tests/v2_token_membershiptokendetails_test.py
+++ b/app/tests/v2_token_membershiptokendetails_test.py
@@ -1,0 +1,196 @@
+# -*- coding: utf-8 -*-
+from eth_utils import to_checksum_address
+from web3 import Web3
+from web3.middleware import geth_poa_middleware
+
+from app.model import Listing
+from app import config
+from app.contracts import Contract
+
+from .account_config import eth_account
+from .contract_modules import membership_issue, membership_register_list, membership_invalidate
+
+web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
+web3.middleware_stack.inject(geth_poa_middleware, layer=0)
+
+
+class TestV2TokenMembershipTokenDetails():
+    """
+    Test Case for v2.token.MembershipTokenDetails
+    """
+
+    # テスト対象API
+    apiurl_base = '/v2/Token/Membership/' # {contract_address}
+
+    def token_attribute(exchange_address):
+        attribute = {
+            'name': 'テスト会員権',
+            'symbol': 'MEMBERSHIP',
+            'initialSupply': 1000000,
+            'tradableExchange': exchange_address,
+            'details': '詳細',
+            'returnDetails': 'リターン詳細',
+            'expirationDate': '20191231',
+            'memo': 'メモ',
+            'transferable': True,
+            'contactInformation': '問い合わせ先',
+            'privacyPolicy': 'プライバシーポリシー'
+        }
+        return attribute
+
+    @staticmethod
+    def tokenlist_contract():
+        deployer = eth_account['deployer']
+        web3.eth.defaultAccount = deployer['account_address']
+        web3.personal. \
+            unlockAccount(deployer['account_address'], deployer['password'])
+        contract_address, abi = Contract. \
+            deploy_contract('TokenList', [], deployer['account_address'])
+        return {'address': contract_address, 'abi': abi}
+
+    def list_token(session, token):
+        listed_token = Listing()
+        listed_token.token_address = token['address']
+        listed_token.payment_method_credit_card = True
+        listed_token.payment_method_bank = True
+        session.add(listed_token)
+
+    # ＜正常系1＞
+    #   データあり
+    def test_membershipdetails_normal_1(self, client, session, shared_contract):
+        # テスト用アカウント
+        issuer = eth_account['issuer']
+
+        # TokenListコントラクト
+        token_list = TestV2TokenMembershipTokenDetails.tokenlist_contract()
+        config.TOKEN_LIST_CONTRACT_ADDRESS = token_list['address']
+
+        # データ準備：会員権新規発行
+        exchange_address = \
+            to_checksum_address(
+                shared_contract['IbetMembershipExchange']['address'])
+        attribute = TestV2TokenMembershipTokenDetails.token_attribute(exchange_address)
+        token = membership_issue(issuer, attribute)
+        membership_register_list(issuer, token, token_list)
+
+        # 取扱トークンデータ挿入
+        TestV2TokenMembershipTokenDetails.list_token(session, token)
+
+        apiurl = self.apiurl_base + token['address']
+        query_string = ''
+        resp = client.simulate_get(apiurl, query_string=query_string)
+
+        assumed_body = {
+            'token_address': token['address'],
+            'token_template': 'IbetMembership',
+            'owner_address': issuer['account_address'],
+            'company_name': '',
+            'rsa_publickey': '',
+            'name': 'テスト会員権',
+            'symbol': 'MEMBERSHIP',
+            'total_supply': 1000000,
+            'details': '詳細',
+            'return_details': 'リターン詳細',
+            'expiration_date': '20191231',
+            'memo': 'メモ',
+            'transferable': True,
+            'status': True,
+            'initial_offering_status': False,
+            'image_url': [
+                {'id': 1, 'url': ''},
+                {'id': 2, 'url': ''},
+                {'id': 3, 'url': ''}
+            ],
+            'payment_method_credit_card': True,
+            'payment_method_bank': True,
+            'contact_information': '問い合わせ先',
+            'privacy_policy': 'プライバシーポリシー'
+        }
+
+        assert resp.status_code == 200
+        assert resp.json['meta'] == {'code': 200, 'message': 'OK'}
+        assert resp.json['data'] == assumed_body
+
+    # ＜エラー系1＞
+    #   無効なコントラクトアドレス
+    #   -> 400エラー
+    def test_membershipdetails_error_1(self, client):
+        apiurl = self.apiurl_base + '0xabcd'
+
+        query_string = ''
+        resp = client.simulate_get(apiurl, query_string=query_string)
+
+        assert resp.status_code == 400
+        assert resp.json['meta'] == {
+            'code': 88,
+            'message': 'Invalid Parameter',
+            'description': 'invalid contract_address'
+        }
+
+    # ＜エラー系2＞
+    #   取扱トークン（DB）に情報が存在しない
+    def test_membershipdetails_error_2(self, client, shared_contract):
+        # テスト用アカウント
+        issuer = eth_account['issuer']
+
+        # TokenListコントラクト
+        token_list = TestV2TokenMembershipTokenDetails.tokenlist_contract()
+        config.TOKEN_LIST_CONTRACT_ADDRESS = token_list['address']
+
+        # データ準備：会員権新規発行
+        exchange_address = \
+            to_checksum_address(
+                shared_contract['IbetMembershipExchange']['address'])
+        attribute = TestV2TokenMembershipTokenDetails.token_attribute(exchange_address)
+        token = membership_issue(issuer, attribute)
+        membership_register_list(issuer, token, token_list)
+
+        # NOTE:取扱トークンデータを挿入しない
+
+        apiurl = self.apiurl_base + token['address']
+        query_string = ''
+        resp = client.simulate_get(apiurl, query_string=query_string)
+
+        assert resp.status_code == 404
+        assert resp.json['meta'] == {
+            'code': 30,
+            'message': 'Data Not Exists',
+            'description': 'contract_address: ' + token['address']
+        }
+
+    # ＜エラー系3＞
+    #   トークン無効化（データなし）
+    #   -> 404エラー
+    def test_membershipdetails_error_3(self, client, session, shared_contract):
+        # テスト用アカウント
+        issuer = eth_account['issuer']
+
+        # TokenListコントラクト
+        token_list = TestV2TokenMembershipTokenDetails.tokenlist_contract()
+        config.TOKEN_LIST_CONTRACT_ADDRESS = token_list['address']
+
+        # データ準備：会員権新規発行
+        exchange_address = \
+            to_checksum_address(
+                shared_contract['IbetMembershipExchange']['address'])
+        attribute = TestV2TokenMembershipTokenDetails. \
+            token_attribute(exchange_address)
+        token = membership_issue(issuer, attribute)
+        membership_register_list(issuer, token, token_list)
+
+        # 取扱トークンデータ挿入
+        TestV2TokenMembershipTokenDetails.list_token(session, token)
+
+        # Tokenの無効化
+        membership_invalidate(issuer, token)
+
+        apiurl = self.apiurl_base + token['address']
+        query_string = ''
+        resp = client.simulate_get(apiurl, query_string=query_string)
+
+        assert resp.status_code == 404
+        assert resp.json['meta'] == {
+            'code': 30,
+            'message': 'Data Not Exists',
+            'description': 'contract_address: ' + token['address']
+        }

--- a/app/tests/v2_token_membershiptokens_test.py
+++ b/app/tests/v2_token_membershiptokens_test.py
@@ -11,8 +11,7 @@ from app import config
 from app.contracts import Contract
 
 from .account_config import eth_account
-from .contract_modules import membership_issue, membership_register_list, membership_invalidate, \
-    issue_coupon_token, coupon_register_list, invalidate_coupon_token
+from .contract_modules import membership_issue, membership_register_list, membership_invalidate
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
 web3.middleware_stack.inject(geth_poa_middleware, layer=0)


### PR DESCRIPTION
#491 
API version2
トークン詳細APIを新規追加

GET: /v2/Token/Membership/{contract_address}
GET: /v2/Token/Coupon/{contract_address}

#### 補足1

- 該当するaddressのトークンが存在しない場合は以下を返す。

```
HTTPステータスコード：404
メタ情報：
　'code': 30,
　'message': 'Data Not Exists',
　'description': 'contract_address: 0x.....'
```

#### 補足2

- 一覧APIでは「id」という項目を返していたが、詳細APIではこの項目は存在しない。