### PR TITLE
feat: add counterpart otc order notification

### DIFF
--- a/app/model/notification.py
+++ b/app/model/notification.py
@@ -119,7 +119,9 @@ Index("notification_index_2", Notification.address, Notification.priority, Notif
 
 class NotificationType(Enum):
     NEW_ORDER = "NewOrder"
+    NEW_ORDER_COUNTERPART = "NewOrderCounterpart"
     CANCEL_ORDER = "CancelOrder"
+    CANCEL_ORDER_COUNTERPART = "CancelOrderCounterpart"
     BUY_AGREEMENT = "BuyAgreement"
     BUY_SETTLEMENT_OK = "BuySettlementOK"
     BUY_SETTLEMENT_NG = "BuySettlementNG"

--- a/async/processor_Notifications_Share_Exchange.py
+++ b/async/processor_Notifications_Share_Exchange.py
@@ -140,6 +140,16 @@ class WatchShareNewOrder(Watcher):
             notification.metainfo = metadata
             db_session.merge(notification)
 
+            notification = Notification()
+            notification.notification_id = self._gen_notification_id(entry)
+            notification.notification_type = NotificationType.NEW_ORDER_COUNTERPART.value
+            notification.priority = 0
+            notification.address = entry["args"]["counterpartAddress"]
+            notification.block_timestamp = self._gen_block_timestamp(entry)
+            notification.args = dict(entry["args"])
+            notification.metainfo = metadata
+            db_session.merge(notification)
+
 
 # イベント：注文取消
 class WatchShareCancelOrder(Watcher):
@@ -176,6 +186,16 @@ class WatchShareCancelOrder(Watcher):
             notification.notification_type = NotificationType.CANCEL_ORDER.value
             notification.priority = 0
             notification.address = entry["args"]["ownerAddress"]
+            notification.block_timestamp = self._gen_block_timestamp(entry)
+            notification.args = dict(entry["args"])
+            notification.metainfo = metadata
+            db_session.merge(notification)
+
+            notification = Notification()
+            notification.notification_id = self._gen_notification_id(entry)
+            notification.notification_type = NotificationType.CANCEL_ORDER_COUNTERPART.value
+            notification.priority = 0
+            notification.address = entry["args"]["counterpartAddress"]
             notification.block_timestamp = self._gen_block_timestamp(entry)
             notification.args = dict(entry["args"])
             notification.metainfo = metadata


### PR DESCRIPTION
close #716 

## 気になるところ
makerならびにtakerのNotificationデータを直列でinsertして問題ないか
（他のパターンは同イベント別アドレスで関数とプロセスを分けていたのでそっちを踏襲すべきでしょうか）