### PR TITLE
feat: add token_address to Notification metaInfo

### DIFF
--- a/async/processor_Notifications_Bond_Exchange.py
+++ b/async/processor_Notifications_Bond_Exchange.py
@@ -120,6 +120,7 @@ class WatchBondNewOrder(Watcher):
 
             metadata = {
                 "company_name": company.corporate_name,
+                "token_address": token_address,
                 "token_name": token.name,
                 "exchange_address": IBET_SB_EXCHANGE_CONTRACT_ADDRESS,
                 "token_type": "IbetStraightBond"
@@ -156,6 +157,7 @@ class WatchBondCancelOrder(Watcher):
 
             metadata = {
                 "company_name": company.corporate_name,
+                "token_address": token_address,
                 "token_name": token.name,
                 "exchange_address": IBET_SB_EXCHANGE_CONTRACT_ADDRESS,
                 "token_type": "IbetStraightBond"
@@ -192,6 +194,7 @@ class WatchBondBuyAgreement(Watcher):
 
             metadata = {
                 "company_name": company.corporate_name,
+                "token_address": token_address,
                 "token_name": token.name,
                 "exchange_address": IBET_SB_EXCHANGE_CONTRACT_ADDRESS,
                 "token_type": "IbetStraightBond"
@@ -228,6 +231,7 @@ class WatchBondSellAgreement(Watcher):
 
             metadata = {
                 "company_name": company.corporate_name,
+                "token_address": token_address,
                 "token_name": token.name,
                 "exchange_address": IBET_SB_EXCHANGE_CONTRACT_ADDRESS,
                 "token_type": "IbetStraightBond"
@@ -264,6 +268,7 @@ class WatchBondBuySettlementOK(Watcher):
 
             metadata = {
                 "company_name": company.corporate_name,
+                "token_address": token_address,
                 "token_name": token.name,
                 "exchange_address": IBET_SB_EXCHANGE_CONTRACT_ADDRESS,
                 "token_type": "IbetStraightBond"
@@ -300,6 +305,7 @@ class WatchBondSellSettlementOK(Watcher):
 
             metadata = {
                 "company_name": company.corporate_name,
+                "token_address": token_address,
                 "token_name": token.name,
                 "exchange_address": IBET_SB_EXCHANGE_CONTRACT_ADDRESS,
                 "token_type": "IbetStraightBond"
@@ -336,6 +342,7 @@ class WatchBondBuySettlementNG(Watcher):
 
             metadata = {
                 "company_name": company.corporate_name,
+                "token_address": token_address,
                 "token_name": token.name,
                 "exchange_address": IBET_SB_EXCHANGE_CONTRACT_ADDRESS,
                 "token_type": "IbetStraightBond"
@@ -372,6 +379,7 @@ class WatchBondSellSettlementNG(Watcher):
 
             metadata = {
                 "company_name": company.corporate_name,
+                "token_address": token_address,
                 "token_name": token.name,
                 "exchange_address": IBET_SB_EXCHANGE_CONTRACT_ADDRESS,
                 "token_type": "IbetStraightBond"

--- a/async/processor_Notifications_Bond_Token.py
+++ b/async/processor_Notifications_Bond_Token.py
@@ -139,6 +139,7 @@ class WatchStartInitialOffering(Watcher):
             company = company_list.find(token_owner_address)
             metadata = {
                 "company_name": company.corporate_name,
+                "token_address": entry["address"],
                 "token_name": token_name,
                 "exchange_address": "",
                 "token_type": "IbetStraightBond"
@@ -166,6 +167,7 @@ class WatchStopInitialOffering(Watcher):
             company = company_list.find(token_owner_address)
             metadata = {
                 "company_name": company.corporate_name,
+                "token_address": entry["address"],
                 "token_name": token_name,
                 "exchange_address": "",
                 "token_type": "IbetStraightBond"
@@ -193,6 +195,7 @@ class WatchRedeem(Watcher):
             company = company_list.find(token_owner_address)
             metadata = {
                 "company_name": company.corporate_name,
+                "token_address": entry["address"],
                 "token_name": token_name,
                 "exchange_address": "",
                 "token_type": "IbetStraightBond"
@@ -220,6 +223,7 @@ class WatchApplyForOffering(Watcher):
             company = company_list.find(token_owner_address)
             metadata = {
                 "company_name": company.corporate_name,
+                "token_address": entry["address"],
                 "token_name": token_name,
                 "exchange_address": "",
                 "token_type": "IbetStraightBond"
@@ -248,6 +252,7 @@ class WatchAllot(Watcher):
             company = company_list.find(token_owner_address)
             metadata = {
                 "company_name": company.corporate_name,
+                "token_address": entry["address"],
                 "token_name": token_name,
                 "exchange_address": "",
                 "token_type": "IbetStraightBond"
@@ -280,6 +285,7 @@ class WatchTransfer(Watcher):
             company = company_list.find(token_owner_address)
             metadata = {
                 "company_name": company.corporate_name,
+                "token_address": entry["address"],
                 "token_name": token_name,
                 "exchange_address": "",
                 "token_type": "IbetStraightBond"

--- a/async/processor_Notifications_Coupon_Exchange.py
+++ b/async/processor_Notifications_Coupon_Exchange.py
@@ -120,6 +120,7 @@ class WatchCouponNewOrder(Watcher):
 
             metadata = {
                 "company_name": company.corporate_name,
+                "token_address": token_address,
                 "token_name": token.name,
                 "exchange_address": IBET_CP_EXCHANGE_CONTRACT_ADDRESS,
                 "token_type": "IbetCoupon"
@@ -156,6 +157,7 @@ class WatchCouponCancelOrder(Watcher):
 
             metadata = {
                 "company_name": company.corporate_name,
+                "token_address": token_address,
                 "token_name": token.name,
                 "exchange_address": IBET_CP_EXCHANGE_CONTRACT_ADDRESS,
                 "token_type": "IbetCoupon"
@@ -192,6 +194,7 @@ class WatchCouponBuyAgreement(Watcher):
 
             metadata = {
                 "company_name": company.corporate_name,
+                "token_address": token_address,
                 "token_name": token.name,
                 "exchange_address": IBET_CP_EXCHANGE_CONTRACT_ADDRESS,
                 "token_type": "IbetCoupon"
@@ -228,6 +231,7 @@ class WatchCouponSellAgreement(Watcher):
 
             metadata = {
                 "company_name": company.corporate_name,
+                "token_address": token_address,
                 "token_name": token.name,
                 "exchange_address": IBET_CP_EXCHANGE_CONTRACT_ADDRESS,
                 "token_type": "IbetCoupon"
@@ -264,6 +268,7 @@ class WatchCouponBuySettlementOK(Watcher):
 
             metadata = {
                 "company_name": company.corporate_name,
+                "token_address": token_address,
                 "token_name": token.name,
                 "exchange_address": IBET_CP_EXCHANGE_CONTRACT_ADDRESS,
                 "token_type": "IbetCoupon"
@@ -300,6 +305,7 @@ class WatchCouponSellSettlementOK(Watcher):
 
             metadata = {
                 "company_name": company.corporate_name,
+                "token_address": token_address,
                 "token_name": token.name,
                 "exchange_address": IBET_CP_EXCHANGE_CONTRACT_ADDRESS,
                 "token_type": "IbetCoupon"
@@ -336,6 +342,7 @@ class WatchCouponBuySettlementNG(Watcher):
 
             metadata = {
                 "company_name": company.corporate_name,
+                "token_address": token_address,
                 "token_name": token.name,
                 "exchange_address": IBET_CP_EXCHANGE_CONTRACT_ADDRESS,
                 "token_type": "IbetCoupon"
@@ -372,6 +379,7 @@ class WatchCouponSellSettlementNG(Watcher):
 
             metadata = {
                 "company_name": company.corporate_name,
+                "token_address": token_address,
                 "token_name": token.name,
                 "exchange_address": IBET_CP_EXCHANGE_CONTRACT_ADDRESS,
                 "token_type": "IbetCoupon"

--- a/async/processor_Notifications_Coupon_Token.py
+++ b/async/processor_Notifications_Coupon_Token.py
@@ -143,6 +143,7 @@ class WatchTransfer(Watcher):
             company = company_list.find(token_owner_address)
             metadata = {
                 "company_name": company.corporate_name,
+                "token_address": entry["address"],
                 "token_name": token_name,
                 "exchange_address": "",
                 "token_type": "IbetCoupon"

--- a/async/processor_Notifications_Membership_Exchange.py
+++ b/async/processor_Notifications_Membership_Exchange.py
@@ -125,6 +125,7 @@ class WatchMembershipNewOrder(Watcher):
 
             metadata = {
                 "company_name": company.corporate_name,
+                "token_address": token_address,
                 "token_name": token.name,
                 "exchange_address": IBET_MEMBERSHIP_EXCHANGE_CONTRACT_ADDRESS,
                 "token_type": "IbetMembership"
@@ -161,6 +162,7 @@ class WatchMembershipCancelOrder(Watcher):
 
             metadata = {
                 "company_name": company.corporate_name,
+                "token_address": token_address,
                 "token_name": token.name,
                 "exchange_address": IBET_MEMBERSHIP_EXCHANGE_CONTRACT_ADDRESS,
                 "token_type": "IbetMembership"
@@ -197,6 +199,7 @@ class WatchMembershipBuyAgreement(Watcher):
 
             metadata = {
                 "company_name": company.corporate_name,
+                "token_address": token_address,
                 "token_name": token.name,
                 "exchange_address": IBET_MEMBERSHIP_EXCHANGE_CONTRACT_ADDRESS,
                 "token_type": "IbetMembership"
@@ -233,6 +236,7 @@ class WatchMembershipSellAgreement(Watcher):
 
             metadata = {
                 "company_name": company.corporate_name,
+                "token_address": token_address,
                 "token_name": token.name,
                 "exchange_address": IBET_MEMBERSHIP_EXCHANGE_CONTRACT_ADDRESS,
                 "token_type": "IbetMembership"
@@ -269,6 +273,7 @@ class WatchMembershipBuySettlementOK(Watcher):
 
             metadata = {
                 "company_name": company.corporate_name,
+                "token_address": token_address,
                 "token_name": token.name,
                 "exchange_address": IBET_MEMBERSHIP_EXCHANGE_CONTRACT_ADDRESS,
                 "token_type": "IbetMembership"
@@ -305,6 +310,7 @@ class WatchMembershipSellSettlementOK(Watcher):
 
             metadata = {
                 "company_name": company.corporate_name,
+                "token_address": token_address,
                 "token_name": token.name,
                 "exchange_address": IBET_MEMBERSHIP_EXCHANGE_CONTRACT_ADDRESS,
                 "token_type": "IbetMembership"
@@ -341,6 +347,7 @@ class WatchMembershipBuySettlementNG(Watcher):
 
             metadata = {
                 "company_name": company.corporate_name,
+                "token_address": token_address,
                 "token_name": token.name,
                 "exchange_address": IBET_MEMBERSHIP_EXCHANGE_CONTRACT_ADDRESS,
                 "token_type": "IbetMembership"
@@ -377,6 +384,7 @@ class WatchMembershipSellSettlementNG(Watcher):
 
             metadata = {
                 "company_name": company.corporate_name,
+                "token_address": token_address,
                 "token_name": token.name,
                 "exchange_address": IBET_MEMBERSHIP_EXCHANGE_CONTRACT_ADDRESS,
                 "token_type": "IbetMembership"

--- a/async/processor_Notifications_Share_Exchange.py
+++ b/async/processor_Notifications_Share_Exchange.py
@@ -125,6 +125,7 @@ class WatchShareNewOrder(Watcher):
 
             metadata = {
                 "company_name": company.corporate_name,
+                "token_address": token_address,
                 "token_name": token.name,
                 "exchange_address": IBET_SHARE_EXCHANGE_CONTRACT_ADDRESS,
                 "token_type": "IbetShare"
@@ -176,6 +177,7 @@ class WatchShareCancelOrder(Watcher):
 
             metadata = {
                 "company_name": company.corporate_name,
+                "token_address": token_address,
                 "token_name": token.name,
                 "exchange_address": IBET_SHARE_EXCHANGE_CONTRACT_ADDRESS,
                 "token_type": "IbetShare"
@@ -227,6 +229,7 @@ class WatchShareBuyAgreement(Watcher):
 
             metadata = {
                 "company_name": company.corporate_name,
+                "token_address": token_address,
                 "token_name": token.name,
                 "exchange_address": IBET_SHARE_EXCHANGE_CONTRACT_ADDRESS,
                 "token_type": "IbetShare"
@@ -268,6 +271,7 @@ class WatchShareSellAgreement(Watcher):
 
             metadata = {
                 "company_name": company.corporate_name,
+                "token_address": token_address,
                 "token_name": token.name,
                 "exchange_address": IBET_SHARE_EXCHANGE_CONTRACT_ADDRESS,
                 "token_type": "IbetShare"
@@ -309,6 +313,7 @@ class WatchShareBuySettlementOK(Watcher):
 
             metadata = {
                 "company_name": company.corporate_name,
+                "token_address": token_address,
                 "token_name": token.name,
                 "exchange_address": IBET_SHARE_EXCHANGE_CONTRACT_ADDRESS,
                 "token_type": "IbetShare"
@@ -350,6 +355,7 @@ class WatchShareSellSettlementOK(Watcher):
 
             metadata = {
                 "company_name": company.corporate_name,
+                "token_address": token_address,
                 "token_name": token.name,
                 "exchange_address": IBET_SHARE_EXCHANGE_CONTRACT_ADDRESS,
                 "token_type": "IbetShare"
@@ -391,6 +397,7 @@ class WatchShareBuySettlementNG(Watcher):
 
             metadata = {
                 "company_name": company.corporate_name,
+                "token_address": token_address,
                 "token_name": token.name,
                 "exchange_address": IBET_SHARE_EXCHANGE_CONTRACT_ADDRESS,
                 "token_type": "IbetShare"
@@ -432,6 +439,7 @@ class WatchShareSellSettlementNG(Watcher):
 
             metadata = {
                 "company_name": company.corporate_name,
+                "token_address": token_address,
                 "token_name": token.name,
                 "exchange_address": IBET_SHARE_EXCHANGE_CONTRACT_ADDRESS,
                 "token_type": "IbetShare"

--- a/async/processor_Notifications_Share_Token.py
+++ b/async/processor_Notifications_Share_Token.py
@@ -139,6 +139,7 @@ class WatchStartOffering(Watcher):
             company = company_list.find(token_owner_address)
             metadata = {
                 "company_name": company.corporate_name,
+                "token_address": entry["address"],
                 "token_name": token_name,
                 "exchange_address": "",
                 "token_type": "IbetShare"
@@ -166,6 +167,7 @@ class WatchStopOffering(Watcher):
             company = company_list.find(token_owner_address)
             metadata = {
                 "company_name": company.corporate_name,
+                "token_address": entry["address"],
                 "token_name": token_name,
                 "exchange_address": "",
                 "token_type": "IbetShare"
@@ -193,6 +195,7 @@ class WatchSuspend(Watcher):
             company = company_list.find(token_owner_address)
             metadata = {
                 "company_name": company.corporate_name,
+                "token_address": entry["address"],
                 "token_name": token_name,
                 "exchange_address": "",
                 "token_type": "IbetShare"
@@ -220,6 +223,7 @@ class WatchApplyForOffering(Watcher):
             company = company_list.find(token_owner_address)
             metadata = {
                 "company_name": company.corporate_name,
+                "token_address": entry["address"],
                 "token_name": token_name,
                 "exchange_address": "",
                 "token_type": "IbetShare"
@@ -248,6 +252,7 @@ class WatchAllot(Watcher):
             company = company_list.find(token_owner_address)
             metadata = {
                 "company_name": company.corporate_name,
+                "token_address": entry["address"],
                 "token_name": token_name,
                 "exchange_address": "",
                 "token_type": "IbetShare"
@@ -280,6 +285,7 @@ class WatchTransfer(Watcher):
             company = company_list.find(token_owner_address)
             metadata = {
                 "company_name": company.corporate_name,
+                "token_address": entry["address"],
                 "token_name": token_name,
                 "exchange_address": "",
                 "token_type": "IbetShare"


### PR DESCRIPTION
close #726 

entry["address"]で本当にtokenのaddress取れるか確認取れたらWIPとります
 -> devのquorumに向けた確認用のプロセッサーでみてみたところ、大丈夫そうでした

```
# entryの中身
AttributeDict({'args': AttributeDict({'accountAddress': '0x3A06A2930E92BbFd4A9C52F430cb02c28340DbfD', 'amount': 3}), 'event': 'ApplyFor', 'logIndex': 0, 'transactionIndex': 0, 'transactionHash': HexBytes('0xb0cd89041a27da23fbf36809b345b2d53735d1445a3cdb004d29f0fbf3330d04'), 'address': '0xe9a0C458f13c27b7640493fC07aa06274C430B2a', 'blockHash': HexBytes('0x7f3c2ce9a85a89a1ad76bc6458ee3eac5c7bb631faab80277179356533999642'), 'blockNumber': 60731705})

# お試しのmetaInfo
{'company_name': 'company', 'token_address': '0xe9a0C458f13c27b7640493fC07aa06274C430B2a', 'token_name': '開発環境優先出資証券', 'exchange_address': '', 'token_type': 'IbetShare'}
```