### PR TITLE
feat: make transaction wait timeout an environment variable

### DIFF
--- a/app/api/v2/eth.py
+++ b/app/api/v2/eth.py
@@ -180,7 +180,7 @@ class SendRawTransaction(BaseResource):
 
             # 実行結果を確認
             try:
-                tx = web3.eth.waitForTransactionReceipt(tx_hash, timeout=5)
+                tx = web3.eth.waitForTransactionReceipt(tx_hash, timeout=config.TRANSACTION_WAIT_TIMEOUT)
             except Exception as err:
                 # NOTE: eth.waitForTransactionReceiptは本来はExceptionではなくNoneを返す仕様だが、
                 #       バグでExceptionを返すようになっているため対応しておく

--- a/app/config.py
+++ b/app/config.py
@@ -54,6 +54,8 @@ CONFIG.read(INI_FILE)
 # Web3設定
 WEB3_HTTP_PROVIDER = os.environ.get("WEB3_HTTP_PROVIDER") or 'http://localhost:8545'
 WEB3_CHAINID = os.environ.get("WEB3_CHAINID") or CONFIG['web3']['chainid']
+TRANSACTION_WAIT_TIMEOUT = int(os.environ.get("TRANSACTION_WAIT_TIMEOUT")) \
+    if os.environ.get("TRANSACTION_WAIT_TIMEOUT") else 120
 
 # サーバ設定
 WORKER_COUNT = int(os.environ.get("WORKER_COUNT")) if os.environ.get("WORKER_COUNT") else 8


### PR DESCRIPTION
- Changed so that the timeout for waiting for transaction acceptance (waitForTransactionReceipt) can be set by an environment variable.
- The default value is set to 120sec, the same as the default value of waitForTransactionReceipt.