### PR TITLE
feat: add upper limit check item

### DIFF
--- a/app/api/v2/position.py
+++ b/app/api/v2/position.py
@@ -16,7 +16,7 @@ from app.api.common import BaseResource
 from app.errors import InvalidParameterError
 from app import config
 from app.contracts import Contract
-from app.model import Listing, PrivateListing, MembershipToken, CouponToken
+from app.model import Listing, PrivateListing, MembershipTokenV2, CouponTokenV2
 
 LOG = log.get_logger()
 
@@ -109,7 +109,7 @@ class MembershipMyTokens(BaseResource):
                             company_name, rsa_publickey = MembershipMyTokens. \
                                 get_company_name(company_list, owner_address)
 
-                            membershiptoken = MembershipToken()
+                            membershiptoken = MembershipTokenV2()
                             membershiptoken.token_address = token_address
                             membershiptoken.token_template = token_template
                             membershiptoken.owner_address = owner_address
@@ -129,6 +129,8 @@ class MembershipMyTokens(BaseResource):
                                 {'id': 2, 'url': image_url_2},
                                 {'id': 3, 'url': image_url_3}
                             ]
+                            membershiptoken.max_holding_quantity = token.max_holding_quantity
+                            membershiptoken.max_sell_amount = token.max_sell_amount
                             membershiptoken.payment_method_credit_card = token.payment_method_credit_card
                             membershiptoken.payment_method_bank = token.payment_method_bank
                             membershiptoken.contact_information = contact_information
@@ -261,7 +263,7 @@ class CouponMyTokens(BaseResource):
                             contact_information = CouponTokenContract.functions.contactInformation().call()
                             privacy_policy = CouponTokenContract.functions.privacyPolicy().call()
 
-                            coupontoken = CouponToken()
+                            coupontoken = CouponTokenV2()
                             coupontoken.token_address = token_address
                             coupontoken.token_template = token_template
                             coupontoken.owner_address = owner_address
@@ -281,6 +283,8 @@ class CouponMyTokens(BaseResource):
                                 {'id': 3, 'url': image_url_3}
                             ]
                             coupontoken.status = status
+                            coupontoken.max_holding_quantity = token.max_holding_quantity
+                            coupontoken.max_sell_amount = token.max_sell_amount
                             coupontoken.payment_method_credit_card = token.payment_method_credit_card
                             coupontoken.payment_method_bank = token.payment_method_bank
                             coupontoken.contact_information = contact_information

--- a/app/api/v2/token.py
+++ b/app/api/v2/token.py
@@ -14,7 +14,7 @@ from app.api.common import BaseResource
 from app.errors import InvalidParameterError, DataNotExistsError
 from app import config
 from app.contracts import Contract
-from app.model import Listing, MembershipToken, CouponToken
+from app.model import Listing, MembershipTokenV2, CouponTokenV2
 
 LOG = log.get_logger()
 
@@ -138,7 +138,7 @@ class MembershipTokens(BaseResource):
                         company_name = company['corporate_name']
                         rsa_publickey = company['rsa_publickey']
 
-                membershiptoken = MembershipToken()
+                membershiptoken = MembershipTokenV2()
                 membershiptoken.token_address = token_address
                 membershiptoken.token_template = token_template
                 membershiptoken.owner_address = owner_address
@@ -159,6 +159,8 @@ class MembershipTokens(BaseResource):
                     {'id': 2, 'url': image_url_2},
                     {'id': 3, 'url': image_url_3},
                 ]
+                membershiptoken.max_holding_quantity = available_token.max_holding_quantity
+                membershiptoken.max_sell_amount = available_token.max_sell_amount
                 membershiptoken.payment_method_credit_card = available_token.payment_method_credit_card
                 membershiptoken.payment_method_bank = available_token.payment_method_bank
                 membershiptoken.contact_information = contact_information
@@ -314,7 +316,7 @@ class MembershipTokenDetails(BaseResource):
                         company_name = company['corporate_name']
                         rsa_publickey = company['rsa_publickey']
 
-                membershiptoken = MembershipToken()
+                membershiptoken = MembershipTokenV2()
                 membershiptoken.token_address = token_address
                 membershiptoken.token_template = token_template
                 membershiptoken.owner_address = owner_address
@@ -335,6 +337,8 @@ class MembershipTokenDetails(BaseResource):
                     {'id': 2, 'url': image_url_2},
                     {'id': 3, 'url': image_url_3},
                 ]
+                membershiptoken.max_holding_quantity = listed_token.max_holding_quantity
+                membershiptoken.max_sell_amount = listed_token.max_sell_amount
                 membershiptoken.payment_method_credit_card = listed_token.payment_method_credit_card
                 membershiptoken.payment_method_bank = listed_token.payment_method_bank
                 membershiptoken.contact_information = contact_information
@@ -469,7 +473,7 @@ class CouponTokens(BaseResource):
                     if to_checksum_address(company['address']) == owner_address:
                         company_name = company['corporate_name']
                         rsa_publickey = company['rsa_publickey']
-                coupontoken = CouponToken()
+                coupontoken = CouponTokenV2()
                 coupontoken.token_address = token_address
                 coupontoken.token_template = token_template
                 coupontoken.owner_address = owner_address
@@ -490,6 +494,8 @@ class CouponTokens(BaseResource):
                     {'id': 2, 'url': image_url_2},
                     {'id': 3, 'url': image_url_3},
                 ]
+                coupontoken.max_holding_quantity = available_token.max_holding_quantity
+                coupontoken.max_sell_amount = available_token.max_sell_amount
                 coupontoken.payment_method_credit_card = available_token.payment_method_credit_card
                 coupontoken.payment_method_bank = available_token.payment_method_bank
                 coupontoken.contact_information = contact_information
@@ -644,7 +650,7 @@ class CouponTokenDetails(BaseResource):
                     if to_checksum_address(company['address']) == owner_address:
                         company_name = company['corporate_name']
                         rsa_publickey = company['rsa_publickey']
-                coupontoken = CouponToken()
+                coupontoken = CouponTokenV2()
                 coupontoken.token_address = token_address
                 coupontoken.token_template = token_template
                 coupontoken.owner_address = owner_address
@@ -665,6 +671,8 @@ class CouponTokenDetails(BaseResource):
                     {'id': 2, 'url': image_url_2},
                     {'id': 3, 'url': image_url_3},
                 ]
+                coupontoken.max_holding_quantity = listed_token.max_holding_quantity
+                coupontoken.max_sell_amount = listed_token.max_sell_amount
                 coupontoken.payment_method_credit_card = listed_token.payment_method_credit_card
                 coupontoken.payment_method_bank = listed_token.payment_method_bank
                 coupontoken.contact_information = contact_information

--- a/app/model/__init__.py
+++ b/app/model/__init__.py
@@ -10,4 +10,5 @@ from .stripe_account import StripeAccount, StripeAccountStatus
 from .listing import Listing
 from .private_listing import PrivateListing
 from .executable_contract import ExecutableContract
-from .token import BondToken, MembershipToken, CouponToken, MRFToken, JDRToken
+from .token import BondToken, MembershipToken, MembershipTokenV2, CouponToken, CouponTokenV2, \
+    MRFToken, JDRToken

--- a/app/model/listing.py
+++ b/app/model/listing.py
@@ -8,6 +8,8 @@ class Listing(Base):
     __tablename__ = 'listing'
     id = Column(BigInteger, primary_key=True, autoincrement=True)
     token_address = Column(String(256), index=True)
+    max_holding_quantity = Column(BigInteger)
+    max_sell_amount = Column(BigInteger)
     payment_method_credit_card = Column(Boolean)
     payment_method_bank = Column(Boolean)
 
@@ -19,6 +21,8 @@ class Listing(Base):
         'id': int,
         'token_address': str,
         'token_template': str,
+        'max_holding_quantity': int,
+        'max_sell_amount': int,
         'payment_method_credit_card': bool,
         'payment_method_bank': bool,
     }

--- a/app/model/private_listing.py
+++ b/app/model/private_listing.py
@@ -8,6 +8,8 @@ class PrivateListing(Base):
     __tablename__ = 'private_listing'
     id = Column(BigInteger, primary_key=True, autoincrement=True)
     token_address = Column(String(256), index=True)
+    max_holding_quantity = Column(BigInteger)
+    max_sell_amount = Column(BigInteger)
     payment_method_credit_card = Column(Boolean)
     payment_method_bank = Column(Boolean)
 
@@ -19,6 +21,8 @@ class PrivateListing(Base):
         'id': int,
         'token_address': str,
         'token_template': str,
+        'max_holding_quantity': int,
+        'max_sell_amount': int,
         'payment_method_credit_card': bool,
         'payment_method_bank': bool,
     }

--- a/app/model/token.py
+++ b/app/model/token.py
@@ -46,6 +46,20 @@ class MembershipToken(TokenBase):
     status: str
     initial_offering_status: str
 
+class MembershipTokenV2(TokenBase):
+    """
+    version2
+    """
+    details: str
+    return_details: str
+    expiration_date: str
+    memo: str
+    transferable: str
+    status: str
+    initial_offering_status: str
+    max_holding_quantity: int
+    max_sell_amount: int
+
 class CouponToken(TokenBase):
     details: str
     return_details: str
@@ -54,6 +68,20 @@ class CouponToken(TokenBase):
     transferable: str
     status: str
     initial_offering_status: str
+
+class CouponTokenV2(TokenBase):
+    """
+    version2
+    """
+    details: str
+    return_details: str
+    expiration_date: str
+    memo: str
+    transferable: str
+    status: str
+    initial_offering_status: str
+    max_holding_quantity: int
+    max_sell_amount: int
 
 class MRFToken(TokenBase):
     details: str

--- a/app/tests/v2_position_couponmytokens_test.py
+++ b/app/tests/v2_position_couponmytokens_test.py
@@ -225,6 +225,8 @@ class TestV2CouponMyTokens:
     def list_token(session, token):
         listed_token = Listing()
         listed_token.token_address = token['address']
+        listed_token.max_holding_quantity = 1
+        listed_token.max_sell_amount = 1000
         listed_token.payment_method_credit_card = True
         listed_token.payment_method_bank = True
         session.add(listed_token)
@@ -233,6 +235,8 @@ class TestV2CouponMyTokens:
     def list_private_token(session, token):
         listed_token = PrivateListing()
         listed_token.token_address = token['address']
+        listed_token.max_holding_quantity = 1
+        listed_token.max_sell_amount = 1000
         listed_token.payment_method_credit_card = True
         listed_token.payment_method_bank = True
         session.add(listed_token)
@@ -288,6 +292,8 @@ class TestV2CouponMyTokens:
                     'url': ''
                 }],
                 'status': True,
+                'max_holding_quantity': 1,
+                'max_sell_amount': 1000,
                 'payment_method_credit_card': True,
                 'payment_method_bank': True,
                 'contact_information': '問い合わせ先',
@@ -359,6 +365,8 @@ class TestV2CouponMyTokens:
                     'url': ''
                 }],
                 'status': False,
+                'max_holding_quantity': 1,
+                'max_sell_amount': 1000,
                 'payment_method_credit_card': True,
                 'payment_method_bank': True,
                 'contact_information': '問い合わせ先',
@@ -428,6 +436,8 @@ class TestV2CouponMyTokens:
                     'url': ''
                 }],
                 'status': True,
+                'max_holding_quantity': 1,
+                'max_sell_amount': 1000,
                 'payment_method_credit_card': True,
                 'payment_method_bank': True,
                 'contact_information': '問い合わせ先',
@@ -498,6 +508,8 @@ class TestV2CouponMyTokens:
                     'url': ''
                 }],
                 'status': True,
+                'max_holding_quantity': 1,
+                'max_sell_amount': 1000,
                 'payment_method_credit_card': True,
                 'payment_method_bank': True,
                 'contact_information': '問い合わせ先',
@@ -568,6 +580,8 @@ class TestV2CouponMyTokens:
                     'url': ''
                 }],
                 'status': True,
+                'max_holding_quantity': 1,
+                'max_sell_amount': 1000,
                 'payment_method_credit_card': True,
                 'payment_method_bank': True,
                 'contact_information': '問い合わせ先',
@@ -637,6 +651,8 @@ class TestV2CouponMyTokens:
                     'url': ''
                 }],
                 'status': True,
+                'max_holding_quantity': 1,
+                'max_sell_amount': 1000,
                 'payment_method_credit_card': True,
                 'payment_method_bank': True,
                 'contact_information': '問い合わせ先',

--- a/app/tests/v2_position_membershipmytokens_test.py
+++ b/app/tests/v2_position_membershipmytokens_test.py
@@ -172,6 +172,8 @@ class TestV2MembershipMyTokens:
     def list_token(session, token):
         listed_token = Listing()
         listed_token.token_address = token['address']
+        listed_token.max_holding_quantity = 1
+        listed_token.max_sell_amount = 1000
         listed_token.payment_method_credit_card = True
         listed_token.payment_method_bank = True
         session.add(listed_token)
@@ -180,6 +182,8 @@ class TestV2MembershipMyTokens:
     def list_private_token(session, token):
         listed_token = PrivateListing()
         listed_token.token_address = token['address']
+        listed_token.max_holding_quantity = 1
+        listed_token.max_sell_amount = 1000
         listed_token.payment_method_credit_card = True
         listed_token.payment_method_bank = True
         session.add(listed_token)
@@ -234,6 +238,8 @@ class TestV2MembershipMyTokens:
                     'id': 3,
                     'url': ''
                 }],
+                'max_holding_quantity': 1,
+                'max_sell_amount': 1000,
                 'payment_method_credit_card': True,
                 'payment_method_bank': True,
                 'contact_information': '問い合わせ先',
@@ -304,6 +310,8 @@ class TestV2MembershipMyTokens:
                     'id': 3,
                     'url': ''
                 }],
+                'max_holding_quantity': 1,
+                'max_sell_amount': 1000,
                 'payment_method_credit_card': True,
                 'payment_method_bank': True,
                 'contact_information': '問い合わせ先',
@@ -410,6 +418,8 @@ class TestV2MembershipMyTokens:
                     'id': 3,
                     'url': ''
                 }],
+                'max_holding_quantity': 1,
+                'max_sell_amount': 1000,
                 'payment_method_credit_card': True,
                 'payment_method_bank': True,
                 'contact_information': '問い合わせ先',
@@ -480,6 +490,8 @@ class TestV2MembershipMyTokens:
                     'id': 3,
                     'url': ''
                 }],
+                'max_holding_quantity': 1,
+                'max_sell_amount': 1000,
                 'payment_method_credit_card': True,
                 'payment_method_bank': True,
                 'contact_information': '問い合わせ先',

--- a/app/tests/v2_token_coupontokendetails_test.py
+++ b/app/tests/v2_token_coupontokendetails_test.py
@@ -51,6 +51,8 @@ class TestV2TokenCouponTokenDetails():
     def list_token(session, token):
         listed_token = Listing()
         listed_token.token_address = token['address']
+        listed_token.max_holding_quantity = 1
+        listed_token.max_sell_amount = 1000
         listed_token.payment_method_credit_card = True
         listed_token.payment_method_bank = True
         session.add(listed_token)
@@ -101,6 +103,8 @@ class TestV2TokenCouponTokenDetails():
                 {'id': 2, 'url': ''},
                 {'id': 3, 'url': ''}
             ],
+            'max_holding_quantity': 1,
+            'max_sell_amount': 1000,
             'payment_method_credit_card': True,
             'payment_method_bank': True,
             'contact_information': '問い合わせ先',

--- a/app/tests/v2_token_coupontokens_test.py
+++ b/app/tests/v2_token_coupontokens_test.py
@@ -55,6 +55,8 @@ class TestV2TokenCouponTokens():
     def list_token(session, token):
         listed_token = Listing()
         listed_token.token_address = token['address']
+        listed_token.max_holding_quantity = 1
+        listed_token.max_sell_amount = 1000
         listed_token.payment_method_credit_card = True
         listed_token.payment_method_bank = True
         session.add(listed_token)
@@ -108,6 +110,8 @@ class TestV2TokenCouponTokens():
                     {'id': 2, 'url': ''},
                     {'id': 3, 'url': ''}
                 ],
+                'max_holding_quantity': 1,
+                'max_sell_amount': 1000,
                 'payment_method_credit_card': True,
                 'payment_method_bank': True,
                 'contact_information': '問い合わせ先',
@@ -171,6 +175,8 @@ class TestV2TokenCouponTokens():
                     {'id': 2, 'url': ''},
                     {'id': 3, 'url': ''}
                 ],
+                'max_holding_quantity': 1,
+                'max_sell_amount': 1000,
                 'payment_method_credit_card': True,
                 'payment_method_bank': True,
                 'contact_information': '問い合わせ先',
@@ -197,6 +203,8 @@ class TestV2TokenCouponTokens():
                     {'id': 2, 'url': ''},
                     {'id': 3, 'url': ''}
                 ],
+                'max_holding_quantity': 1,
+                'max_sell_amount': 1000,
                 'payment_method_credit_card': True,
                 'payment_method_bank': True,
                 'contact_information': '問い合わせ先',
@@ -260,6 +268,8 @@ class TestV2TokenCouponTokens():
                     {'id': 2, 'url': ''},
                     {'id': 3, 'url': ''}
                 ],
+                'max_holding_quantity': 1,
+                'max_sell_amount': 1000,
                 'payment_method_credit_card': True,
                 'payment_method_bank': True,
                 'contact_information': '問い合わせ先',
@@ -286,6 +296,8 @@ class TestV2TokenCouponTokens():
                     {'id': 2, 'url': ''},
                     {'id': 3, 'url': ''}
                 ],
+                'max_holding_quantity': 1,
+                'max_sell_amount': 1000,
                 'payment_method_credit_card': True,
                 'payment_method_bank': True,
                 'contact_information': '問い合わせ先',
@@ -348,6 +360,8 @@ class TestV2TokenCouponTokens():
                 {'id': 2, 'url': ''},
                 {'id': 3, 'url': ''}
             ],
+            'max_holding_quantity': 1,
+            'max_sell_amount': 1000,
             'payment_method_credit_card': True,
             'payment_method_bank': True,
             'contact_information': '問い合わせ先',
@@ -409,6 +423,8 @@ class TestV2TokenCouponTokens():
                 {'id': 2, 'url': ''},
                 {'id': 3, 'url': ''}
             ],
+            'max_holding_quantity': 1,
+            'max_sell_amount': 1000,
             'payment_method_credit_card': True,
             'payment_method_bank': True,
             'contact_information': '問い合わせ先',

--- a/app/tests/v2_token_membershiptokendetails_test.py
+++ b/app/tests/v2_token_membershiptokendetails_test.py
@@ -51,6 +51,8 @@ class TestV2TokenMembershipTokenDetails():
     def list_token(session, token):
         listed_token = Listing()
         listed_token.token_address = token['address']
+        listed_token.max_holding_quantity = 1
+        listed_token.max_sell_amount = 1000
         listed_token.payment_method_credit_card = True
         listed_token.payment_method_bank = True
         session.add(listed_token)
@@ -101,6 +103,8 @@ class TestV2TokenMembershipTokenDetails():
                 {'id': 2, 'url': ''},
                 {'id': 3, 'url': ''}
             ],
+            'max_holding_quantity': 1,
+            'max_sell_amount': 1000,
             'payment_method_credit_card': True,
             'payment_method_bank': True,
             'contact_information': '問い合わせ先',

--- a/app/tests/v2_token_membershiptokens_test.py
+++ b/app/tests/v2_token_membershiptokens_test.py
@@ -54,6 +54,8 @@ class TestV2TokenMembershipTokens():
     def list_token(session, token):
         listed_token = Listing()
         listed_token.token_address = token['address']
+        listed_token.max_holding_quantity = 1
+        listed_token.max_sell_amount = 1000
         listed_token.payment_method_credit_card = True
         listed_token.payment_method_bank = True
         session.add(listed_token)
@@ -107,6 +109,8 @@ class TestV2TokenMembershipTokens():
                     {'id': 2, 'url': ''},
                     {'id': 3, 'url': ''}
                 ],
+                'max_holding_quantity': 1,
+                'max_sell_amount': 1000,
                 'payment_method_credit_card': True,
                 'payment_method_bank': True,
                 'contact_information': '問い合わせ先',
@@ -170,6 +174,8 @@ class TestV2TokenMembershipTokens():
                     {'id': 2, 'url': ''},
                     {'id': 3, 'url': ''}
                 ],
+                'max_holding_quantity': 1,
+                'max_sell_amount': 1000,
                 'payment_method_credit_card': True,
                 'payment_method_bank': True,
                 'contact_information': '問い合わせ先',
@@ -196,6 +202,8 @@ class TestV2TokenMembershipTokens():
                     {'id': 2, 'url': ''},
                     {'id': 3, 'url': ''}
                 ],
+                'max_holding_quantity': 1,
+                'max_sell_amount': 1000,
                 'payment_method_credit_card': True,
                 'payment_method_bank': True,
                 'contact_information': '問い合わせ先',
@@ -259,6 +267,8 @@ class TestV2TokenMembershipTokens():
                     {'id': 2, 'url': ''},
                     {'id': 3, 'url': ''}
                 ],
+                'max_holding_quantity': 1,
+                'max_sell_amount': 1000,
                 'payment_method_credit_card': True,
                 'payment_method_bank': True,
                 'contact_information': '問い合わせ先',
@@ -285,6 +295,8 @@ class TestV2TokenMembershipTokens():
                     {'id': 2, 'url': ''},
                     {'id': 3, 'url': ''}
                 ],
+                'max_holding_quantity': 1,
+                'max_sell_amount': 1000,
                 'payment_method_credit_card': True,
                 'payment_method_bank': True,
                 'contact_information': '問い合わせ先',
@@ -347,6 +359,8 @@ class TestV2TokenMembershipTokens():
                 {'id': 2, 'url': ''},
                 {'id': 3, 'url': ''}
             ],
+            'max_holding_quantity': 1,
+            'max_sell_amount': 1000,
             'payment_method_credit_card': True,
             'payment_method_bank': True,
             'contact_information': '問い合わせ先',
@@ -408,6 +422,8 @@ class TestV2TokenMembershipTokens():
                 {'id': 2, 'url': ''},
                 {'id': 3, 'url': ''}
             ],
+            'max_holding_quantity': 1,
+            'max_sell_amount': 1000,
             'payment_method_credit_card': True,
             'payment_method_bank': True,
             'contact_information': '問い合わせ先',


### PR DESCRIPTION
close #501 
クライアントにおける上限値チェック用の項目を追加

max_holding_quantity：最大保有数
max_sell_amount：売却金額上限

version2 API のみ対応