### PR TITLE
feat: improve indexer batch

### DIFF
--- a/app/model/db/idx_position.py
+++ b/app/model/db/idx_position.py
@@ -65,6 +65,13 @@ class IDXPositionBondBlockNumber(Base):
     # latest blockNumber
     latest_block_number = Column(BigInteger)
 
+    FIELDS = {
+        'id': int,
+        'latest_block_number': int,
+    }
+
+    FIELDS.update(Base.FIELDS)
+
 
 class IDXPositionShareBlockNumber(Base):
     """Synchronized blockNumber of IDXPosition(Share token)"""
@@ -74,6 +81,13 @@ class IDXPositionShareBlockNumber(Base):
     id = Column(BigInteger, primary_key=True, autoincrement=True)
     # latest blockNumber
     latest_block_number = Column(BigInteger)
+
+    FIELDS = {
+        'id': int,
+        'latest_block_number': int,
+    }
+
+    FIELDS.update(Base.FIELDS)
 
 
 class IDXPositionCouponBlockNumber(Base):
@@ -85,6 +99,13 @@ class IDXPositionCouponBlockNumber(Base):
     # latest blockNumber
     latest_block_number = Column(BigInteger)
 
+    FIELDS = {
+        'id': int,
+        'latest_block_number': int,
+    }
+
+    FIELDS.update(Base.FIELDS)
+
 
 class IDXPositionMembershipBlockNumber(Base):
     """Synchronized blockNumber of IDXPosition(Membership token)"""
@@ -94,3 +115,10 @@ class IDXPositionMembershipBlockNumber(Base):
     id = Column(BigInteger, primary_key=True, autoincrement=True)
     # latest blockNumber
     latest_block_number = Column(BigInteger)
+
+    FIELDS = {
+        'id': int,
+        'latest_block_number': int,
+    }
+
+    FIELDS.update(Base.FIELDS)

--- a/app/model/db/idx_position.py
+++ b/app/model/db/idx_position.py
@@ -1,14 +1,19 @@
 """
 Copyright BOOSTRY Co., Ltd.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
+
 You may obtain a copy of the License at
 http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
 See the License for the specific language governing permissions and
 limitations under the License.
+
 SPDX-License-Identifier: Apache-2.0
 """
 from sqlalchemy import (

--- a/app/model/db/idx_position.py
+++ b/app/model/db/idx_position.py
@@ -1,19 +1,14 @@
 """
 Copyright BOOSTRY Co., Ltd.
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
-
 You may obtain a copy of the License at
 http://www.apache.org/licenses/LICENSE-2.0
-
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-
 See the License for the specific language governing permissions and
 limitations under the License.
-
 SPDX-License-Identifier: Apache-2.0
 """
 from sqlalchemy import (
@@ -54,3 +49,43 @@ class IDXPosition(Base):
         "pending_transfer": int
     }
     FIELDS.update(Base.FIELDS)
+
+
+class IDXPositionBondBlockNumber(Base):
+    """Synchronized blockNumber of IDXPosition(Bond token)"""
+    __tablename__ = "idx_position_bond_block_number"
+
+    # sequence id
+    id = Column(BigInteger, primary_key=True, autoincrement=True)
+    # latest blockNumber
+    latest_block_number = Column(BigInteger)
+
+
+class IDXPositionShareBlockNumber(Base):
+    """Synchronized blockNumber of IDXPosition(Share token)"""
+    __tablename__ = "idx_position_share_block_number"
+
+    # sequence id
+    id = Column(BigInteger, primary_key=True, autoincrement=True)
+    # latest blockNumber
+    latest_block_number = Column(BigInteger)
+
+
+class IDXPositionCouponBlockNumber(Base):
+    """Synchronized blockNumber of IDXPosition(Coupon token)"""
+    __tablename__ = "idx_position_coupon_block_number"
+
+    # sequence id
+    id = Column(BigInteger, primary_key=True, autoincrement=True)
+    # latest blockNumber
+    latest_block_number = Column(BigInteger)
+
+
+class IDXPositionMembershipBlockNumber(Base):
+    """Synchronized blockNumber of IDXPosition(Membership token)"""
+    __tablename__ = "idx_position_membership_block_number"
+
+    # sequence id
+    id = Column(BigInteger, primary_key=True, autoincrement=True)
+    # latest blockNumber
+    latest_block_number = Column(BigInteger)

--- a/batch/indexer_Position_Bond.py
+++ b/batch/indexer_Position_Bond.py
@@ -196,7 +196,10 @@ class Processor:
                     fromBlock=block_from,
                     toBlock=block_to
                 )
-                events_filtered = self.remove_duplicate_event_by_token_account_desc(events, ["from", "to"])
+                events_filtered = self.remove_duplicate_event_by_token_account_desc(
+                    events=events,
+                    account_keys=["from", "to"]
+                )
                 for event in events_filtered:
                     args = event["args"]
                     for _account in [args.get("from", ZERO_ADDRESS), args.get("to", ZERO_ADDRESS)]:
@@ -229,7 +232,10 @@ class Processor:
                     fromBlock=block_from,
                     toBlock=block_to
                 )
-                events_filtered = self.remove_duplicate_event_by_token_account_desc(events, ["accountAddress"])
+                events_filtered = self.remove_duplicate_event_by_token_account_desc(
+                    events=events,
+                    account_keys=["accountAddress"]
+                )
                 for event in events_filtered:
                     args = event["args"]
                     account = args.get("accountAddress", ZERO_ADDRESS)
@@ -258,7 +264,10 @@ class Processor:
                     fromBlock=block_from,
                     toBlock=block_to
                 )
-                events_filtered = self.remove_duplicate_event_by_token_account_desc(events, ["recipientAddress"])
+                events_filtered = self.remove_duplicate_event_by_token_account_desc(
+                    events=events,
+                    account_keys=["recipientAddress"]
+                )
                 for event in events_filtered:
                     args = event["args"]
                     account = args.get("recipientAddress", ZERO_ADDRESS)
@@ -287,7 +296,10 @@ class Processor:
                     fromBlock=block_from,
                     toBlock=block_to
                 )
-                events_filtered = self.remove_duplicate_event_by_token_account_desc(events, ["targetAddress"])
+                events_filtered = self.remove_duplicate_event_by_token_account_desc(
+                    events=events,
+                    account_keys=["targetAddress"]
+                )
                 for event in events_filtered:
                     args = event["args"]
                     account = args.get("targetAddress", ZERO_ADDRESS)
@@ -316,7 +328,10 @@ class Processor:
                     fromBlock=block_from,
                     toBlock=block_to
                 )
-                events_filtered = self.remove_duplicate_event_by_token_account_desc(events, ["targetAddress"])
+                events_filtered = self.remove_duplicate_event_by_token_account_desc(
+                    events=events,
+                    account_keys=["targetAddress"]
+                )
                 for event in events_filtered:
                     args = event["args"]
                     account = args.get("targetAddress", ZERO_ADDRESS)
@@ -345,7 +360,10 @@ class Processor:
                     fromBlock=block_from,
                     toBlock=block_to
                 )
-                events_filtered = self.remove_duplicate_event_by_token_account_desc(events, ["from"])
+                events_filtered = self.remove_duplicate_event_by_token_account_desc(
+                    events=events,
+                    account_keys=["from"]
+                )
                 for event in events_filtered:
                     args = event["args"]
                     account = args.get("from", ZERO_ADDRESS)
@@ -374,7 +392,10 @@ class Processor:
                     fromBlock=block_from,
                     toBlock=block_to
                 )
-                events_filtered = self.remove_duplicate_event_by_token_account_desc(events, ["from"])
+                events_filtered = self.remove_duplicate_event_by_token_account_desc(
+                    events=events,
+                    account_keys=["from"]
+                )
                 for event in events_filtered:
                     args = event["args"]
                     account = args.get("from", ZERO_ADDRESS)
@@ -403,7 +424,10 @@ class Processor:
                     fromBlock=block_from,
                     toBlock=block_to
                 )
-                events_filtered = self.remove_duplicate_event_by_token_account_desc(events, ["from", "to"])
+                events_filtered = self.remove_duplicate_event_by_token_account_desc(
+                    events=events,
+                    account_keys=["from", "to"]
+                )
                 for event in events_filtered:
                     args = event["args"]
                     for _account in [args.get("from", ZERO_ADDRESS), args.get("to", ZERO_ADDRESS)]:
@@ -753,7 +777,8 @@ class Processor:
             db_session.add(position)
 
     @staticmethod
-    def remove_duplicate_event_by_token_account_desc(events: [], account_keys: List[str]):
+    def remove_duplicate_event_by_token_account_desc(events: List,
+                                                     account_keys: List[str]) -> List:
         """Remove duplicate event from event list.
         Events that have same account key will be removed.
 
@@ -779,7 +804,7 @@ class Processor:
                 seen.add(record_tuple[1])
 
         # return events in original order
-        return reversed(remove_duplicate_list)
+        return list(reversed(remove_duplicate_list))
 
 
 def main():

--- a/batch/indexer_Position_Bond.py
+++ b/batch/indexer_Position_Bond.py
@@ -74,13 +74,13 @@ class Processor:
             if idx_position_block_number >= latest_block:
                 LOG.debug(
                     f"Initial Sync is skipped since current block number({web3.eth.blockNumber}) is equal to or less "
-                    f"than last synced block number({idx_position_block_number}) this processor does. "
+                    f"than last synced block number({idx_position_block_number}) this processor did."
                 )
                 pass
             else:
                 _from_block = idx_position_block_number + 1
-                _to_block = 999999
-                if latest_block > 999999:
+                _to_block = 999999 + _from_block
+                if latest_block > _to_block:
                     while _to_block < latest_block:
                         self.__sync_all(
                             db_session=local_session,
@@ -116,7 +116,7 @@ class Processor:
             if idx_position_block_number >= latest_block:
                 LOG.debug(
                     f"Initial Sync is skipped since current block number({latest_block}) is equal to or less "
-                    f"than last synced block number({idx_position_block_number}) this processor does. "
+                    f"than last synced block number({idx_position_block_number}) this processor did."
                 )
                 pass
             else:

--- a/batch/indexer_Position_Bond.py
+++ b/batch/indexer_Position_Bond.py
@@ -69,12 +69,12 @@ class Processor:
             self.__get_contract_list(local_session)
             # Synchronize 1,000,000 blocks each
             # if some blocks have already synced, sync starting from next block
-            idx_position_block_number = self.get_idx_position_block_number(db_session=local_session)
+            idx_position_block_number = self.__get_idx_position_block_number(db_session=local_session)
             latest_block = web3.eth.blockNumber
             if idx_position_block_number >= latest_block:
                 LOG.debug(
                     f"Initial Sync is skipped since current block number({web3.eth.blockNumber}) is equal to or less "
-                    f"than last synced block number({idx_position_block_number} this processor does. "
+                    f"than last synced block number({idx_position_block_number}) this processor does. "
                 )
                 pass
             else:
@@ -100,7 +100,7 @@ class Processor:
                         block_from=_from_block,
                         block_to=latest_block
                     )
-                self.set_idx_position_block_number(local_session, latest_block)
+                self.__set_idx_position_block_number(local_session, latest_block)
                 local_session.commit()
         finally:
             local_session.close()
@@ -112,11 +112,11 @@ class Processor:
             self.__get_contract_list(local_session)
             latest_block = web3.eth.blockNumber
             # if some blocks have already synced, sync starting from next block
-            idx_position_block_number = self.get_idx_position_block_number(db_session=local_session)
+            idx_position_block_number = self.__get_idx_position_block_number(db_session=local_session)
             if idx_position_block_number >= latest_block:
                 LOG.debug(
                     f"Initial Sync is skipped since current block number({latest_block}) is equal to or less "
-                    f"than last synced block number({idx_position_block_number} this processor does. "
+                    f"than last synced block number({idx_position_block_number}) this processor does. "
                 )
                 pass
             else:
@@ -126,7 +126,7 @@ class Processor:
                     block_from=_from_block,
                     block_to=latest_block
                 )
-                self.set_idx_position_block_number(local_session, latest_block)
+                self.__set_idx_position_block_number(local_session, latest_block)
                 local_session.commit()
         finally:
             local_session.close()
@@ -607,7 +607,7 @@ class Processor:
                 LOG.exception(e)
 
     @staticmethod
-    def get_idx_position_block_number(db_session: Session):
+    def __get_idx_position_block_number(db_session: Session):
         """Get position index for Bond """
         _idx_position_block_number = db_session.query(IDXPositionBondBlockNumber).first()
         if _idx_position_block_number is None:
@@ -616,7 +616,7 @@ class Processor:
             return _idx_position_block_number.latest_block_number
 
     @staticmethod
-    def set_idx_position_block_number(db_session: Session, block_number: int):
+    def __set_idx_position_block_number(db_session: Session, block_number: int):
         """Set position index for Bond """
         _idx_position_block_number = db_session.query(IDXPositionBondBlockNumber). \
             first()

--- a/batch/indexer_Position_Bond.py
+++ b/batch/indexer_Position_Bond.py
@@ -16,7 +16,7 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 """
-from typing import Optional
+from typing import Optional, List
 import os
 import sys
 import time
@@ -26,6 +26,8 @@ from eth_utils import to_checksum_address
 from sqlalchemy import create_engine
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
+
+from app.model.db.idx_position import IDXPositionBondBlockNumber
 
 path = os.path.join(os.path.dirname(__file__), "../")
 sys.path.append(path)
@@ -55,7 +57,6 @@ class Processor:
     """Processor for indexing Bond balances"""
 
     def __init__(self):
-        self.latest_block = web3.eth.blockNumber
         self.token_list = []
 
     @staticmethod
@@ -67,29 +68,40 @@ class Processor:
         try:
             self.__get_contract_list(local_session)
             # Synchronize 1,000,000 blocks each
-            _to_block = 999999
-            _from_block = 0
-            if self.latest_block > 999999:
-                while _to_block < self.latest_block:
+            # if some blocks have already synced, sync starting from next block
+            idx_position_block_number = self.get_idx_position_block_number(db_session=local_session)
+            latest_block = web3.eth.blockNumber
+            if idx_position_block_number >= latest_block:
+                LOG.debug(
+                    f"Initial Sync is skipped since current block number({web3.eth.blockNumber}) is equal to or less "
+                    f"than last synced block number({idx_position_block_number} this processor does. "
+                )
+                pass
+            else:
+                _from_block = idx_position_block_number + 1
+                _to_block = 999999
+                if latest_block > 999999:
+                    while _to_block < latest_block:
+                        self.__sync_all(
+                            db_session=local_session,
+                            block_from=_from_block,
+                            block_to=_to_block
+                        )
+                        _to_block += 1000000
+                        _from_block += 1000000
                     self.__sync_all(
                         db_session=local_session,
                         block_from=_from_block,
-                        block_to=_to_block
+                        block_to=latest_block
                     )
-                    _to_block += 1000000
-                    _from_block += 1000000
-                self.__sync_all(
-                    db_session=local_session,
-                    block_from=_from_block,
-                    block_to=self.latest_block
-                )
-            else:
-                self.__sync_all(
-                    db_session=local_session,
-                    block_from=_from_block,
-                    block_to=self.latest_block
-                )
-            local_session.commit()
+                else:
+                    self.__sync_all(
+                        db_session=local_session,
+                        block_from=_from_block,
+                        block_to=latest_block
+                    )
+                self.set_idx_position_block_number(local_session, latest_block)
+                local_session.commit()
         finally:
             local_session.close()
         LOG.info(f"<{process_name}> Initial sync has been completed")
@@ -98,16 +110,24 @@ class Processor:
         local_session = self.__get_db_session()
         try:
             self.__get_contract_list(local_session)
-            blockTo = web3.eth.blockNumber
-            if blockTo == self.latest_block:
-                return
-            self.__sync_all(
-                db_session=local_session,
-                block_from=self.latest_block + 1,
-                block_to=blockTo
-            )
-            self.latest_block = blockTo
-            local_session.commit()
+            latest_block = web3.eth.blockNumber
+            # if some blocks have already synced, sync starting from next block
+            idx_position_block_number = self.get_idx_position_block_number(db_session=local_session)
+            if idx_position_block_number >= latest_block:
+                LOG.debug(
+                    f"Initial Sync is skipped since current block number({latest_block}) is equal to or less "
+                    f"than last synced block number({idx_position_block_number} this processor does. "
+                )
+                pass
+            else:
+                _from_block = idx_position_block_number + 1
+                self.__sync_all(
+                    db_session=local_session,
+                    block_from=_from_block,
+                    block_to=latest_block
+                )
+                self.set_idx_position_block_number(local_session, latest_block)
+                local_session.commit()
         finally:
             local_session.close()
 
@@ -176,7 +196,8 @@ class Processor:
                     fromBlock=block_from,
                     toBlock=block_to
                 )
-                for event in events:
+                events_filtered = self.remove_duplicate_event_by_token_account_desc(events, ["from", "to"])
+                for event in events_filtered:
                     args = event["args"]
                     for _account in [args.get("from", ZERO_ADDRESS), args.get("to", ZERO_ADDRESS)]:
                         if web3.eth.getCode(_account).hex() == "0x":
@@ -208,7 +229,8 @@ class Processor:
                     fromBlock=block_from,
                     toBlock=block_to
                 )
-                for event in events:
+                events_filtered = self.remove_duplicate_event_by_token_account_desc(events, ["accountAddress"])
+                for event in events_filtered:
                     args = event["args"]
                     account = args.get("accountAddress", ZERO_ADDRESS)
                     balance, pending_transfer = self.__get_account_balance_token(token, account)
@@ -236,7 +258,8 @@ class Processor:
                     fromBlock=block_from,
                     toBlock=block_to
                 )
-                for event in events:
+                events_filtered = self.remove_duplicate_event_by_token_account_desc(events, ["recipientAddress"])
+                for event in events_filtered:
                     args = event["args"]
                     account = args.get("recipientAddress", ZERO_ADDRESS)
                     balance, pending_transfer = self.__get_account_balance_token(token, account)
@@ -264,7 +287,8 @@ class Processor:
                     fromBlock=block_from,
                     toBlock=block_to
                 )
-                for event in events:
+                events_filtered = self.remove_duplicate_event_by_token_account_desc(events, ["targetAddress"])
+                for event in events_filtered:
                     args = event["args"]
                     account = args.get("targetAddress", ZERO_ADDRESS)
                     balance, pending_transfer = self.__get_account_balance_token(token, account)
@@ -292,7 +316,8 @@ class Processor:
                     fromBlock=block_from,
                     toBlock=block_to
                 )
-                for event in events:
+                events_filtered = self.remove_duplicate_event_by_token_account_desc(events, ["targetAddress"])
+                for event in events_filtered:
                     args = event["args"]
                     account = args.get("targetAddress", ZERO_ADDRESS)
                     balance, pending_transfer = self.__get_account_balance_token(token, account)
@@ -320,7 +345,8 @@ class Processor:
                     fromBlock=block_from,
                     toBlock=block_to
                 )
-                for event in events:
+                events_filtered = self.remove_duplicate_event_by_token_account_desc(events, ["from"])
+                for event in events_filtered:
                     args = event["args"]
                     account = args.get("from", ZERO_ADDRESS)
                     balance, pending_transfer = self.__get_account_balance_token(token, account)
@@ -348,7 +374,8 @@ class Processor:
                     fromBlock=block_from,
                     toBlock=block_to
                 )
-                for event in events:
+                events_filtered = self.remove_duplicate_event_by_token_account_desc(events, ["from"])
+                for event in events_filtered:
                     args = event["args"]
                     account = args.get("from", ZERO_ADDRESS)
                     balance, pending_transfer = self.__get_account_balance_token(token, account)
@@ -376,7 +403,8 @@ class Processor:
                     fromBlock=block_from,
                     toBlock=block_to
                 )
-                for event in events:
+                events_filtered = self.remove_duplicate_event_by_token_account_desc(events, ["from", "to"])
+                for event in events_filtered:
                     args = event["args"]
                     for _account in [args.get("from", ZERO_ADDRESS), args.get("to", ZERO_ADDRESS)]:
                         _balance, _pending_transfer = self.__get_account_balance_token(token, _account)
@@ -579,6 +607,25 @@ class Processor:
                 LOG.exception(e)
 
     @staticmethod
+    def get_idx_position_block_number(db_session: Session):
+        """Get position index for Bond """
+        _idx_position_block_number = db_session.query(IDXPositionBondBlockNumber).first()
+        if _idx_position_block_number is None:
+            return -1
+        else:
+            return _idx_position_block_number.latest_block_number
+
+    @staticmethod
+    def set_idx_position_block_number(db_session: Session, block_number: int):
+        """Set position index for Bond """
+        _idx_position_block_number = db_session.query(IDXPositionBondBlockNumber). \
+            first()
+        if _idx_position_block_number is None:
+            _idx_position_block_number = IDXPositionBondBlockNumber()
+        _idx_position_block_number.latest_block_number = block_number
+        db_session.merge(_idx_position_block_number)
+
+    @staticmethod
     def __get_account_balance_all(token_contract, account_address: str):
         """Get balance"""
         balance = Contract.call_function(
@@ -704,6 +751,35 @@ class Processor:
             position.exchange_balance = exchange_balance or 0
             position.exchange_commitment = exchange_commitment or 0
             db_session.add(position)
+
+    @staticmethod
+    def remove_duplicate_event_by_token_account_desc(events: [], account_keys: List[str]):
+        """Remove duplicate event from event list.
+        Events that have same account key will be removed.
+
+        :param events: event list
+        :param account_keys: keys in which event contains account address
+        :return: events: event list filtered
+        """
+        event_token_account_list = []
+
+        # reversed events loop for removing duplicates from the front
+        for event in reversed(events):
+            args = event["args"]
+            for arg_key in account_keys:
+                account_address = args.get(arg_key, ZERO_ADDRESS)
+                if account_address != ZERO_ADDRESS:
+                    event_token_account_list.append([event, account_address])
+        seen = set()
+        remove_duplicate_list = []
+        for record in event_token_account_list:
+            record_tuple = tuple(record)
+            if record_tuple[1] not in seen:
+                remove_duplicate_list.append(record[0])
+                seen.add(record_tuple[1])
+
+        # return events in original order
+        return reversed(remove_duplicate_list)
 
 
 def main():

--- a/batch/indexer_Position_Coupon.py
+++ b/batch/indexer_Position_Coupon.py
@@ -189,7 +189,10 @@ class Processor:
                     fromBlock=block_from,
                     toBlock=block_to
                 )
-                events_filtered = self.remove_duplicate_event_by_token_account_desc(events, ["from","to"])
+                events_filtered = self.remove_duplicate_event_by_token_account_desc(
+                    events=events,
+                    account_keys=["from", "to"]
+                )
                 for event in events_filtered:
                     args = event["args"]
                     for _account in [args.get("from", ZERO_ADDRESS), args.get("to", ZERO_ADDRESS)]:
@@ -222,7 +225,10 @@ class Processor:
                     toBlock=block_to
                 )
 
-                events_filtered = self.remove_duplicate_event_by_token_account_desc(events, ["consumer"])
+                events_filtered = self.remove_duplicate_event_by_token_account_desc(
+                    events=events,
+                    account_keys=["consumer"]
+                )
                 for event in events_filtered:
                     args = event["args"]
                     consumer_address = args.get("consumer", ZERO_ADDRESS)
@@ -553,7 +559,8 @@ class Processor:
             db_session.add(position)
 
     @staticmethod
-    def remove_duplicate_event_by_token_account_desc(events: [], account_keys: List[str]):
+    def remove_duplicate_event_by_token_account_desc(events: List,
+                                                     account_keys: List[str]) -> List:
         """Remove duplicate event from event list.
         Events that have same account key will be removed.
 
@@ -579,7 +586,7 @@ class Processor:
                 seen.add(record_tuple[1])
 
         # return events in original order
-        return reversed(remove_duplicate_list)
+        return list(reversed(remove_duplicate_list))
 
 
 def main():

--- a/batch/indexer_Position_Coupon.py
+++ b/batch/indexer_Position_Coupon.py
@@ -69,12 +69,12 @@ class Processor:
             self.__get_contract_list(local_session)
             # Synchronize 1,000,000 blocks each
             # if some blocks have already synced, sync starting from next block
-            idx_position_block_number = self.get_idx_position_block_number(db_session=local_session)
+            idx_position_block_number = self.__get_idx_position_block_number(db_session=local_session)
             latest_block = web3.eth.blockNumber
             if idx_position_block_number >= latest_block:
                 LOG.debug(
                     f"Initial Sync is skipped since current block number({web3.eth.blockNumber}) is equal to or less "
-                    f"than last synced block number({idx_position_block_number} this processor does. "
+                    f"than last synced block number({idx_position_block_number}) this processor does. "
                 )
                 pass
             else:
@@ -100,7 +100,7 @@ class Processor:
                         block_from=_from_block,
                         block_to=latest_block
                     )
-                self.set_idx_position_block_number(local_session, latest_block)
+                self.__set_idx_position_block_number(local_session, latest_block)
                 local_session.commit()
         finally:
             local_session.close()
@@ -112,11 +112,11 @@ class Processor:
             self.__get_contract_list(local_session)
             latest_block = web3.eth.blockNumber
             # if some blocks have already synced, sync starting from next block
-            idx_position_block_number = self.get_idx_position_block_number(db_session=local_session)
+            idx_position_block_number = self.__get_idx_position_block_number(db_session=local_session)
             if idx_position_block_number >= latest_block:
                 LOG.debug(
                     f"Initial Sync is skipped since current block number({latest_block}) is equal to or less "
-                    f"than last synced block number({idx_position_block_number} this processor does. "
+                    f"than last synced block number({idx_position_block_number}) this processor does. "
                 )
                 pass
             else:
@@ -126,7 +126,7 @@ class Processor:
                     block_from=_from_block,
                     block_to=latest_block
                 )
-                self.set_idx_position_block_number(local_session, latest_block)
+                self.__set_idx_position_block_number(local_session, latest_block)
                 local_session.commit()
         finally:
             local_session.close()
@@ -425,7 +425,7 @@ class Processor:
                 LOG.exception(e)
 
     @staticmethod
-    def get_idx_position_block_number(db_session: Session):
+    def __get_idx_position_block_number(db_session: Session):
         """Get position index for Coupon """
         _idx_position_block_number = db_session.query(IDXPositionCouponBlockNumber).first()
         if _idx_position_block_number is None:
@@ -434,7 +434,7 @@ class Processor:
             return _idx_position_block_number.latest_block_number
 
     @staticmethod
-    def set_idx_position_block_number(db_session: Session, block_number: int):
+    def __set_idx_position_block_number(db_session: Session, block_number: int):
         """Set position index for Coupon """
         _idx_position_block_number = db_session.query(IDXPositionCouponBlockNumber). \
             first()

--- a/batch/indexer_Position_Coupon.py
+++ b/batch/indexer_Position_Coupon.py
@@ -16,7 +16,7 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 """
-from typing import Optional
+from typing import Optional, List
 import os
 import sys
 import time
@@ -26,6 +26,8 @@ from eth_utils import to_checksum_address
 from sqlalchemy import create_engine
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
+
+from app.model.db.idx_position import IDXPositionCouponBlockNumber
 
 path = os.path.join(os.path.dirname(__file__), "../")
 sys.path.append(path)
@@ -55,7 +57,6 @@ class Processor:
     """Processor for indexing Coupon balances"""
 
     def __init__(self):
-        self.latest_block = web3.eth.blockNumber
         self.token_list = []
 
     @staticmethod
@@ -67,29 +68,40 @@ class Processor:
         try:
             self.__get_contract_list(local_session)
             # Synchronize 1,000,000 blocks each
-            _to_block = 999999
-            _from_block = 0
-            if self.latest_block > 999999:
-                while _to_block < self.latest_block:
+            # if some blocks have already synced, sync starting from next block
+            idx_position_block_number = self.get_idx_position_block_number(db_session=local_session)
+            latest_block = web3.eth.blockNumber
+            if idx_position_block_number >= latest_block:
+                LOG.debug(
+                    f"Initial Sync is skipped since current block number({web3.eth.blockNumber}) is equal to or less "
+                    f"than last synced block number({idx_position_block_number} this processor does. "
+                )
+                pass
+            else:
+                _from_block = idx_position_block_number + 1
+                _to_block = 999999
+                if latest_block > 999999:
+                    while _to_block < latest_block:
+                        self.__sync_all(
+                            db_session=local_session,
+                            block_from=_from_block,
+                            block_to=_to_block
+                        )
+                        _to_block += 1000000
+                        _from_block += 1000000
                     self.__sync_all(
                         db_session=local_session,
                         block_from=_from_block,
-                        block_to=_to_block
+                        block_to=latest_block
                     )
-                    _to_block += 1000000
-                    _from_block += 1000000
-                self.__sync_all(
-                    db_session=local_session,
-                    block_from=_from_block,
-                    block_to=self.latest_block
-                )
-            else:
-                self.__sync_all(
-                    db_session=local_session,
-                    block_from=_from_block,
-                    block_to=self.latest_block
-                )
-            local_session.commit()
+                else:
+                    self.__sync_all(
+                        db_session=local_session,
+                        block_from=_from_block,
+                        block_to=latest_block
+                    )
+                self.set_idx_position_block_number(local_session, latest_block)
+                local_session.commit()
         finally:
             local_session.close()
         LOG.info(f"<{process_name}> Initial sync has been completed")
@@ -98,16 +110,24 @@ class Processor:
         local_session = self.__get_db_session()
         try:
             self.__get_contract_list(local_session)
-            blockTo = web3.eth.blockNumber
-            if blockTo == self.latest_block:
-                return
-            self.__sync_all(
-                db_session=local_session,
-                block_from=self.latest_block + 1,
-                block_to=blockTo
-            )
-            self.latest_block = blockTo
-            local_session.commit()
+            latest_block = web3.eth.blockNumber
+            # if some blocks have already synced, sync starting from next block
+            idx_position_block_number = self.get_idx_position_block_number(db_session=local_session)
+            if idx_position_block_number >= latest_block:
+                LOG.debug(
+                    f"Initial Sync is skipped since current block number({latest_block}) is equal to or less "
+                    f"than last synced block number({idx_position_block_number} this processor does. "
+                )
+                pass
+            else:
+                _from_block = idx_position_block_number + 1
+                self.__sync_all(
+                    db_session=local_session,
+                    block_from=_from_block,
+                    block_to=latest_block
+                )
+                self.set_idx_position_block_number(local_session, latest_block)
+                local_session.commit()
         finally:
             local_session.close()
 
@@ -169,7 +189,8 @@ class Processor:
                     fromBlock=block_from,
                     toBlock=block_to
                 )
-                for event in events:
+                events_filtered = self.remove_duplicate_event_by_token_account_desc(events, ["from","to"])
+                for event in events_filtered:
                     args = event["args"]
                     for _account in [args.get("from", ZERO_ADDRESS), args.get("to", ZERO_ADDRESS)]:
                         if web3.eth.getCode(_account).hex() == "0x":
@@ -200,7 +221,9 @@ class Processor:
                     fromBlock=block_from,
                     toBlock=block_to
                 )
-                for event in events:
+
+                events_filtered = self.remove_duplicate_event_by_token_account_desc(events, ["consumer"])
+                for event in events_filtered:
                     args = event["args"]
                     consumer_address = args.get("consumer", ZERO_ADDRESS)
                     balance = self.__get_account_balance_token(token, consumer_address)
@@ -402,6 +425,25 @@ class Processor:
                 LOG.exception(e)
 
     @staticmethod
+    def get_idx_position_block_number(db_session: Session):
+        """Get position index for Coupon """
+        _idx_position_block_number = db_session.query(IDXPositionCouponBlockNumber).first()
+        if _idx_position_block_number is None:
+            return -1
+        else:
+            return _idx_position_block_number.latest_block_number
+
+    @staticmethod
+    def set_idx_position_block_number(db_session: Session, block_number: int):
+        """Set position index for Coupon """
+        _idx_position_block_number = db_session.query(IDXPositionCouponBlockNumber). \
+            first()
+        if _idx_position_block_number is None:
+            _idx_position_block_number = IDXPositionCouponBlockNumber()
+        _idx_position_block_number.latest_block_number = block_number
+        db_session.merge(_idx_position_block_number)
+
+    @staticmethod
     def __get_account_balance_all(token_contract, account_address: str):
         """Get balance"""
         balance = Contract.call_function(
@@ -509,6 +551,35 @@ class Processor:
             position.exchange_balance = exchange_balance or 0
             position.exchange_commitment = exchange_commitment or 0
             db_session.add(position)
+
+    @staticmethod
+    def remove_duplicate_event_by_token_account_desc(events: [], account_keys: List[str]):
+        """Remove duplicate event from event list.
+        Events that have same account key will be removed.
+
+        :param events: event list
+        :param account_keys: keys in which event contains account address
+        :return: events: event list filtered
+        """
+        event_token_account_list = []
+
+        # reversed events loop for removing duplicates from the front
+        for event in reversed(events):
+            args = event["args"]
+            for arg_key in account_keys:
+                account_address = args.get(arg_key, ZERO_ADDRESS)
+                if account_address != ZERO_ADDRESS:
+                    event_token_account_list.append([event, account_address])
+        seen = set()
+        remove_duplicate_list = []
+        for record in event_token_account_list:
+            record_tuple = tuple(record)
+            if record_tuple[1] not in seen:
+                remove_duplicate_list.append(record[0])
+                seen.add(record_tuple[1])
+
+        # return events in original order
+        return reversed(remove_duplicate_list)
 
 
 def main():

--- a/batch/indexer_Position_Coupon.py
+++ b/batch/indexer_Position_Coupon.py
@@ -74,13 +74,13 @@ class Processor:
             if idx_position_block_number >= latest_block:
                 LOG.debug(
                     f"Initial Sync is skipped since current block number({web3.eth.blockNumber}) is equal to or less "
-                    f"than last synced block number({idx_position_block_number}) this processor does. "
+                    f"than last synced block number({idx_position_block_number}) this processor did."
                 )
                 pass
             else:
                 _from_block = idx_position_block_number + 1
-                _to_block = 999999
-                if latest_block > 999999:
+                _to_block = 999999 + _from_block
+                if latest_block > _to_block:
                     while _to_block < latest_block:
                         self.__sync_all(
                             db_session=local_session,
@@ -116,7 +116,7 @@ class Processor:
             if idx_position_block_number >= latest_block:
                 LOG.debug(
                     f"Initial Sync is skipped since current block number({latest_block}) is equal to or less "
-                    f"than last synced block number({idx_position_block_number}) this processor does. "
+                    f"than last synced block number({idx_position_block_number}) this processor did."
                 )
                 pass
             else:

--- a/batch/indexer_Position_Membership.py
+++ b/batch/indexer_Position_Membership.py
@@ -67,12 +67,12 @@ class Processor:
             self.__get_contract_list(local_session)
             # Synchronize 1,000,000 blocks each
             # if some blocks have already synced, sync starting from next block
-            idx_position_block_number = self.get_idx_position_block_number(db_session=local_session)
+            idx_position_block_number = self.__get_idx_position_block_number(db_session=local_session)
             latest_block = web3.eth.blockNumber
             if idx_position_block_number >= latest_block:
                 LOG.debug(
                     f"Initial Sync is skipped since current block number({web3.eth.blockNumber}) is equal to or less "
-                    f"than last synced block number({idx_position_block_number} this processor does. "
+                    f"than last synced block number({idx_position_block_number}) this processor does. "
                 )
                 pass
             else:
@@ -98,7 +98,7 @@ class Processor:
                         block_from=_from_block,
                         block_to=latest_block
                     )
-                self.set_idx_position_block_number(local_session, latest_block)
+                self.__set_idx_position_block_number(local_session, latest_block)
                 local_session.commit()
         finally:
             local_session.close()
@@ -110,11 +110,11 @@ class Processor:
             self.__get_contract_list(local_session)
             latest_block = web3.eth.blockNumber
             # if some blocks have already synced, sync starting from next block
-            idx_position_block_number = self.get_idx_position_block_number(db_session=local_session)
+            idx_position_block_number = self.__get_idx_position_block_number(db_session=local_session)
             if idx_position_block_number >= latest_block:
                 LOG.debug(
                     f"Initial Sync is skipped since current block number({latest_block}) is equal to or less "
-                    f"than last synced block number({idx_position_block_number} this processor does. "
+                    f"than last synced block number({idx_position_block_number}) this processor does. "
                 )
                 pass
             else:
@@ -124,7 +124,7 @@ class Processor:
                     block_from=_from_block,
                     block_to=latest_block
                 )
-                self.set_idx_position_block_number(local_session, latest_block)
+                self.__set_idx_position_block_number(local_session, latest_block)
                 local_session.commit()
         finally:
             local_session.close()
@@ -392,7 +392,7 @@ class Processor:
                 LOG.exception(e)
 
     @staticmethod
-    def get_idx_position_block_number(db_session: Session):
+    def __get_idx_position_block_number(db_session: Session):
         """Get position index for Membership """
         _idx_position_block_number = db_session.query(IDXPositionMembershipBlockNumber).first()
         if _idx_position_block_number is None:
@@ -401,7 +401,7 @@ class Processor:
             return _idx_position_block_number.latest_block_number
 
     @staticmethod
-    def set_idx_position_block_number(db_session: Session, block_number: int):
+    def __set_idx_position_block_number(db_session: Session, block_number: int):
         """Set position index for Membership """
         _idx_position_block_number = db_session.query(IDXPositionMembershipBlockNumber). \
             first()

--- a/batch/indexer_Position_Membership.py
+++ b/batch/indexer_Position_Membership.py
@@ -72,13 +72,13 @@ class Processor:
             if idx_position_block_number >= latest_block:
                 LOG.debug(
                     f"Initial Sync is skipped since current block number({web3.eth.blockNumber}) is equal to or less "
-                    f"than last synced block number({idx_position_block_number}) this processor does. "
+                    f"than last synced block number({idx_position_block_number}) this processor did."
                 )
                 pass
             else:
                 _from_block = idx_position_block_number + 1
-                _to_block = 999999
-                if latest_block > 999999:
+                _to_block = 999999 + _from_block
+                if latest_block > _to_block:
                     while _to_block < latest_block:
                         self.__sync_all(
                             db_session=local_session,
@@ -114,7 +114,7 @@ class Processor:
             if idx_position_block_number >= latest_block:
                 LOG.debug(
                     f"Initial Sync is skipped since current block number({latest_block}) is equal to or less "
-                    f"than last synced block number({idx_position_block_number}) this processor does. "
+                    f"than last synced block number({idx_position_block_number}) this processor did."
                 )
                 pass
             else:

--- a/batch/indexer_Position_Membership.py
+++ b/batch/indexer_Position_Membership.py
@@ -185,7 +185,10 @@ class Processor:
                     fromBlock=block_from,
                     toBlock=block_to
                 )
-                events_filtered = self.remove_duplicate_event_by_token_account_desc(events, ["from", "to"])
+                events_filtered = self.remove_duplicate_event_by_token_account_desc(
+                    events=events,
+                    account_keys=["from", "to"]
+                )
                 for event in events_filtered:
                     args = event["args"]
                     for _account in [args.get("from", ZERO_ADDRESS), args.get("to", ZERO_ADDRESS)]:
@@ -520,7 +523,8 @@ class Processor:
             db_session.add(position)
 
     @staticmethod
-    def remove_duplicate_event_by_token_account_desc(events: [], account_keys: List[str]):
+    def remove_duplicate_event_by_token_account_desc(events: List,
+                                                     account_keys: List[str]) -> List:
         """Remove duplicate event from event list.
         Events that have same account key will be removed.
 
@@ -546,7 +550,7 @@ class Processor:
                 seen.add(record_tuple[1])
 
         # return events in original order
-        return reversed(remove_duplicate_list)
+        return list(reversed(remove_duplicate_list))
 
 
 def main():

--- a/batch/indexer_Position_Membership.py
+++ b/batch/indexer_Position_Membership.py
@@ -16,7 +16,7 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 """
-from typing import Optional
+from typing import Optional, List
 import os
 import sys
 import time
@@ -26,6 +26,8 @@ from eth_utils import to_checksum_address
 from sqlalchemy import create_engine
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
+
+from app.model.db.idx_position import IDXPositionMembershipBlockNumber
 
 path = os.path.join(os.path.dirname(__file__), "../")
 sys.path.append(path)
@@ -53,7 +55,6 @@ db_engine = create_engine(DATABASE_URL, echo=False, pool_pre_ping=True)
 
 class Processor:
     def __init__(self):
-        self.latest_block = web3.eth.blockNumber
         self.token_list = []
 
     @staticmethod
@@ -65,29 +66,40 @@ class Processor:
         try:
             self.__get_contract_list(local_session)
             # Synchronize 1,000,000 blocks each
-            _to_block = 999999
-            _from_block = 0
-            if self.latest_block > 999999:
-                while _to_block < self.latest_block:
+            # if some blocks have already synced, sync starting from next block
+            idx_position_block_number = self.get_idx_position_block_number(db_session=local_session)
+            latest_block = web3.eth.blockNumber
+            if idx_position_block_number >= latest_block:
+                LOG.debug(
+                    f"Initial Sync is skipped since current block number({web3.eth.blockNumber}) is equal to or less "
+                    f"than last synced block number({idx_position_block_number} this processor does. "
+                )
+                pass
+            else:
+                _from_block = idx_position_block_number + 1
+                _to_block = 999999
+                if latest_block > 999999:
+                    while _to_block < latest_block:
+                        self.__sync_all(
+                            db_session=local_session,
+                            block_from=_from_block,
+                            block_to=_to_block
+                        )
+                        _to_block += 1000000
+                        _from_block += 1000000
                     self.__sync_all(
                         db_session=local_session,
                         block_from=_from_block,
-                        block_to=_to_block
+                        block_to=latest_block
                     )
-                    _to_block += 1000000
-                    _from_block += 1000000
-                self.__sync_all(
-                    db_session=local_session,
-                    block_from=_from_block,
-                    block_to=self.latest_block
-                )
-            else:
-                self.__sync_all(
-                    db_session=local_session,
-                    block_from=_from_block,
-                    block_to=self.latest_block
-                )
-            local_session.commit()
+                else:
+                    self.__sync_all(
+                        db_session=local_session,
+                        block_from=_from_block,
+                        block_to=latest_block
+                    )
+                self.set_idx_position_block_number(local_session, latest_block)
+                local_session.commit()
         finally:
             local_session.close()
         LOG.info(f"<{process_name}> Initial sync has been completed")
@@ -96,16 +108,24 @@ class Processor:
         local_session = self.__get_db_session()
         try:
             self.__get_contract_list(local_session)
-            blockTo = web3.eth.blockNumber
-            if blockTo == self.latest_block:
-                return
-            self.__sync_all(
-                db_session=local_session,
-                block_from=self.latest_block + 1,
-                block_to=blockTo
-            )
-            self.latest_block = blockTo
-            local_session.commit()
+            latest_block = web3.eth.blockNumber
+            # if some blocks have already synced, sync starting from next block
+            idx_position_block_number = self.get_idx_position_block_number(db_session=local_session)
+            if idx_position_block_number >= latest_block:
+                LOG.debug(
+                    f"Initial Sync is skipped since current block number({latest_block}) is equal to or less "
+                    f"than last synced block number({idx_position_block_number} this processor does. "
+                )
+                pass
+            else:
+                _from_block = idx_position_block_number + 1
+                self.__sync_all(
+                    db_session=local_session,
+                    block_from=_from_block,
+                    block_to=latest_block
+                )
+                self.set_idx_position_block_number(local_session, latest_block)
+                local_session.commit()
         finally:
             local_session.close()
 
@@ -165,7 +185,8 @@ class Processor:
                     fromBlock=block_from,
                     toBlock=block_to
                 )
-                for event in events:
+                events_filtered = self.remove_duplicate_event_by_token_account_desc(events, ["from", "to"])
+                for event in events_filtered:
                     args = event["args"]
                     for _account in [args.get("from", ZERO_ADDRESS), args.get("to", ZERO_ADDRESS)]:
                         if web3.eth.getCode(_account).hex() == "0x":
@@ -371,6 +392,25 @@ class Processor:
                 LOG.exception(e)
 
     @staticmethod
+    def get_idx_position_block_number(db_session: Session):
+        """Get position index for Membership """
+        _idx_position_block_number = db_session.query(IDXPositionMembershipBlockNumber).first()
+        if _idx_position_block_number is None:
+            return -1
+        else:
+            return _idx_position_block_number.latest_block_number
+
+    @staticmethod
+    def set_idx_position_block_number(db_session: Session, block_number: int):
+        """Set position index for Membership """
+        _idx_position_block_number = db_session.query(IDXPositionMembershipBlockNumber). \
+            first()
+        if _idx_position_block_number is None:
+            _idx_position_block_number = IDXPositionMembershipBlockNumber()
+        _idx_position_block_number.latest_block_number = block_number
+        db_session.merge(_idx_position_block_number)
+
+    @staticmethod
     def __get_account_balance_all(token_contract, account_address: str):
         """Get balance"""
         balance = Contract.call_function(
@@ -478,6 +518,35 @@ class Processor:
             position.exchange_balance = exchange_balance or 0
             position.exchange_commitment = exchange_commitment or 0
             db_session.add(position)
+
+    @staticmethod
+    def remove_duplicate_event_by_token_account_desc(events: [], account_keys: List[str]):
+        """Remove duplicate event from event list.
+        Events that have same account key will be removed.
+
+        :param events: event list
+        :param account_keys: keys in which event contains account address
+        :return: events: event list filtered
+        """
+        event_token_account_list = []
+
+        # reversed events loop for removing duplicates from the front
+        for event in reversed(events):
+            args = event["args"]
+            for arg_key in account_keys:
+                account_address = args.get(arg_key, ZERO_ADDRESS)
+                if account_address != ZERO_ADDRESS:
+                    event_token_account_list.append([event, account_address])
+        seen = set()
+        remove_duplicate_list = []
+        for record in event_token_account_list:
+            record_tuple = tuple(record)
+            if record_tuple[1] not in seen:
+                remove_duplicate_list.append(record[0])
+                seen.add(record_tuple[1])
+
+        # return events in original order
+        return reversed(remove_duplicate_list)
 
 
 def main():

--- a/batch/indexer_Position_Share.py
+++ b/batch/indexer_Position_Share.py
@@ -195,7 +195,10 @@ class Processor:
                     fromBlock=block_from,
                     toBlock=block_to
                 )
-                events_filtered = self.remove_duplicate_event_by_token_account_desc(events, ["from", "to"])
+                events_filtered = self.remove_duplicate_event_by_token_account_desc(
+                    events=events,
+                    account_keys=["from", "to"]
+                )
                 for event in events_filtered:
                     args = event["args"]
                     for _account in [args.get("from", ZERO_ADDRESS), args.get("to", ZERO_ADDRESS)]:
@@ -228,7 +231,10 @@ class Processor:
                     fromBlock=block_from,
                     toBlock=block_to
                 )
-                events_filtered = self.remove_duplicate_event_by_token_account_desc(events, ["accountAddress"])
+                events_filtered = self.remove_duplicate_event_by_token_account_desc(
+                    events=events,
+                    account_keys=["accountAddress"]
+                )
                 for event in events_filtered:
                     args = event["args"]
                     account = args.get("accountAddress", ZERO_ADDRESS)
@@ -257,7 +263,10 @@ class Processor:
                     fromBlock=block_from,
                     toBlock=block_to
                 )
-                events_filtered = self.remove_duplicate_event_by_token_account_desc(events, ["recipientAddress"])
+                events_filtered = self.remove_duplicate_event_by_token_account_desc(
+                    events=events,
+                    account_keys=["recipientAddress"]
+                )
                 for event in events_filtered:
                     args = event["args"]
                     account = args.get("recipientAddress", ZERO_ADDRESS)
@@ -286,7 +295,10 @@ class Processor:
                     fromBlock=block_from,
                     toBlock=block_to
                 )
-                events_filtered = self.remove_duplicate_event_by_token_account_desc(events, ["targetAddress"])
+                events_filtered = self.remove_duplicate_event_by_token_account_desc(
+                    events=events,
+                    account_keys=["targetAddress"]
+                )
                 for event in events_filtered:
                     args = event["args"]
                     account = args.get("targetAddress", ZERO_ADDRESS)
@@ -315,7 +327,10 @@ class Processor:
                     fromBlock=block_from,
                     toBlock=block_to
                 )
-                events_filtered = self.remove_duplicate_event_by_token_account_desc(events, ["targetAddress"])
+                events_filtered = self.remove_duplicate_event_by_token_account_desc(
+                    events=events,
+                    account_keys=["targetAddress"]
+                )
                 for event in events_filtered:
                     args = event["args"]
                     account = args.get("targetAddress", ZERO_ADDRESS)
@@ -344,7 +359,10 @@ class Processor:
                     fromBlock=block_from,
                     toBlock=block_to
                 )
-                events_filtered = self.remove_duplicate_event_by_token_account_desc(events, ["from"])
+                events_filtered = self.remove_duplicate_event_by_token_account_desc(
+                    events=events,
+                    account_keys=["from"]
+                )
                 for event in events_filtered:
                     args = event["args"]
                     account = args.get("from", ZERO_ADDRESS)
@@ -373,7 +391,10 @@ class Processor:
                     fromBlock=block_from,
                     toBlock=block_to
                 )
-                events_filtered = self.remove_duplicate_event_by_token_account_desc(events, ["from"])
+                events_filtered = self.remove_duplicate_event_by_token_account_desc(
+                    events=events,
+                    account_keys=["from"]
+                )
                 for event in events_filtered:
                     args = event["args"]
                     account = args.get("from", ZERO_ADDRESS)
@@ -402,7 +423,10 @@ class Processor:
                     fromBlock=block_from,
                     toBlock=block_to
                 )
-                events_filtered = self.remove_duplicate_event_by_token_account_desc(events, ["from", "to"])
+                events_filtered = self.remove_duplicate_event_by_token_account_desc(
+                    events=events,
+                    account_keys=["from", "to"]
+                )
                 for event in events_filtered:
                     args = event["args"]
                     for _account in [args.get("from", ZERO_ADDRESS), args.get("to", ZERO_ADDRESS)]:
@@ -752,7 +776,8 @@ class Processor:
             db_session.add(position)
 
     @staticmethod
-    def remove_duplicate_event_by_token_account_desc(events: [], account_keys: List[str]):
+    def remove_duplicate_event_by_token_account_desc(events: List,
+                                                     account_keys: List[str]) -> List:
         """Remove duplicate event from event list.
         Events that have same account key will be removed.
 
@@ -778,7 +803,7 @@ class Processor:
                 seen.add(record_tuple[1])
 
         # return events in original order
-        return reversed(remove_duplicate_list)
+        return list(reversed(remove_duplicate_list))
 
 
 def main():

--- a/batch/indexer_Position_Share.py
+++ b/batch/indexer_Position_Share.py
@@ -69,12 +69,12 @@ class Processor:
             self.__get_contract_list(local_session)
             # Synchronize 1,000,000 blocks each
             # if some blocks have already synced, sync starting from next block
-            idx_position_block_number = self.get_idx_position_block_number(db_session=local_session)
+            idx_position_block_number = self.__get_idx_position_block_number(db_session=local_session)
             latest_block = web3.eth.blockNumber
             if idx_position_block_number >= latest_block:
                 LOG.debug(
                     f"Initial Sync is skipped since current block number({web3.eth.blockNumber}) is equal to or less "
-                    f"than last synced block number({idx_position_block_number} this processor does. "
+                    f"than last synced block number({idx_position_block_number}) this processor does. "
                 )
                 pass
             else:
@@ -100,7 +100,7 @@ class Processor:
                         block_from=_from_block,
                         block_to=latest_block
                     )
-                self.set_idx_position_block_number(local_session, latest_block)
+                self.__set_idx_position_block_number(local_session, latest_block)
                 local_session.commit()
         finally:
             local_session.close()
@@ -112,11 +112,11 @@ class Processor:
             self.__get_contract_list(local_session)
             latest_block = web3.eth.blockNumber
             # if some blocks have already synced, sync starting from next block
-            idx_position_block_number = self.get_idx_position_block_number(db_session=local_session)
+            idx_position_block_number = self.__get_idx_position_block_number(db_session=local_session)
             if idx_position_block_number >= latest_block:
                 LOG.debug(
                     f"Initial Sync is skipped since current block number({latest_block}) is equal to or less "
-                    f"than last synced block number({idx_position_block_number} this processor does. "
+                    f"than last synced block number({idx_position_block_number}) this processor does. "
                 )
                 pass
             else:
@@ -126,7 +126,7 @@ class Processor:
                     block_from=_from_block,
                     block_to=latest_block
                 )
-                self.set_idx_position_block_number(local_session, latest_block)
+                self.__set_idx_position_block_number(local_session, latest_block)
                 local_session.commit()
         finally:
             local_session.close()
@@ -606,7 +606,7 @@ class Processor:
                 LOG.exception(e)
 
     @staticmethod
-    def get_idx_position_block_number(db_session: Session):
+    def __get_idx_position_block_number(db_session: Session):
         """Get position index for Coupon """
         _idx_position_block_number = db_session.query(IDXPositionShareBlockNumber).first()
         if _idx_position_block_number is None:
@@ -615,7 +615,7 @@ class Processor:
             return _idx_position_block_number.latest_block_number
 
     @staticmethod
-    def set_idx_position_block_number(db_session: Session, block_number: int):
+    def __set_idx_position_block_number(db_session: Session, block_number: int):
         """Set position index for Coupon """
         _idx_position_block_number = db_session.query(IDXPositionShareBlockNumber). \
             first()

--- a/batch/indexer_Position_Share.py
+++ b/batch/indexer_Position_Share.py
@@ -16,7 +16,7 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 """
-from typing import Optional
+from typing import Optional, List
 import os
 import sys
 import time
@@ -26,6 +26,8 @@ from eth_utils import to_checksum_address
 from sqlalchemy import create_engine
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
+
+from app.model.db.idx_position import IDXPositionShareBlockNumber
 
 path = os.path.join(os.path.dirname(__file__), "../")
 sys.path.append(path)
@@ -55,7 +57,6 @@ class Processor:
     """Processor for indexing Share balances"""
 
     def __init__(self):
-        self.latest_block = web3.eth.blockNumber
         self.token_list = []
 
     @staticmethod
@@ -67,29 +68,40 @@ class Processor:
         try:
             self.__get_contract_list(local_session)
             # Synchronize 1,000,000 blocks each
-            _to_block = 999999
-            _from_block = 0
-            if self.latest_block > 999999:
-                while _to_block < self.latest_block:
+            # if some blocks have already synced, sync starting from next block
+            idx_position_block_number = self.get_idx_position_block_number(db_session=local_session)
+            latest_block = web3.eth.blockNumber
+            if idx_position_block_number >= latest_block:
+                LOG.debug(
+                    f"Initial Sync is skipped since current block number({web3.eth.blockNumber}) is equal to or less "
+                    f"than last synced block number({idx_position_block_number} this processor does. "
+                )
+                pass
+            else:
+                _from_block = idx_position_block_number + 1
+                _to_block = 999999
+                if latest_block > 999999:
+                    while _to_block < latest_block:
+                        self.__sync_all(
+                            db_session=local_session,
+                            block_from=_from_block,
+                            block_to=_to_block
+                        )
+                        _to_block += 1000000
+                        _from_block += 1000000
                     self.__sync_all(
                         db_session=local_session,
-                        block_from=_from_block, 
-                        block_to=_to_block
+                        block_from=_from_block,
+                        block_to=latest_block
                     )
-                    _to_block += 1000000
-                    _from_block += 1000000
-                self.__sync_all(
-                    db_session=local_session,
-                    block_from=_from_block, 
-                    block_to=self.latest_block
-                )
-            else:
-                self.__sync_all(
-                    db_session=local_session,
-                    block_from=_from_block, 
-                    block_to=self.latest_block
-                )
-            local_session.commit()
+                else:
+                    self.__sync_all(
+                        db_session=local_session,
+                        block_from=_from_block,
+                        block_to=latest_block
+                    )
+                self.set_idx_position_block_number(local_session, latest_block)
+                local_session.commit()
         finally:
             local_session.close()
         LOG.info(f"<{process_name}> Initial sync has been completed")
@@ -98,16 +110,24 @@ class Processor:
         local_session = self.__get_db_session()
         try:
             self.__get_contract_list(local_session)
-            blockTo = web3.eth.blockNumber
-            if blockTo == self.latest_block:
-                return
-            self.__sync_all(
-                db_session=local_session,
-                block_from=self.latest_block + 1,
-                block_to=blockTo
-            )
-            self.latest_block = blockTo
-            local_session.commit()
+            latest_block = web3.eth.blockNumber
+            # if some blocks have already synced, sync starting from next block
+            idx_position_block_number = self.get_idx_position_block_number(db_session=local_session)
+            if idx_position_block_number >= latest_block:
+                LOG.debug(
+                    f"Initial Sync is skipped since current block number({latest_block}) is equal to or less "
+                    f"than last synced block number({idx_position_block_number} this processor does. "
+                )
+                pass
+            else:
+                _from_block = idx_position_block_number + 1
+                self.__sync_all(
+                    db_session=local_session,
+                    block_from=_from_block,
+                    block_to=latest_block
+                )
+                self.set_idx_position_block_number(local_session, latest_block)
+                local_session.commit()
         finally:
             local_session.close()
 
@@ -175,7 +195,8 @@ class Processor:
                     fromBlock=block_from,
                     toBlock=block_to
                 )
-                for event in events:
+                events_filtered = self.remove_duplicate_event_by_token_account_desc(events, ["from", "to"])
+                for event in events_filtered:
                     args = event["args"]
                     for _account in [args.get("from", ZERO_ADDRESS), args.get("to", ZERO_ADDRESS)]:
                         if web3.eth.getCode(_account).hex() == "0x":
@@ -207,7 +228,8 @@ class Processor:
                     fromBlock=block_from,
                     toBlock=block_to
                 )
-                for event in events:
+                events_filtered = self.remove_duplicate_event_by_token_account_desc(events, ["accountAddress"])
+                for event in events_filtered:
                     args = event["args"]
                     account = args.get("accountAddress", ZERO_ADDRESS)
                     balance, pending_transfer = self.__get_account_balance_token(token, account)
@@ -235,7 +257,8 @@ class Processor:
                     fromBlock=block_from,
                     toBlock=block_to
                 )
-                for event in events:
+                events_filtered = self.remove_duplicate_event_by_token_account_desc(events, ["recipientAddress"])
+                for event in events_filtered:
                     args = event["args"]
                     account = args.get("recipientAddress", ZERO_ADDRESS)
                     balance, pending_transfer = self.__get_account_balance_token(token, account)
@@ -263,7 +286,8 @@ class Processor:
                     fromBlock=block_from,
                     toBlock=block_to
                 )
-                for event in events:
+                events_filtered = self.remove_duplicate_event_by_token_account_desc(events, ["targetAddress"])
+                for event in events_filtered:
                     args = event["args"]
                     account = args.get("targetAddress", ZERO_ADDRESS)
                     balance, pending_transfer = self.__get_account_balance_token(token, account)
@@ -291,7 +315,8 @@ class Processor:
                     fromBlock=block_from,
                     toBlock=block_to
                 )
-                for event in events:
+                events_filtered = self.remove_duplicate_event_by_token_account_desc(events, ["targetAddress"])
+                for event in events_filtered:
                     args = event["args"]
                     account = args.get("targetAddress", ZERO_ADDRESS)
                     balance, pending_transfer = self.__get_account_balance_token(token, account)
@@ -319,7 +344,8 @@ class Processor:
                     fromBlock=block_from,
                     toBlock=block_to
                 )
-                for event in events:
+                events_filtered = self.remove_duplicate_event_by_token_account_desc(events, ["from"])
+                for event in events_filtered:
                     args = event["args"]
                     account = args.get("from", ZERO_ADDRESS)
                     balance, pending_transfer = self.__get_account_balance_token(token, account)
@@ -347,7 +373,8 @@ class Processor:
                     fromBlock=block_from,
                     toBlock=block_to
                 )
-                for event in events:
+                events_filtered = self.remove_duplicate_event_by_token_account_desc(events, ["from"])
+                for event in events_filtered:
                     args = event["args"]
                     account = args.get("from", ZERO_ADDRESS)
                     balance, pending_transfer = self.__get_account_balance_token(token, account)
@@ -375,7 +402,8 @@ class Processor:
                     fromBlock=block_from,
                     toBlock=block_to
                 )
-                for event in events:
+                events_filtered = self.remove_duplicate_event_by_token_account_desc(events, ["from", "to"])
+                for event in events_filtered:
                     args = event["args"]
                     for _account in [args.get("from", ZERO_ADDRESS), args.get("to", ZERO_ADDRESS)]:
                         _balance, _pending_transfer = self.__get_account_balance_token(token, _account)
@@ -578,6 +606,25 @@ class Processor:
                 LOG.exception(e)
 
     @staticmethod
+    def get_idx_position_block_number(db_session: Session):
+        """Get position index for Coupon """
+        _idx_position_block_number = db_session.query(IDXPositionShareBlockNumber).first()
+        if _idx_position_block_number is None:
+            return -1
+        else:
+            return _idx_position_block_number.latest_block_number
+
+    @staticmethod
+    def set_idx_position_block_number(db_session: Session, block_number: int):
+        """Set position index for Coupon """
+        _idx_position_block_number = db_session.query(IDXPositionShareBlockNumber). \
+            first()
+        if _idx_position_block_number is None:
+            _idx_position_block_number = IDXPositionShareBlockNumber()
+        _idx_position_block_number.latest_block_number = block_number
+        db_session.merge(_idx_position_block_number)
+
+    @staticmethod
     def __get_account_balance_all(token_contract, account_address: str):
         """Get balance"""
         balance = Contract.call_function(
@@ -703,6 +750,35 @@ class Processor:
             position.exchange_balance = exchange_balance or 0
             position.exchange_commitment = exchange_commitment or 0
             db_session.add(position)
+
+    @staticmethod
+    def remove_duplicate_event_by_token_account_desc(events: [], account_keys: List[str]):
+        """Remove duplicate event from event list.
+        Events that have same account key will be removed.
+
+        :param events: event list
+        :param account_keys: keys in which event contains account address
+        :return: events: event list filtered
+        """
+        event_token_account_list = []
+
+        # reversed events loop for removing duplicates from the front
+        for event in reversed(events):
+            args = event["args"]
+            for arg_key in account_keys:
+                account_address = args.get(arg_key, ZERO_ADDRESS)
+                if account_address != ZERO_ADDRESS:
+                    event_token_account_list.append([event, account_address])
+        seen = set()
+        remove_duplicate_list = []
+        for record in event_token_account_list:
+            record_tuple = tuple(record)
+            if record_tuple[1] not in seen:
+                remove_duplicate_list.append(record[0])
+                seen.add(record_tuple[1])
+
+        # return events in original order
+        return reversed(remove_duplicate_list)
 
 
 def main():

--- a/batch/indexer_Position_Share.py
+++ b/batch/indexer_Position_Share.py
@@ -74,13 +74,13 @@ class Processor:
             if idx_position_block_number >= latest_block:
                 LOG.debug(
                     f"Initial Sync is skipped since current block number({web3.eth.blockNumber}) is equal to or less "
-                    f"than last synced block number({idx_position_block_number}) this processor does. "
+                    f"than last synced block number({idx_position_block_number}) this processor did."
                 )
                 pass
             else:
                 _from_block = idx_position_block_number + 1
-                _to_block = 999999
-                if latest_block > 999999:
+                _to_block = 999999 + _from_block
+                if latest_block > _to_block:
                     while _to_block < latest_block:
                         self.__sync_all(
                             db_session=local_session,
@@ -116,7 +116,7 @@ class Processor:
             if idx_position_block_number >= latest_block:
                 LOG.debug(
                     f"Initial Sync is skipped since current block number({latest_block}) is equal to or less "
-                    f"than last synced block number({idx_position_block_number}) this processor does. "
+                    f"than last synced block number({idx_position_block_number}) this processor did."
                 )
                 pass
             else:

--- a/tests/batch/indexer_Position_Bond_test.py
+++ b/tests/batch/indexer_Position_Bond_test.py
@@ -147,12 +147,14 @@ class TestProcessor:
             self.issuer, {"address": self.trader["account_address"]}, token, 10000)
 
         # Run target process
+        block_number = web3.eth.blockNumber
         processor.sync_new_logs()
 
         # Assertion
         _position_list = session.query(
             IDXPosition).order_by(IDXPosition.created).all()
         assert len(_position_list) == 2
+        _idx_position_bond_block_number = session.query(IDXPositionBondBlockNumber).first()
         _position = _position_list[0]
         assert _position.id == 1
         assert _position.token_address == token["address"]
@@ -169,6 +171,7 @@ class TestProcessor:
         assert _position.pending_transfer == 0
         assert _position.exchange_balance == 0
         assert _position.exchange_commitment == 0
+        assert _idx_position_bond_block_number.latest_block_number == block_number
 
     # <Normal_2>
     # Single Token
@@ -193,12 +196,14 @@ class TestProcessor:
             self.issuer, {"address": self.trader["account_address"]}, token, 3000)
 
         # Run target process
+        block_number = web3.eth.blockNumber
         processor.sync_new_logs()
 
         # Assertion
         _position_list = session.query(
             IDXPosition).order_by(IDXPosition.created).all()
         assert len(_position_list) == 2
+        _idx_position_bond_block_number = session.query(IDXPositionBondBlockNumber).first()
         _position: IDXPosition = _position_list[0]
         assert _position.id == 1
         assert _position.token_address == token["address"]
@@ -215,6 +220,7 @@ class TestProcessor:
         assert _position.pending_transfer == 0
         assert _position.exchange_balance == 0
         assert _position.exchange_commitment == 0
+        assert _idx_position_bond_block_number.latest_block_number == block_number
 
     # <Normal_3>
     # Multi Token
@@ -248,12 +254,14 @@ class TestProcessor:
             self.issuer, {"address": self.trader2["account_address"]}, token2, 3000)
 
         # Run target process
+        block_number = web3.eth.blockNumber
         processor.sync_new_logs()
 
         # Assertion
         _position_list = session.query(
             IDXPosition).order_by(IDXPosition.created).all()
         assert len(_position_list) == 6
+        _idx_position_bond_block_number = session.query(IDXPositionBondBlockNumber).first()
         _position = _position_list[0]
         assert _position.id == 1
         assert _position.token_address == token["address"]
@@ -302,6 +310,7 @@ class TestProcessor:
         assert _position.pending_transfer == 0
         assert _position.exchange_balance == 0
         assert _position.exchange_commitment == 0
+        assert _idx_position_bond_block_number.latest_block_number == block_number
 
     # <Normal_4>
     # Single Token
@@ -333,12 +342,14 @@ class TestProcessor:
         web3.eth.waitForTransactionReceipt(tx_hash)
 
         # Run target process
+        block_number = web3.eth.blockNumber
         processor.sync_new_logs()
 
         # Assertion
         _position_list = session.query(
             IDXPosition).order_by(IDXPosition.created).all()
         assert len(_position_list) == 1
+        _idx_position_bond_block_number = session.query(IDXPositionBondBlockNumber).first()
         _position = _position_list[0]
         assert _position.id == 1
         assert _position.token_address == token["address"]
@@ -347,6 +358,7 @@ class TestProcessor:
         assert _position.pending_transfer == 0
         assert _position.exchange_balance == 0
         assert _position.exchange_commitment == 0
+        assert _idx_position_bond_block_number.latest_block_number == block_number
 
     # <Normal_5>
     # Single Token
@@ -386,12 +398,14 @@ class TestProcessor:
         web3.eth.waitForTransactionReceipt(tx_hash)
 
         # Run target process
+        block_number = web3.eth.blockNumber
         processor.sync_new_logs()
 
         # Assertion
         _position_list = session.query(
             IDXPosition).order_by(IDXPosition.created).all()
         assert len(_position_list) == 2
+        _idx_position_bond_block_number = session.query(IDXPositionBondBlockNumber).first()
         _position = _position_list[0]
         assert _position.id == 1
         assert _position.token_address == token["address"]
@@ -408,6 +422,7 @@ class TestProcessor:
         assert _position.pending_transfer == 0
         assert _position.exchange_balance == 0
         assert _position.exchange_commitment == 0
+        assert _idx_position_bond_block_number.latest_block_number == block_number
 
     # <Normal_6>
     # Single Token
@@ -431,12 +446,14 @@ class TestProcessor:
         web3.eth.waitForTransactionReceipt(tx_hash)
 
         # Run target process
+        block_number = web3.eth.blockNumber
         processor.sync_new_logs()
 
         # Assertion
         _position_list = session.query(
             IDXPosition).order_by(IDXPosition.created).all()
         assert len(_position_list) == 1
+        _idx_position_bond_block_number = session.query(IDXPositionBondBlockNumber).first()
         _position = _position_list[0]
         assert _position.id == 1
         assert _position.token_address == token["address"]
@@ -445,6 +462,7 @@ class TestProcessor:
         assert _position.pending_transfer == 0
         assert _position.exchange_balance == 0
         assert _position.exchange_commitment == 0
+        assert _idx_position_bond_block_number.latest_block_number == block_number
 
     # <Normal_7>
     # Single Token
@@ -472,12 +490,14 @@ class TestProcessor:
         web3.eth.waitForTransactionReceipt(tx_hash)
 
         # Run target process
+        block_number = web3.eth.blockNumber
         processor.sync_new_logs()
 
         # Assertion
         _position_list = session.query(
             IDXPosition).order_by(IDXPosition.created).all()
         assert len(_position_list) == 1
+        _idx_position_bond_block_number = session.query(IDXPositionBondBlockNumber).first()
         _position = _position_list[0]
         assert _position.id == 1
         assert _position.token_address == token["address"]
@@ -486,6 +506,7 @@ class TestProcessor:
         assert _position.pending_transfer == 0
         assert _position.exchange_balance == 0
         assert _position.exchange_commitment == 0
+        assert _idx_position_bond_block_number.latest_block_number == block_number
 
     # <Normal_8>
     # Single Token
@@ -545,12 +566,14 @@ class TestProcessor:
         web3.eth.waitForTransactionReceipt(tx_hash)
 
         # Run target process
+        block_number = web3.eth.blockNumber
         processor.sync_new_logs()
 
         # Assertion
         _position_list = session.query(
             IDXPosition).order_by(IDXPosition.created).all()
         assert len(_position_list) == 2
+        _idx_position_bond_block_number = session.query(IDXPositionBondBlockNumber).first()
         _position = _position_list[0]
         assert _position.id == 1
         assert _position.token_address == token["address"]
@@ -567,6 +590,7 @@ class TestProcessor:
         assert _position.pending_transfer == 2000
         assert _position.exchange_balance == 0
         assert _position.exchange_commitment == 0
+        assert _idx_position_bond_block_number.latest_block_number == block_number
 
     # <Normal_9>
     # Single Token
@@ -637,12 +661,14 @@ class TestProcessor:
         web3.eth.waitForTransactionReceipt(tx_hash)
 
         # Run target process
+        block_number = web3.eth.blockNumber
         processor.sync_new_logs()
 
         # Assertion
         _position_list = session.query(
             IDXPosition).order_by(IDXPosition.created).all()
         assert len(_position_list) == 3
+        _idx_position_bond_block_number = session.query(IDXPositionBondBlockNumber).first()
         _position = _position_list[0]
         assert _position.id == 1
         assert _position.token_address == token["address"]
@@ -667,6 +693,7 @@ class TestProcessor:
         assert _position.pending_transfer == 0
         assert _position.exchange_balance == 0
         assert _position.exchange_commitment == 0
+        assert _idx_position_bond_block_number.latest_block_number == block_number
 
     # <Normal_10>
     # Single Token
@@ -739,12 +766,14 @@ class TestProcessor:
         web3.eth.waitForTransactionReceipt(tx_hash)
 
         # Run target process
+        block_number = web3.eth.blockNumber
         processor.sync_new_logs()
 
         # Assertion
         _position_list = session.query(
             IDXPosition).order_by(IDXPosition.created).all()
         assert len(_position_list) == 2
+        _idx_position_bond_block_number = session.query(IDXPositionBondBlockNumber).first()
         _position = _position_list[0]
         assert _position.id == 1
         assert _position.token_address == token["address"]
@@ -761,6 +790,7 @@ class TestProcessor:
         assert _position.pending_transfer == 0
         assert _position.exchange_balance == 0
         assert _position.exchange_commitment == 0
+        assert _idx_position_bond_block_number.latest_block_number == block_number
 
     # <Normal_11>
     # Single Token
@@ -791,12 +821,14 @@ class TestProcessor:
                                      token, self.trader["account_address"], self.issuer["account_address"], 300)
 
         # Run target process
+        block_number = web3.eth.blockNumber
         processor.sync_new_logs()
 
         # Assertion
         _position_list = session.query(
             IDXPosition).order_by(IDXPosition.created).all()
         assert len(_position_list) == 2
+        _idx_position_bond_block_number = session.query(IDXPositionBondBlockNumber).first()
         _position: IDXPosition = _position_list[0]
         assert _position.id == 1
         assert _position.token_address == token["address"]
@@ -813,6 +845,7 @@ class TestProcessor:
         assert _position.pending_transfer == 0
         assert _position.exchange_balance == 200
         assert _position.exchange_commitment == 0
+        assert _idx_position_bond_block_number.latest_block_number == block_number
 
     # <Normal_12>
     # Single Token
@@ -842,12 +875,14 @@ class TestProcessor:
         make_sell(self.issuer, exchange_contract, token, 333, 1000)
 
         # Run target process
+        block_number = web3.eth.blockNumber
         processor.sync_new_logs()
 
         # Assertion
         _position_list = session.query(
             IDXPosition).order_by(IDXPosition.created).all()
         assert len(_position_list) == 1
+        _idx_position_bond_block_number = session.query(IDXPositionBondBlockNumber).first()
         _position: IDXPosition = _position_list[0]
         assert _position.id == 1
         assert _position.token_address == token["address"]
@@ -856,6 +891,7 @@ class TestProcessor:
         assert _position.pending_transfer == 0
         assert _position.exchange_balance == 10000 - 111 - 222 - 333
         assert _position.exchange_commitment == 333
+        assert _idx_position_bond_block_number.latest_block_number == block_number
 
     # <Normal_13>
     # Single Token
@@ -888,12 +924,14 @@ class TestProcessor:
         take_sell(self.issuer, exchange_contract, get_latest_orderid(exchange_contract), 66)
 
         # Run target process
+        block_number = web3.eth.blockNumber
         processor.sync_new_logs()
 
         # Assertion
         _position_list = session.query(
             IDXPosition).order_by(IDXPosition.created).all()
         assert len(_position_list) == 1
+        _idx_position_bond_block_number = session.query(IDXPositionBondBlockNumber).first()
         _position: IDXPosition = _position_list[0]
         assert _position.id == 1
         assert _position.token_address == token["address"]
@@ -902,6 +940,7 @@ class TestProcessor:
         assert _position.pending_transfer == 0
         assert _position.exchange_balance == 10000 - 55 - 66
         assert _position.exchange_commitment == 66
+        assert _idx_position_bond_block_number.latest_block_number == block_number
 
     # <Normal_14>
     # No event logs
@@ -915,12 +954,15 @@ class TestProcessor:
 
         # Not Event
         # Run target process
+        block_number = web3.eth.blockNumber
         processor.sync_new_logs()
 
         # Assertion
         _position_list = session.query(
             IDXPosition).order_by(IDXPosition.created).all()
         assert len(_position_list) == 0
+        _idx_position_bond_block_number = session.query(IDXPositionBondBlockNumber).first()
+        assert _idx_position_bond_block_number.latest_block_number == block_number
 
     # <Normal_15>
     # Not Listing Token
@@ -939,12 +981,15 @@ class TestProcessor:
             self.issuer, {"address": self.trader["account_address"]}, token, 10000)
 
         # Run target process
+        block_number = web3.eth.blockNumber
         processor.sync_new_logs()
 
         # Assertion
         _position_list = session.query(
             IDXPosition).order_by(IDXPosition.created).all()
         assert len(_position_list) == 0
+        _idx_position_bond_block_number = session.query(IDXPositionBondBlockNumber).first()
+        assert _idx_position_bond_block_number.latest_block_number == block_number
 
     # <Normal_16>
     # Single Token
@@ -976,92 +1021,6 @@ class TestProcessor:
         assert len(events) == 5
         filtered_events = list(processor.remove_duplicate_event_by_token_account_desc(events, ["from", "to"]))
         assert len(filtered_events) == 2
-
-    # <Normal_17>
-    # Single Token
-    # Multi event logs
-    # - Transfer
-    # Last event log block number to be stored in block number processor
-    def test_normal_17(self, processor, shared_contract, session):
-        token_list_contract = shared_contract["TokenList"]
-        escrow_contract = shared_contract["IbetSecurityTokenEscrow"]
-        personal_info_contract = shared_contract["PersonalInfo"]
-
-        token = self.issue_token_bond(
-            self.issuer, escrow_contract.address, personal_info_contract["address"], token_list_contract)
-        self.listing_token(token["address"], session)
-
-        PersonalInfoUtils.register(
-            self.trader["account_address"], personal_info_contract["address"], self.issuer["account_address"])
-        for i in range(0, 5):
-            # Transfer
-            bond_transfer_to_exchange(
-                self.issuer, {"address": self.trader["account_address"]}, token, 1000)
-
-        # Run target process
-        processor.sync_new_logs()
-
-        # Get events for token address
-        events = Contract.get_contract('IbetStraightBond', token["address"]).events.Transfer.getLogs(
-                    fromBlock=0,
-                    toBlock=10000
-                )
-        idx_position_block_number = processor.get_idx_position_block_number(session)
-
-        # Ensure last block number is properly stored in db
-        assert events[-1]['blockNumber'] == idx_position_block_number
-
-    # <Normal_18>
-    # Single Token
-    # Multi event logs
-    # - Transfer
-    # Expect that "sync new log" process starts from the latest block index.
-    def test_normal_18(self, processor, shared_contract, session):
-        token_list_contract = shared_contract["TokenList"]
-        escrow_contract = shared_contract["IbetSecurityTokenEscrow"]
-        personal_info_contract = shared_contract["PersonalInfo"]
-
-        token = self.issue_token_bond(
-            self.issuer, escrow_contract.address, personal_info_contract["address"], token_list_contract)
-        self.listing_token(token["address"], session)
-
-        PersonalInfoUtils.register(
-            self.trader["account_address"], personal_info_contract["address"], self.issuer["account_address"])
-        for i in range(0, 5):
-            # Transfer
-            bond_transfer_to_exchange(
-                self.issuer, {"address": self.trader["account_address"]}, token, 1000)
-
-        # Set index position
-        processor.set_idx_position_block_number(session, 10000)
-        session.commit()
-
-        latest_block_bf = processor.get_idx_position_block_number(session)
-        # Stored index is higher than current block number, so init sync is skipped.
-        processor.initial_sync()
-
-        # Run target process
-        processor.sync_new_logs()
-        latest_block_af = processor.get_idx_position_block_number(session)
-
-        # Expect that processor doesn't sync any blocks.
-        assert latest_block_bf == latest_block_af == 10000
-
-        processor.set_idx_position_block_number(session, -1)
-        session.commit()
-        assert processor.get_idx_position_block_number(session) == -1
-
-        # Run target process
-        processor.sync_new_logs()
-        # Get events for token address
-        events = Contract.get_contract('IbetStraightBond', token["address"]).events.Transfer.getLogs(
-                    fromBlock=0,
-                    toBlock=10000
-                )
-        idx_position_block_number = processor.get_idx_position_block_number(session)
-
-        # Ensure last block number is properly stored in db
-        assert events[-1]['blockNumber'] == idx_position_block_number
 
     ###########################################################################
     # Error Case

--- a/tests/batch/indexer_Position_Bond_test.py
+++ b/tests/batch/indexer_Position_Bond_test.py
@@ -31,6 +31,7 @@ from app.model.db import (
 )
 from app.model.db.idx_position import IDXPositionBondBlockNumber
 from batch import indexer_Position_Bond
+from batch.indexer_Position_Bond import Processor
 from tests.account_config import eth_account
 from tests.contract_modules import (
     cancel_agreement,
@@ -1021,6 +1022,28 @@ class TestProcessor:
         assert len(events) == 5
         filtered_events = list(processor.remove_duplicate_event_by_token_account_desc(events, ["from", "to"]))
         assert len(filtered_events) == 2
+
+    # <Normal_17>
+    # When stored index is 9,999,999 and current block number is 19,999,999,
+    # then processor must process "__sync_all" method 10 times.
+    def test_normal_17(self, processor, shared_contract, session):
+        current_block_number = 20000000 - 1
+        latest_block_number = 10000000 - 1
+
+        mock_lib = MagicMock()
+        # Setting current block number to 19,999,999
+        with mock.patch("web3.eth.Eth.blockNumber", current_block_number):
+            with mock.patch.object(Processor, "_Processor__sync_all", return_value=mock_lib) as __sync_all_mock:
+                idx_position_bond_block_number = IDXPositionBondBlockNumber()
+                idx_position_bond_block_number.id = 1
+                # Setting stored index to 9,999,999
+                idx_position_bond_block_number.latest_block_number = latest_block_number
+                session.merge(idx_position_bond_block_number)
+                session.commit()
+                __sync_all_mock.return_value = None
+                processor.initial_sync()
+                # Then processor call "__sync_all" method 10 times.
+                assert __sync_all_mock.call_count == 10
 
     ###########################################################################
     # Error Case

--- a/tests/batch/indexer_Position_Bond_test.py
+++ b/tests/batch/indexer_Position_Bond_test.py
@@ -1020,7 +1020,7 @@ class TestProcessor:
                 )
         # Ensure 5 events squashed to 2 events
         assert len(events) == 5
-        filtered_events = list(processor.remove_duplicate_event_by_token_account_desc(events, ["from", "to"]))
+        filtered_events = processor.remove_duplicate_event_by_token_account_desc(events, ["from", "to"])
         assert len(filtered_events) == 2
 
     # <Normal_17>

--- a/tests/batch/indexer_Position_Coupon_test.py
+++ b/tests/batch/indexer_Position_Coupon_test.py
@@ -24,6 +24,7 @@ from web3 import Web3
 from web3.middleware import geth_poa_middleware
 
 from app import config
+from app.contracts import Contract
 from app.model.db import (
     IDXPosition,
     Listing
@@ -411,6 +412,106 @@ class TestProcessor:
         # Assertion
         _position_list = session.query(IDXPosition).order_by(IDXPosition.created).all()
         assert len(_position_list) == 0
+
+    # <Normal_9>
+    # Single Token
+    # Multi event logs
+    # - Transfer
+    # Duplicate events to be removed
+    def test_normal_9(self, processor, shared_contract, session):
+        # Issue Token
+        token_list_contract = shared_contract["TokenList"]
+        token = self.issue_token_coupon(self.issuer, config.ZERO_ADDRESS, token_list_contract)
+        self.listing_token(token["address"], session)
+        for i in range(0, 5):
+            # Transfer
+            transfer_coupon_token(self.issuer, token, self.trader["account_address"], 10000)
+
+        # Get events for token address
+        events = Contract.get_contract('IbetCoupon', token["address"]).events.Transfer.getLogs(
+                    fromBlock=0,
+                    toBlock=10000
+                )
+        # Ensure 5 events squashed to 2 events
+        assert len(events) == 5
+        filtered_events = list(processor.remove_duplicate_event_by_token_account_desc(events, ["from", "to"]))
+        assert len(filtered_events) == 2
+
+    # <Normal_10>
+    # Single Token
+    # Multi event logs
+    # - Transfer
+    # Last event log block number to be stored in block number processor
+    def test_normal_10(self, processor, shared_contract, session):
+        # Issue Token
+        token_list_contract = shared_contract["TokenList"]
+        token = self.issue_token_coupon(self.issuer, config.ZERO_ADDRESS, token_list_contract)
+        self.listing_token(token["address"], session)
+        for i in range(0, 5):
+            # Transfer
+            transfer_coupon_token(self.issuer, token, self.trader["account_address"], 10000)
+
+        # Run target process
+        processor.sync_new_logs()
+
+        # Get events for token address
+        events = Contract.get_contract('IbetCoupon', token["address"]).events.Transfer.getLogs(
+                    fromBlock=0,
+                    toBlock=10000
+                )
+
+        idx_position_block_number = processor.get_idx_position_block_number(session)
+
+        # Ensure last block number is properly stored in db
+        assert events[-1]['blockNumber'] == idx_position_block_number
+
+    # <Normal_11>
+    # Single Token
+    # Multi event logs
+    # - Transfer
+    # Expect that "sync new log" process starts from the latest block index.
+    def test_normal_11(self, processor, shared_contract, session):
+        # Issue Token
+        token_list_contract = shared_contract["TokenList"]
+
+        token = self.issue_token_coupon(self.issuer, config.ZERO_ADDRESS, token_list_contract)
+
+        self.listing_token(token["address"], session)
+        for i in range(0, 5):
+            # Transfer
+            coupon_transfer_to_exchange(
+                self.issuer, {"address": self.trader["account_address"]}, token, 1000)
+
+        # Set index position
+        processor.set_idx_position_block_number(session, 10000)
+        session.commit()
+
+        latest_block_bf = processor.get_idx_position_block_number(session)
+        # Stored index is higher than current block number, so init sync is skipped.
+        processor.initial_sync()
+
+        # Run target process
+        processor.sync_new_logs()
+        latest_block_af = processor.get_idx_position_block_number(session)
+
+        # Expect that processor doesn't sync any blocks.
+        assert latest_block_bf == latest_block_af == 10000
+
+        processor.set_idx_position_block_number(session, -1)
+        session.commit()
+        assert processor.get_idx_position_block_number(session) == -1
+
+        # Run target process
+        processor.sync_new_logs()
+        # Get events for token address
+        events = Contract.get_contract('IbetCoupon', token["address"]).events.Transfer.getLogs(
+                    fromBlock=0,
+                    toBlock=10000
+                )
+        idx_position_block_number = processor.get_idx_position_block_number(session)
+
+        # Ensure last block number is properly stored in db
+        assert events[-1]['blockNumber'] == idx_position_block_number
 
     ###########################################################################
     # Error Case

--- a/tests/batch/indexer_Position_Coupon_test.py
+++ b/tests/batch/indexer_Position_Coupon_test.py
@@ -460,7 +460,7 @@ class TestProcessor:
                 )
         # Ensure 5 events squashed to 2 events
         assert len(events) == 5
-        filtered_events = list(processor.remove_duplicate_event_by_token_account_desc(events, ["from", "to"]))
+        filtered_events = processor.remove_duplicate_event_by_token_account_desc(events, ["from", "to"])
         assert len(filtered_events) == 2
 
     # <Normal_10>

--- a/tests/batch/indexer_Position_Coupon_test.py
+++ b/tests/batch/indexer_Position_Coupon_test.py
@@ -29,6 +29,7 @@ from app.model.db import (
     IDXPosition,
     Listing
 )
+from app.model.db.idx_position import IDXPositionCouponBlockNumber
 from batch import indexer_Position_Coupon
 from tests.account_config import eth_account
 from tests.contract_modules import (
@@ -119,11 +120,13 @@ class TestProcessor:
         transfer_coupon_token(self.issuer, token, self.trader["account_address"], 10000)
 
         # Run target process
+        block_number = web3.eth.blockNumber
         processor.sync_new_logs()
 
         # Assertion
         _position_list = session.query(IDXPosition).order_by(IDXPosition.created).all()
         assert len(_position_list) == 2
+        _idx_position_coupon_block_number = session.query(IDXPositionCouponBlockNumber).first()
         _position = _position_list[0]
         assert _position.id == 1
         assert _position.token_address == token["address"]
@@ -136,6 +139,7 @@ class TestProcessor:
         assert _position.account_address == self.trader["account_address"]
         assert _position.balance == 10000
         assert _position.pending_transfer is None
+        assert _idx_position_coupon_block_number.latest_block_number == block_number
 
     # <Normal_2>
     # Single Token
@@ -152,11 +156,13 @@ class TestProcessor:
         transfer_coupon_token(self.issuer, token, self.trader2["account_address"], 3000)
 
         # Run target process
+        block_number = web3.eth.blockNumber
         processor.sync_new_logs()
 
         # Assertion
         _position_list = session.query(IDXPosition).order_by(IDXPosition.created).all()
         assert len(_position_list) == 3
+        _idx_position_coupon_block_number = session.query(IDXPositionCouponBlockNumber).first()
         _position: IDXPosition = _position_list[0]
         assert _position.id == 1
         assert _position.token_address == token["address"]
@@ -181,6 +187,7 @@ class TestProcessor:
         assert _position.pending_transfer is None
         assert _position.exchange_balance == 0
         assert _position.exchange_commitment == 0
+        assert _idx_position_coupon_block_number.latest_block_number == block_number
 
     # <Normal_3>
     # Multi Token
@@ -201,11 +208,13 @@ class TestProcessor:
         transfer_coupon_token(self.issuer, token2, self.trader2["account_address"], 3000)
 
         # Run target process
+        block_number = web3.eth.blockNumber
         processor.sync_new_logs()
 
         # Assertion
         _position_list = session.query(IDXPosition).order_by(IDXPosition.created).all()
         assert len(_position_list) == 6
+        _idx_position_coupon_block_number = session.query(IDXPositionCouponBlockNumber).first()
         _position = _position_list[0]
         assert _position.id == 1
         assert _position.token_address == token["address"]
@@ -254,6 +263,7 @@ class TestProcessor:
         assert _position.pending_transfer is None
         assert _position.exchange_balance == 0
         assert _position.exchange_commitment == 0
+        assert _idx_position_coupon_block_number.latest_block_number == block_number
 
     # <Normal_4>
     # Single Token
@@ -273,11 +283,13 @@ class TestProcessor:
         consume_coupon_token(self.issuer, token, 3000)
 
         # Run target process
+        block_number = web3.eth.blockNumber
         processor.sync_new_logs()
 
         # Assertion
         _position_list = session.query(IDXPosition).order_by(IDXPosition.created).all()
         assert len(_position_list) == 2
+        _idx_position_coupon_block_number = session.query(IDXPositionCouponBlockNumber).first()
         _position = _position_list[0]
         assert _position.id == 1
         assert _position.token_address == token["address"]
@@ -294,6 +306,7 @@ class TestProcessor:
         assert _position.pending_transfer is None
         assert _position.exchange_balance == 0
         assert _position.exchange_commitment == 0
+        assert _idx_position_coupon_block_number.latest_block_number == block_number
 
     # <Normal_5>
     # Single Token
@@ -318,12 +331,14 @@ class TestProcessor:
         make_sell(self.issuer, coupon_exchange, token, 333, 1000)
 
         # Run target process
+        block_number = web3.eth.blockNumber
         processor.sync_new_logs()
 
         # Assertion
         _position_list = session.query(
             IDXPosition).order_by(IDXPosition.created).all()
         assert len(_position_list) == 1
+        _idx_position_coupon_block_number = session.query(IDXPositionCouponBlockNumber).first()
         _position: IDXPosition = _position_list[0]
         assert _position.id == 1
         assert _position.token_address == token["address"]
@@ -332,6 +347,7 @@ class TestProcessor:
         assert _position.pending_transfer is None
         assert _position.exchange_balance == 10000 - 111 - 222 - 333
         assert _position.exchange_commitment == 333
+        assert _idx_position_coupon_block_number.latest_block_number == block_number
 
     # <Normal_6>
     # Single Token
@@ -357,12 +373,14 @@ class TestProcessor:
                                      token, self.trader["account_address"], self.issuer["account_address"], 300)
 
         # Run target process
+        block_number = web3.eth.blockNumber
         processor.sync_new_logs()
 
         # Assertion
         _position_list = session.query(
             IDXPosition).order_by(IDXPosition.created).all()
         assert len(_position_list) == 2
+        _idx_position_coupon_block_number = session.query(IDXPositionCouponBlockNumber).first()
         _position: IDXPosition = _position_list[0]
         assert _position.id == 1
         assert _position.token_address == token["address"]
@@ -379,6 +397,7 @@ class TestProcessor:
         assert _position.pending_transfer is None
         assert _position.exchange_balance == 200
         assert _position.exchange_commitment == 0
+        assert _idx_position_coupon_block_number.latest_block_number == block_number
 
     # <Normal_7>
     # No event logs
@@ -390,11 +409,14 @@ class TestProcessor:
 
         # Not Event
         # Run target process
+        block_number = web3.eth.blockNumber
         processor.sync_new_logs()
 
         # Assertion
         _position_list = session.query(IDXPosition).order_by(IDXPosition.created).all()
         assert len(_position_list) == 0
+        _idx_position_coupon_block_number = session.query(IDXPositionCouponBlockNumber).first()
+        assert _idx_position_coupon_block_number.latest_block_number == block_number
 
     # <Normal_8>
     # Not Listing Token
@@ -407,11 +429,14 @@ class TestProcessor:
         membership_transfer_to_exchange(self.issuer, {"address": self.trader["account_address"]}, token, 10000)
 
         # Run target process
+        block_number = web3.eth.blockNumber
         processor.sync_new_logs()
 
         # Assertion
         _position_list = session.query(IDXPosition).order_by(IDXPosition.created).all()
         assert len(_position_list) == 0
+        _idx_position_coupon_block_number = session.query(IDXPositionCouponBlockNumber).first()
+        assert _idx_position_coupon_block_number.latest_block_number == block_number
 
     # <Normal_9>
     # Single Token
@@ -436,82 +461,6 @@ class TestProcessor:
         assert len(events) == 5
         filtered_events = list(processor.remove_duplicate_event_by_token_account_desc(events, ["from", "to"]))
         assert len(filtered_events) == 2
-
-    # <Normal_10>
-    # Single Token
-    # Multi event logs
-    # - Transfer
-    # Last event log block number to be stored in block number processor
-    def test_normal_10(self, processor, shared_contract, session):
-        # Issue Token
-        token_list_contract = shared_contract["TokenList"]
-        token = self.issue_token_coupon(self.issuer, config.ZERO_ADDRESS, token_list_contract)
-        self.listing_token(token["address"], session)
-        for i in range(0, 5):
-            # Transfer
-            transfer_coupon_token(self.issuer, token, self.trader["account_address"], 10000)
-
-        # Run target process
-        processor.sync_new_logs()
-
-        # Get events for token address
-        events = Contract.get_contract('IbetCoupon', token["address"]).events.Transfer.getLogs(
-                    fromBlock=0,
-                    toBlock=10000
-                )
-
-        idx_position_block_number = processor.get_idx_position_block_number(session)
-
-        # Ensure last block number is properly stored in db
-        assert events[-1]['blockNumber'] == idx_position_block_number
-
-    # <Normal_11>
-    # Single Token
-    # Multi event logs
-    # - Transfer
-    # Expect that "sync new log" process starts from the latest block index.
-    def test_normal_11(self, processor, shared_contract, session):
-        # Issue Token
-        token_list_contract = shared_contract["TokenList"]
-
-        token = self.issue_token_coupon(self.issuer, config.ZERO_ADDRESS, token_list_contract)
-
-        self.listing_token(token["address"], session)
-        for i in range(0, 5):
-            # Transfer
-            coupon_transfer_to_exchange(
-                self.issuer, {"address": self.trader["account_address"]}, token, 1000)
-
-        # Set index position
-        processor.set_idx_position_block_number(session, 10000)
-        session.commit()
-
-        latest_block_bf = processor.get_idx_position_block_number(session)
-        # Stored index is higher than current block number, so init sync is skipped.
-        processor.initial_sync()
-
-        # Run target process
-        processor.sync_new_logs()
-        latest_block_af = processor.get_idx_position_block_number(session)
-
-        # Expect that processor doesn't sync any blocks.
-        assert latest_block_bf == latest_block_af == 10000
-
-        processor.set_idx_position_block_number(session, -1)
-        session.commit()
-        assert processor.get_idx_position_block_number(session) == -1
-
-        # Run target process
-        processor.sync_new_logs()
-        # Get events for token address
-        events = Contract.get_contract('IbetCoupon', token["address"]).events.Transfer.getLogs(
-                    fromBlock=0,
-                    toBlock=10000
-                )
-        idx_position_block_number = processor.get_idx_position_block_number(session)
-
-        # Ensure last block number is properly stored in db
-        assert events[-1]['blockNumber'] == idx_position_block_number
 
     ###########################################################################
     # Error Case

--- a/tests/batch/indexer_Position_Membership_test.py
+++ b/tests/batch/indexer_Position_Membership_test.py
@@ -418,7 +418,7 @@ class TestProcessor:
                 )
         # Ensure 5 events squashed to 2 events
         assert len(events) == 5
-        filtered_events = list(processor.remove_duplicate_event_by_token_account_desc(events, ["from", "to"]))
+        filtered_events = processor.remove_duplicate_event_by_token_account_desc(events, ["from", "to"])
         assert len(filtered_events) == 2
 
     # <Normal_9>

--- a/tests/batch/indexer_Position_Membership_test.py
+++ b/tests/batch/indexer_Position_Membership_test.py
@@ -31,6 +31,7 @@ from app.model.db import (
 )
 from app.model.db.idx_position import IDXPositionMembershipBlockNumber
 from batch import indexer_Position_Membership
+from batch.indexer_Position_Membership import Processor
 from tests.account_config import eth_account
 from tests.contract_modules import (
     cancel_order,
@@ -420,6 +421,28 @@ class TestProcessor:
         filtered_events = list(processor.remove_duplicate_event_by_token_account_desc(events, ["from", "to"]))
         assert len(filtered_events) == 2
 
+    # <Normal_9>
+    # When stored index is 9,999,999 and current block number is 19,999,999,
+    # then processor must process "__sync_all" method 10 times.
+    def test_normal_9(self, processor, shared_contract, session):
+        current_block_number = 20000000 - 1
+        latest_block_number = 10000000 - 1
+
+        mock_lib = MagicMock()
+        # Setting current block number to 19,999,999
+        with mock.patch("web3.eth.Eth.blockNumber", current_block_number):
+            with mock.patch.object(Processor, "_Processor__sync_all", return_value=mock_lib) as __sync_all_mock:
+                idx_position_membership_block_number = IDXPositionMembershipBlockNumber()
+                idx_position_membership_block_number.id = 1
+                # Setting stored index to 9,999,999
+                idx_position_membership_block_number.latest_block_number = latest_block_number
+                session.merge(idx_position_membership_block_number)
+                session.commit()
+                __sync_all_mock.return_value = None
+                processor.initial_sync()
+                # Then processor call "__sync_all" method 10 times.
+                assert __sync_all_mock.call_count == 10
+                
     ###########################################################################
     # Error Case
     ###########################################################################

--- a/tests/batch/indexer_Position_Share_test.py
+++ b/tests/batch/indexer_Position_Share_test.py
@@ -893,7 +893,7 @@ class TestProcessor:
                 )
         # Ensure 5 events squashed to 2 events
         assert len(events) == 5
-        filtered_events = list(processor.remove_duplicate_event_by_token_account_desc(events, ["from", "to"]))
+        filtered_events = processor.remove_duplicate_event_by_token_account_desc(events, ["from", "to"])
         assert len(filtered_events) == 2
 
     # <Normal_17>

--- a/tests/batch/indexer_Position_Share_test.py
+++ b/tests/batch/indexer_Position_Share_test.py
@@ -31,6 +31,7 @@ from app.model.db import (
 )
 from app.model.db.idx_position import IDXPositionShareBlockNumber
 from batch import indexer_Position_Share
+from batch.indexer_Position_Share import Processor
 from tests.account_config import eth_account
 from tests.contract_modules import (
     cancel_agreement,
@@ -771,7 +772,7 @@ class TestProcessor:
         assert _position.exchange_commitment == 333
         assert _idx_position_share_block_number.latest_block_number == block_number
 
-    # <Normal_12>
+    # <Normal_13>
     # Single Token
     # Multi event with IbetExchange logs
     # - Transfer
@@ -894,6 +895,28 @@ class TestProcessor:
         assert len(events) == 5
         filtered_events = list(processor.remove_duplicate_event_by_token_account_desc(events, ["from", "to"]))
         assert len(filtered_events) == 2
+
+    # <Normal_17>
+    # When stored index is 9,999,999 and current block number is 19,999,999,
+    # then processor must process "__sync_all" method 10 times.
+    def test_normal_17(self, processor, shared_contract, session):
+        current_block_number = 20000000 - 1
+        latest_block_number = 10000000 - 1
+
+        mock_lib = MagicMock()
+        # Setting current block number to 19,999,999
+        with mock.patch("web3.eth.Eth.blockNumber", current_block_number):
+            with mock.patch.object(Processor, "_Processor__sync_all", return_value=mock_lib) as __sync_all_mock:
+                idx_position_share_block_number = IDXPositionShareBlockNumber()
+                idx_position_share_block_number.id = 1
+                # Setting stored index to 9,999,999
+                idx_position_share_block_number.latest_block_number = latest_block_number
+                session.merge(idx_position_share_block_number)
+                session.commit()
+                __sync_all_mock.return_value = None
+                processor.initial_sync()
+                # Then processor call "__sync_all" method 10 times.
+                assert __sync_all_mock.call_count == 10
 
     ###########################################################################
     # Error Case

--- a/tests/batch/indexer_Position_Share_test.py
+++ b/tests/batch/indexer_Position_Share_test.py
@@ -744,7 +744,7 @@ class TestProcessor:
     # - CancelAgreement
     # - MakeOrder
     # - TakeOrder
-    def test_normal_12(self, processor, shared_contract, session):
+    def test_normal_13(self, processor, shared_contract, session):
         # Issue Token
         token_list_contract = shared_contract["TokenList"]
         exchange_contract = shared_contract["IbetShareExchange"]
@@ -820,6 +820,119 @@ class TestProcessor:
         # Assertion
         _position_list = session.query(IDXPosition).order_by(IDXPosition.created).all()
         assert len(_position_list) == 0
+
+    # <Normal_16>
+    # Single Token
+    # Multi event logs
+    # - Transfer
+    # Duplicate events to be removed
+    def test_normal_16(self, processor, shared_contract, session):
+        # Issue Token
+        token_list_contract = shared_contract["TokenList"]
+        personal_info_contract = shared_contract["PersonalInfo"]
+        token = self.issue_token_share(
+            self.issuer, config.ZERO_ADDRESS, personal_info_contract["address"], token_list_contract)
+        self.listing_token(token["address"], session)
+
+        PersonalInfoUtils.register(
+            self.trader["account_address"], personal_info_contract["address"], self.issuer["account_address"])
+        for i in range(0, 5):
+            # Transfer
+            share_transfer_to_exchange(self.issuer, {"address": self.trader["account_address"]}, token, 10000)
+
+        # Get events for token address
+        events = Contract.get_contract('IbetShare', token["address"]).events.Transfer.getLogs(
+                    fromBlock=0,
+                    toBlock=10000
+                )
+        # Ensure 5 events squashed to 2 events
+        assert len(events) == 5
+        filtered_events = list(processor.remove_duplicate_event_by_token_account_desc(events, ["from", "to"]))
+        assert len(filtered_events) == 2
+
+    # <Normal_17>
+    # Single Token
+    # Multi event logs
+    # - Transfer
+    # Last event log block number to be stored in block number processor
+    def test_normal_17(self, processor, shared_contract, session):
+        # Issue Token
+        token_list_contract = shared_contract["TokenList"]
+        personal_info_contract = shared_contract["PersonalInfo"]
+        token = self.issue_token_share(
+            self.issuer, config.ZERO_ADDRESS, personal_info_contract["address"], token_list_contract)
+        self.listing_token(token["address"], session)
+
+        PersonalInfoUtils.register(
+            self.trader["account_address"], personal_info_contract["address"], self.issuer["account_address"])
+        for i in range(0, 5):
+            # Transfer
+            share_transfer_to_exchange(self.issuer, {"address": self.trader["account_address"]}, token, 10000)
+
+        # Run target process
+        processor.sync_new_logs()
+
+        # Get events for token address
+        events = Contract.get_contract('IbetCoupon', token["address"]).events.Transfer.getLogs(
+                    fromBlock=0,
+                    toBlock=10000
+                )
+
+        idx_position_block_number = processor.get_idx_position_block_number(session)
+
+        # Ensure last block number is properly stored in db
+        assert events[-1]['blockNumber'] == idx_position_block_number
+
+    # <Normal_18>
+    # Single Token
+    # Multi event logs
+    # - Transfer
+    # Expect that "sync new log" process starts from the latest block index.
+    def test_normal_18(self, processor, shared_contract, session):
+        # Issue Token
+        token_list_contract = shared_contract["TokenList"]
+        personal_info_contract = shared_contract["PersonalInfo"]
+        token = self.issue_token_share(
+            self.issuer, config.ZERO_ADDRESS, personal_info_contract["address"], token_list_contract)
+
+        self.listing_token(token["address"], session)
+        PersonalInfoUtils.register(
+            self.trader["account_address"], personal_info_contract["address"], self.issuer["account_address"])
+        for i in range(0, 5):
+            # Transfer
+            share_transfer_to_exchange(
+                self.issuer, {"address": self.trader["account_address"]}, token, 1000)
+
+        # Set index position
+        processor.set_idx_position_block_number(session, 10000)
+        session.commit()
+
+        latest_block_bf = processor.get_idx_position_block_number(session)
+        # Stored index is higher than current block number, so init sync is skipped.
+        processor.initial_sync()
+
+        # Run target process
+        processor.sync_new_logs()
+        latest_block_af = processor.get_idx_position_block_number(session)
+
+        # Expect that processor doesn't sync any blocks.
+        assert latest_block_bf == latest_block_af == 10000
+
+        processor.set_idx_position_block_number(session, -1)
+        session.commit()
+        assert processor.get_idx_position_block_number(session) == -1
+
+        # Run target process
+        processor.sync_new_logs()
+        # Get events for token address
+        events = Contract.get_contract('IbetShare', token["address"]).events.Transfer.getLogs(
+                    fromBlock=0,
+                    toBlock=10000
+                )
+        idx_position_block_number = processor.get_idx_position_block_number(session)
+
+        # Ensure last block number is properly stored in db
+        assert events[-1]['blockNumber'] == idx_position_block_number
 
     ###########################################################################
     # Error Case

--- a/tests/batch/indexer_Position_Share_test.py
+++ b/tests/batch/indexer_Position_Share_test.py
@@ -29,6 +29,7 @@ from app.model.db import (
     Listing,
     IDXPosition
 )
+from app.model.db.idx_position import IDXPositionShareBlockNumber
 from batch import indexer_Position_Share
 from tests.account_config import eth_account
 from tests.contract_modules import (
@@ -130,11 +131,13 @@ class TestProcessor:
         share_transfer_to_exchange(self.issuer, {"address": self.trader["account_address"]}, token, 10000)
 
         # Run target process
+        block_number = web3.eth.blockNumber
         processor.sync_new_logs()
 
         # Assertion
         _position_list = session.query(IDXPosition).order_by(IDXPosition.created).all()
         assert len(_position_list) == 2
+        _idx_position_share_block_number = session.query(IDXPositionShareBlockNumber).first()
         _position = _position_list[0]
         assert _position.id == 1
         assert _position.token_address == token["address"]
@@ -151,7 +154,7 @@ class TestProcessor:
         assert _position.pending_transfer == 0
         assert _position.exchange_balance == 0
         assert _position.exchange_commitment == 0
-
+        assert _idx_position_share_block_number.latest_block_number == block_number
 
     # <Normal_2>
     # Single Token
@@ -174,11 +177,13 @@ class TestProcessor:
         share_transfer_to_exchange(self.issuer, {"address": self.trader["account_address"]}, token, 3000)
 
         # Run target process
+        block_number = web3.eth.blockNumber
         processor.sync_new_logs()
 
         # Assertion
         _position_list = session.query(IDXPosition).order_by(IDXPosition.created).all()
         assert len(_position_list) == 2
+        _idx_position_share_block_number = session.query(IDXPositionShareBlockNumber).first()
         _position: IDXPosition = _position_list[0]
         assert _position.id == 1
         assert _position.token_address == token["address"]
@@ -195,6 +200,7 @@ class TestProcessor:
         assert _position.pending_transfer == 0
         assert _position.exchange_balance == 0
         assert _position.exchange_commitment == 0
+        assert _idx_position_share_block_number.latest_block_number == block_number
 
     # <Normal_3>
     # Multi Token
@@ -224,11 +230,13 @@ class TestProcessor:
         share_transfer_to_exchange(self.issuer, {"address": self.trader2["account_address"]}, token2, 3000)
 
         # Run target process
+        block_number = web3.eth.blockNumber
         processor.sync_new_logs()
 
         # Assertion
         _position_list = session.query(IDXPosition).order_by(IDXPosition.created).all()
         assert len(_position_list) == 6
+        _idx_position_share_block_number = session.query(IDXPositionShareBlockNumber).first()
         _position = _position_list[0]
         assert _position.id == 1
         assert _position.token_address == token["address"]
@@ -277,6 +285,7 @@ class TestProcessor:
         assert _position.pending_transfer == 0
         assert _position.exchange_balance == 0
         assert _position.exchange_commitment == 0
+        assert _idx_position_share_block_number.latest_block_number == block_number
 
     # <Normal_4>
     # Single Token
@@ -307,11 +316,13 @@ class TestProcessor:
         web3.eth.waitForTransactionReceipt(tx_hash)
 
         # Run target process
+        block_number = web3.eth.blockNumber
         processor.sync_new_logs()
 
         # Assertion
         _position_list = session.query(IDXPosition).order_by(IDXPosition.created).all()
         assert len(_position_list) == 1
+        _idx_position_share_block_number = session.query(IDXPositionShareBlockNumber).first()
         _position = _position_list[0]
         assert _position.id == 1
         assert _position.token_address == token["address"]
@@ -320,6 +331,7 @@ class TestProcessor:
         assert _position.pending_transfer == 0
         assert _position.exchange_balance == 0
         assert _position.exchange_commitment == 0
+        assert _idx_position_share_block_number.latest_block_number == block_number
 
     # <Normal_5>
     # Single Token
@@ -358,11 +370,13 @@ class TestProcessor:
         web3.eth.waitForTransactionReceipt(tx_hash)
 
         # Run target process
+        block_number = web3.eth.blockNumber
         processor.sync_new_logs()
 
         # Assertion
         _position_list = session.query(IDXPosition).order_by(IDXPosition.created).all()
         assert len(_position_list) == 2
+        _idx_position_share_block_number = session.query(IDXPositionShareBlockNumber).first()
         _position = _position_list[0]
         assert _position.id == 1
         assert _position.token_address == token["address"]
@@ -379,6 +393,7 @@ class TestProcessor:
         assert _position.pending_transfer == 0
         assert _position.exchange_balance == 0
         assert _position.exchange_commitment == 0
+        assert _idx_position_share_block_number.latest_block_number == block_number
 
     # <Normal_6>
     # Single Token
@@ -401,11 +416,13 @@ class TestProcessor:
         web3.eth.waitForTransactionReceipt(tx_hash)
 
         # Run target process
+        block_number = web3.eth.blockNumber
         processor.sync_new_logs()
 
         # Assertion
         _position_list = session.query(IDXPosition).order_by(IDXPosition.created).all()
         assert len(_position_list) == 1
+        _idx_position_share_block_number = session.query(IDXPositionShareBlockNumber).first()
         _position = _position_list[0]
         assert _position.id == 1
         assert _position.token_address == token["address"]
@@ -414,6 +431,7 @@ class TestProcessor:
         assert _position.pending_transfer == 0
         assert _position.exchange_balance == 0
         assert _position.exchange_commitment == 0
+        assert _idx_position_share_block_number.latest_block_number == block_number
 
     # <Normal_7>
     # Single Token
@@ -436,11 +454,13 @@ class TestProcessor:
         web3.eth.waitForTransactionReceipt(tx_hash)
 
         # Run target process
+        block_number = web3.eth.blockNumber
         processor.sync_new_logs()
 
         # Assertion
         _position_list = session.query(IDXPosition).order_by(IDXPosition.created).all()
         assert len(_position_list) == 1
+        _idx_position_share_block_number = session.query(IDXPositionShareBlockNumber).first()
         _position = _position_list[0]
         assert _position.id == 1
         assert _position.token_address == token["address"]
@@ -449,6 +469,7 @@ class TestProcessor:
         assert _position.pending_transfer == 0
         assert _position.exchange_balance == 0
         assert _position.exchange_commitment == 0
+        assert _idx_position_share_block_number.latest_block_number == block_number
 
     # <Normal_8>
     # Single Token
@@ -484,11 +505,13 @@ class TestProcessor:
         web3.eth.waitForTransactionReceipt(tx_hash)
 
         # Run target process
+        block_number = web3.eth.blockNumber
         processor.sync_new_logs()
 
         # Assertion
         _position_list = session.query(IDXPosition).order_by(IDXPosition.created).all()
         assert len(_position_list) == 2
+        _idx_position_share_block_number = session.query(IDXPositionShareBlockNumber).first()
         _position = _position_list[0]
         assert _position.id == 1
         assert _position.token_address == token["address"]
@@ -505,6 +528,7 @@ class TestProcessor:
         assert _position.pending_transfer == 2000
         assert _position.exchange_balance == 0
         assert _position.exchange_commitment == 0
+        assert _idx_position_share_block_number.latest_block_number == block_number
 
     # <Normal_9>
     # Single Token
@@ -547,11 +571,13 @@ class TestProcessor:
         web3.eth.waitForTransactionReceipt(tx_hash)
 
         # Run target process
+        block_number = web3.eth.blockNumber
         processor.sync_new_logs()
 
         # Assertion
         _position_list = session.query(IDXPosition).order_by(IDXPosition.created).all()
         assert len(_position_list) == 3
+        _idx_position_share_block_number = session.query(IDXPositionShareBlockNumber).first()
         _position = _position_list[0]
         assert _position.id == 1
         assert _position.token_address == token["address"]
@@ -576,6 +602,7 @@ class TestProcessor:
         assert _position.pending_transfer == 0
         assert _position.exchange_balance == 0
         assert _position.exchange_commitment == 0
+        assert _idx_position_share_block_number.latest_block_number == block_number
 
     # <Normal_10>
     # Single Token
@@ -618,11 +645,13 @@ class TestProcessor:
         web3.eth.waitForTransactionReceipt(tx_hash)
 
         # Run target process
+        block_number = web3.eth.blockNumber
         processor.sync_new_logs()
 
         # Assertion
         _position_list = session.query(IDXPosition).order_by(IDXPosition.created).all()
         assert len(_position_list) == 2
+        _idx_position_share_block_number = session.query(IDXPositionShareBlockNumber).first()
         _position = _position_list[0]
         assert _position.id == 1
         assert _position.token_address == token["address"]
@@ -639,6 +668,7 @@ class TestProcessor:
         assert _position.pending_transfer == 0
         assert _position.exchange_balance == 0
         assert _position.exchange_commitment == 0
+        assert _idx_position_share_block_number.latest_block_number == block_number
 
     # <Normal_11>
     # Single Token
@@ -669,12 +699,14 @@ class TestProcessor:
                                      token, self.trader["account_address"], self.issuer["account_address"], 300)
 
         # Run target process
+        block_number = web3.eth.blockNumber
         processor.sync_new_logs()
 
         # Assertion
         _position_list = session.query(
             IDXPosition).order_by(IDXPosition.created).all()
         assert len(_position_list) == 2
+        _idx_position_share_block_number = session.query(IDXPositionShareBlockNumber).first()
         _position: IDXPosition = _position_list[0]
         assert _position.id == 1
         assert _position.token_address == token["address"]
@@ -691,6 +723,7 @@ class TestProcessor:
         assert _position.pending_transfer == 0
         assert _position.exchange_balance == 200
         assert _position.exchange_commitment == 0
+        assert _idx_position_share_block_number.latest_block_number == block_number
 
     # <Normal_12>
     # Single Token
@@ -720,12 +753,14 @@ class TestProcessor:
         make_sell(self.issuer, exchange_contract, token, 333, 1000)
 
         # Run target process
+        block_number = web3.eth.blockNumber
         processor.sync_new_logs()
 
         # Assertion
         _position_list = session.query(
             IDXPosition).order_by(IDXPosition.created).all()
         assert len(_position_list) == 1
+        _idx_position_share_block_number = session.query(IDXPositionShareBlockNumber).first()
         _position: IDXPosition = _position_list[0]
         assert _position.id == 1
         assert _position.token_address == token["address"]
@@ -734,6 +769,7 @@ class TestProcessor:
         assert _position.pending_transfer == 0
         assert _position.exchange_balance == 10000 - 111 - 222 - 333
         assert _position.exchange_commitment == 333
+        assert _idx_position_share_block_number.latest_block_number == block_number
 
     # <Normal_12>
     # Single Token
@@ -766,12 +802,14 @@ class TestProcessor:
         take_sell(self.issuer, exchange_contract, get_latest_orderid(exchange_contract), 66)
 
         # Run target process
+        block_number = web3.eth.blockNumber
         processor.sync_new_logs()
 
         # Assertion
         _position_list = session.query(
             IDXPosition).order_by(IDXPosition.created).all()
         assert len(_position_list) == 1
+        _idx_position_share_block_number = session.query(IDXPositionShareBlockNumber).first()
         _position: IDXPosition = _position_list[0]
         assert _position.id == 1
         assert _position.token_address == token["address"]
@@ -780,6 +818,7 @@ class TestProcessor:
         assert _position.pending_transfer == 0
         assert _position.exchange_balance == 10000 - 55 - 66
         assert _position.exchange_commitment == 66
+        assert _idx_position_share_block_number.latest_block_number == block_number
 
     # <Normal_14>
     # No event logs
@@ -793,11 +832,14 @@ class TestProcessor:
 
         # Not Event
         # Run target process
+        block_number = web3.eth.blockNumber
         processor.sync_new_logs()
 
         # Assertion
         _position_list = session.query(IDXPosition).order_by(IDXPosition.created).all()
         assert len(_position_list) == 0
+        _idx_position_share_block_number = session.query(IDXPositionShareBlockNumber).first()
+        assert _idx_position_share_block_number.latest_block_number == block_number
 
     # <Normal_15>
     # Not Listing Token
@@ -815,11 +857,14 @@ class TestProcessor:
         share_transfer_to_exchange(self.issuer, {"address": self.trader["account_address"]}, token, 10000)
 
         # Run target process
+        block_number = web3.eth.blockNumber
         processor.sync_new_logs()
 
         # Assertion
         _position_list = session.query(IDXPosition).order_by(IDXPosition.created).all()
         assert len(_position_list) == 0
+        _idx_position_share_block_number = session.query(IDXPositionShareBlockNumber).first()
+        assert _idx_position_share_block_number.latest_block_number == block_number
 
     # <Normal_16>
     # Single Token
@@ -849,90 +894,6 @@ class TestProcessor:
         assert len(events) == 5
         filtered_events = list(processor.remove_duplicate_event_by_token_account_desc(events, ["from", "to"]))
         assert len(filtered_events) == 2
-
-    # <Normal_17>
-    # Single Token
-    # Multi event logs
-    # - Transfer
-    # Last event log block number to be stored in block number processor
-    def test_normal_17(self, processor, shared_contract, session):
-        # Issue Token
-        token_list_contract = shared_contract["TokenList"]
-        personal_info_contract = shared_contract["PersonalInfo"]
-        token = self.issue_token_share(
-            self.issuer, config.ZERO_ADDRESS, personal_info_contract["address"], token_list_contract)
-        self.listing_token(token["address"], session)
-
-        PersonalInfoUtils.register(
-            self.trader["account_address"], personal_info_contract["address"], self.issuer["account_address"])
-        for i in range(0, 5):
-            # Transfer
-            share_transfer_to_exchange(self.issuer, {"address": self.trader["account_address"]}, token, 10000)
-
-        # Run target process
-        processor.sync_new_logs()
-
-        # Get events for token address
-        events = Contract.get_contract('IbetCoupon', token["address"]).events.Transfer.getLogs(
-                    fromBlock=0,
-                    toBlock=10000
-                )
-
-        idx_position_block_number = processor.get_idx_position_block_number(session)
-
-        # Ensure last block number is properly stored in db
-        assert events[-1]['blockNumber'] == idx_position_block_number
-
-    # <Normal_18>
-    # Single Token
-    # Multi event logs
-    # - Transfer
-    # Expect that "sync new log" process starts from the latest block index.
-    def test_normal_18(self, processor, shared_contract, session):
-        # Issue Token
-        token_list_contract = shared_contract["TokenList"]
-        personal_info_contract = shared_contract["PersonalInfo"]
-        token = self.issue_token_share(
-            self.issuer, config.ZERO_ADDRESS, personal_info_contract["address"], token_list_contract)
-
-        self.listing_token(token["address"], session)
-        PersonalInfoUtils.register(
-            self.trader["account_address"], personal_info_contract["address"], self.issuer["account_address"])
-        for i in range(0, 5):
-            # Transfer
-            share_transfer_to_exchange(
-                self.issuer, {"address": self.trader["account_address"]}, token, 1000)
-
-        # Set index position
-        processor.set_idx_position_block_number(session, 10000)
-        session.commit()
-
-        latest_block_bf = processor.get_idx_position_block_number(session)
-        # Stored index is higher than current block number, so init sync is skipped.
-        processor.initial_sync()
-
-        # Run target process
-        processor.sync_new_logs()
-        latest_block_af = processor.get_idx_position_block_number(session)
-
-        # Expect that processor doesn't sync any blocks.
-        assert latest_block_bf == latest_block_af == 10000
-
-        processor.set_idx_position_block_number(session, -1)
-        session.commit()
-        assert processor.get_idx_position_block_number(session) == -1
-
-        # Run target process
-        processor.sync_new_logs()
-        # Get events for token address
-        events = Contract.get_contract('IbetShare', token["address"]).events.Transfer.getLogs(
-                    fromBlock=0,
-                    toBlock=10000
-                )
-        idx_position_block_number = processor.get_idx_position_block_number(session)
-
-        # Ensure last block number is properly stored in db
-        assert events[-1]['blockNumber'] == idx_position_block_number
 
     ###########################################################################
     # Error Case


### PR DESCRIPTION
**Draft**
close #1128 

1. 
> Create a table to save the processed block number, and batch start processing from that number.
> refer https://github.com/BoostryJP/ibet-Prime/blob/dev-22.3/batch/indexer_position_bond.py#L70

2. 
> Data of duplicate combinations within the specified range will be deleted and then synchronized.

~~I added mixins and made position processors inherit them.~~
~~Is it OK?~~
* I'm going to implement methods to each processors, not use mixins.