### PR TITLE
feat: add function for obtaining a list of holders in a given block number

### DIFF
--- a/app/api/common/base.py
+++ b/app/api/common/base.py
@@ -19,6 +19,7 @@ SPDX-License-Identifier: Apache-2.0
 
 import falcon
 import json
+from falcon import Request, Response
 
 try:
     from collections import OrderedDict
@@ -65,19 +66,19 @@ class BaseResource(object):
         obj['data'] = data
         res.text = self.to_json(obj)
 
-    def on_get(self, req, res, *args, **kwargs):
+    def on_get(self, req: Request, res: Response, *args, **kwargs):
         if req.path == '/':
             res.status = falcon.HTTP_200
             res.text = self.to_json(self.HELLO_WORLD)
         else:
             raise NotSupportedError(method='GET', url=req.path)
 
-    def on_post(self, req, res, *args, **kwargs):
+    def on_post(self, req: Request, res: Response, *args, **kwargs):
         raise NotSupportedError(method='POST', url=req.path)
 
-    def on_put(self, req, res, *args, **kwargs):
+    def on_put(self, req: Request, res: Response, *args, **kwargs):
         raise NotSupportedError(method='PUT', url=req.path)
 
-    def on_delete(self, req, res, *args, **kwargs):
+    def on_delete(self, req: Request, res: Response, *args, **kwargs):
         raise NotSupportedError(method='DELETE', url=req.path)
 

--- a/app/api/v2/token.py
+++ b/app/api/v2/token.py
@@ -17,6 +17,7 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 import uuid
+from typing import List
 from cerberus import Validator
 from sqlalchemy import (
     or_,
@@ -334,23 +335,15 @@ class TokenHoldersCollectionId(BaseResource):
             description = "list_id: %s is not collection for contract_address: %s"%(list_id, contract_address)
             raise InvalidParameterError(description=description)
 
-        holders = []
-        if _same_list_id_record.batch_status == TokenHolderBatchStatus.PENDING.value:
-            return self.on_success(res, {
-                "status": _same_list_id_record.batch_status,
-                "holders": holders
-            })
-        else:
-            token_holders = session.query(TokenHolder). \
-                filter(TokenHolder.holder_list_id == _same_list_id_record.id). \
-                all()
-            for th in token_holders:
-                holders.append(th.account_address)
+        _token_holders: List[TokenHolder] = session.query(TokenHolder). \
+            filter(TokenHolder.holder_list_id == _same_list_id_record.id). \
+            all()
+        token_holders = [_token_holder.json() for _token_holder in _token_holders]
 
-            return self.on_success(res, {
-                "status": _same_list_id_record.batch_status,
-                "holders": holders
-            })
+        return self.on_success(res, {
+            "status": _same_list_id_record.batch_status,
+            "holders": token_holders
+        })
 
 
 class TransferHistory(BaseResource):

--- a/app/api/v2/token.py
+++ b/app/api/v2/token.py
@@ -21,7 +21,8 @@ from typing import List
 from cerberus import Validator
 from sqlalchemy import (
     or_,
-    desc
+    desc,
+    asc
 )
 from web3 import Web3
 from eth_utils import to_checksum_address
@@ -337,7 +338,7 @@ class TokenHoldersCollectionId(BaseResource):
 
         _token_holders: List[TokenHolder] = session.query(TokenHolder). \
             filter(TokenHolder.holder_list_id == _same_list_id_record.id). \
-            all()
+            order_by(asc(TokenHolder.holder_list_id)).all()
         token_holders = [_token_holder.json() for _token_holder in _token_holders]
 
         return self.on_success(res, {

--- a/app/api/v2/token.py
+++ b/app/api/v2/token.py
@@ -338,7 +338,8 @@ class TokenHoldersCollectionId(BaseResource):
 
         _token_holders: List[TokenHolder] = session.query(TokenHolder). \
             filter(TokenHolder.holder_list_id == _same_list_id_record.id). \
-            order_by(asc(TokenHolder.holder_list_id)).all()
+            order_by(asc(TokenHolder.account_address)).\
+            all()
         token_holders = [_token_holder.json() for _token_holder in _token_holders]
 
         return self.on_success(res, {

--- a/app/api/v2/token.py
+++ b/app/api/v2/token.py
@@ -36,13 +36,15 @@ from app.errors import (
 )
 from app import config
 from app.contracts import Contract
-from app.model.db.tokenholders import TokenHoldersList, BatchStatus, TokenHolder
 from app.utils.web3_utils import Web3Wrapper
 from app.model.db import (
     Listing,
     IDXPosition,
     IDXTransfer,
-    IDXTransferApproval
+    IDXTransferApproval,
+    TokenHoldersList,
+    TokenHolderBatchStatus,
+    TokenHolder
 )
 from app.model.blockchain import (
     BondToken,
@@ -52,12 +54,8 @@ from app.model.blockchain import (
 )
 
 LOG = log.get_logger()
-web3 = Web3Wrapper()
 
 
-# ------------------------------
-# [トークン管理]トークン取扱ステータス
-# ------------------------------
 class TokenStatus(BaseResource):
     """
     Endpoint: /v2/Token/{contract_address}/Status
@@ -125,9 +123,10 @@ class TokenStatus(BaseResource):
         self.on_success(res, response_json)
 
 
-# /Token/{contract_address}/Holders
 class TokenHolders(BaseResource):
-    """トークン保有者一覧"""
+    """
+    Endpoint: /v2/Token/{contract_address}/Holders
+    """
 
     def on_get(self, req, res, contract_address=None, **kwargs):
         LOG.info('v2.token.TokenHolders')
@@ -177,9 +176,187 @@ class TokenHolders(BaseResource):
         self.on_success(res, resp_body)
 
 
-# /Token/{contract_address}/TransferHistory
+class TokenHoldersCollection(BaseResource):
+    """
+    Endpoint: /v2/Token/{contract_address}/Holders/Collection
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.web3 = Web3Wrapper()
+
+    def on_post(self, req: Request, res: Response, *args, **kwargs):
+        """Token holders collection"""
+        LOG.info("v2.token.TokenHoldersCollection(POST)")
+
+        session: Session = req.context["session"]
+
+        # body部の入力値チェック
+        request_json = self.validate(req)
+        list_id = request_json["list_id"]
+        block_number = request_json["block_number"]
+
+        # contract_addressのフォーマットチェック
+        contract_address = kwargs.get("contract_address", "")
+        try:
+            if not Web3.isAddress(contract_address):
+                raise InvalidParameterError("Invalid contract address")
+        except Exception as err:
+            LOG.debug(f"invalid contract address: {err}")
+            raise InvalidParameterError("Invalid contract address")
+
+        # ブロックナンバーのチェック
+        if block_number > self.web3.eth.blockNumber or block_number < 1:
+            raise InvalidParameterError("Block number must be current or past one.")
+
+        # 取扱トークンチェック
+        # NOTE:非公開トークンも取扱対象とする
+        listed_token = session.query(Listing).\
+            filter(Listing.token_address == contract_address).\
+            first()
+        if listed_token is None:
+            raise DataNotExistsError('contract_address: %s' % contract_address)
+
+        # list_idの衝突チェック
+        _same_list_id_record = session.query(TokenHoldersList). \
+            filter(TokenHoldersList.list_id == list_id). \
+            first()
+        if _same_list_id_record is not None:
+            raise InvalidParameterError("list_id must be unique.")
+
+        _same_combi_record = session.query(TokenHoldersList). \
+            filter(TokenHoldersList.token_address == contract_address). \
+            filter(TokenHoldersList.block_number == block_number). \
+            filter(TokenHoldersList.batch_status != TokenHolderBatchStatus.FAILED.value). \
+            first()
+
+        if _same_combi_record is not None:
+            # 同じブロックナンバー・トークンアドレスのコレクションが、PENDINGかDONEで既に存在する場合、
+            # そのlist_idとstatusを返却する。
+            return self.on_success(res, {
+                "list_id": _same_combi_record.list_id,
+                "status": _same_combi_record.batch_status,
+            })
+        else:
+            token_holder_list = TokenHoldersList()
+            token_holder_list.list_id = list_id
+            token_holder_list.batch_status = TokenHolderBatchStatus.PENDING.value
+            token_holder_list.block_number = block_number
+            token_holder_list.token_address = contract_address
+            session.add(token_holder_list)
+            session.commit()
+
+            return self.on_success(res, {
+                "list_id": token_holder_list.list_id,
+                "status": token_holder_list.batch_status,
+            })
+
+    @staticmethod
+    def validate(req):
+        request_json = req.context['data']
+        if request_json is None:
+            raise InvalidParameterError
+
+        validator = Validator({
+            "list_id": {
+                "type": "string",
+                "required": True
+            },
+            "block_number": {
+                "type": "integer",
+                "required": True
+            },
+        })
+
+        if not validator.validate(request_json):
+            raise InvalidParameterError(validator.errors)
+
+        # UUIDのフォーマットチェック
+        try:
+            if not uuid.UUID(request_json["list_id"]).version == 4:
+                description = "list_id must be UUIDv4."
+                raise InvalidParameterError(description=description)
+        except:
+            description = "list_id must be UUIDv4."
+            raise InvalidParameterError(description=description)
+        return request_json
+
+
+class TokenHoldersCollectionId(BaseResource):
+    """
+    Endpoint: /v2/Token/{contract_address}/Holders/Collection/{list_id}
+    """
+
+    def on_get(self, req: Request, res: Response, *args, **kwargs):
+        """Token holders collection Id"""
+        LOG.info("v2.token.TokenHoldersCollectionId(GET)")
+
+        contract_address = kwargs.get("contract_address", "")
+        list_id = kwargs.get("list_id", "")
+
+        # 入力アドレスフォーマットチェック
+        try:
+            contract_address = to_checksum_address(contract_address)
+            if not Web3.isAddress(contract_address):
+                description = 'invalid contract_address'
+                raise InvalidParameterError(description=description)
+        except:
+            description = 'invalid contract_address'
+            raise InvalidParameterError(description=description)
+
+        # 入力IDフォーマットチェック
+        try:
+            if not uuid.UUID(list_id).version == 4:
+                description = "list_id must be UUIDv4."
+                raise InvalidParameterError(description=description)
+        except:
+            description = "list_id must be UUIDv4."
+            raise InvalidParameterError(description=description)
+
+        session: Session = req.context["session"]
+
+        # 取扱トークンチェック
+        # NOTE:非公開トークンも取扱対象とする
+        listed_token = session.query(Listing).\
+            filter(Listing.token_address == contract_address).\
+            first()
+        if listed_token is None:
+            raise DataNotExistsError('contract_address: %s' % contract_address)
+
+        # 既存レコードの存在チェック
+        _same_list_id_record: TokenHoldersList = session.query(TokenHoldersList). \
+            filter(TokenHoldersList.list_id == list_id). \
+            first()
+
+        if not _same_list_id_record:
+            raise DataNotExistsError("list_id: %s"%list_id)
+        if _same_list_id_record.token_address != contract_address:
+            description = "list_id: %s is not collection for contract_address: %s"%(list_id, contract_address)
+            raise InvalidParameterError(description=description)
+
+        holders = []
+        if _same_list_id_record.batch_status == TokenHolderBatchStatus.PENDING.value:
+            return self.on_success(res, {
+                "status": _same_list_id_record.batch_status,
+                "holders": holders
+            })
+        else:
+            token_holders = session.query(TokenHolder). \
+                filter(TokenHolder.holder_list_id == _same_list_id_record.id). \
+                all()
+            for th in token_holders:
+                holders.append(th.account_address)
+
+            return self.on_success(res, {
+                "status": _same_list_id_record.batch_status,
+                "holders": holders
+            })
+
+
 class TransferHistory(BaseResource):
-    """トークン移転履歴"""
+    """
+    Endpoint: /v2/Token/{contract_address}/TransferHistory
+    """
 
     def on_get(self, req, res, contract_address=None, **kwargs):
         LOG.info('v2.token.TransferHistory')
@@ -263,9 +440,10 @@ class TransferHistory(BaseResource):
         return validator.document
 
 
-# /Token/{contract_address}/TransferApprovalHistory
 class TransferApprovalHistory(BaseResource):
-    """トークン移転承諾履歴"""
+    """
+    Endpoint: /v2/Token/{contract_address}/TransferApprovalHistory
+    """
 
     def on_get(self, req, res, contract_address=None, **kwargs):
         LOG.info("v2.token.TransferApprovalHistory")
@@ -348,9 +526,6 @@ class TransferApprovalHistory(BaseResource):
         return validator.document
 
 
-# ------------------------------
-# [普通社債]トークン一覧
-# ------------------------------
 class StraightBondTokens(BaseResource):
     """
     Endpoint: /v2/Token/StraightBond
@@ -464,9 +639,6 @@ class StraightBondTokens(BaseResource):
         return validator.document
 
 
-# ------------------------------
-# [普通社債]トークン一覧（トークンアドレス）
-# ------------------------------
 class StraightBondTokenAddresses(BaseResource):
     """
     Endpoint: /v2/Token/StraightBond/Address
@@ -562,9 +734,6 @@ class StraightBondTokenAddresses(BaseResource):
         return validator.document
 
 
-# ------------------------------
-# [普通社債]トークン詳細
-# ------------------------------
 class StraightBondTokenDetails(BaseResource):
     """
     Endpoint: /v2/Token/StraightBond/{contract_address}
@@ -660,9 +829,6 @@ class StraightBondTokenDetails(BaseResource):
                 return None
 
 
-# ------------------------------
-# [株式]トークン一覧
-# ------------------------------
 class ShareTokens(BaseResource):
     """
     Endpoint: /v2/Token/Share
@@ -777,9 +943,6 @@ class ShareTokens(BaseResource):
         return validator.document
 
 
-# ------------------------------
-# [株式]トークン一覧（トークンアドレス）
-# ------------------------------
 class ShareTokenAddresses(BaseResource):
     """
     Endpoint: /v2/Token/Share/Address
@@ -876,9 +1039,6 @@ class ShareTokenAddresses(BaseResource):
         return validator.document
 
 
-# ------------------------------
-# [株式]トークン詳細
-# ------------------------------
 class ShareTokenDetails(BaseResource):
     """
     Endpoint: /v2/Token/Share/{contract_address}
@@ -970,9 +1130,6 @@ class ShareTokenDetails(BaseResource):
                 return None
 
 
-# ------------------------------
-# [会員権]トークン一覧
-# ------------------------------
 class MembershipTokens(BaseResource):
     """
     Endpoint: /v2/Token/Membership
@@ -1087,9 +1244,6 @@ class MembershipTokens(BaseResource):
         return validator.document
 
 
-# ------------------------------
-# [会員権]トークン一覧（トークンアドレス）
-# ------------------------------
 class MembershipTokenAddresses(BaseResource):
     """
     Endpoint: /v2/Token/Membership/Address
@@ -1185,9 +1339,6 @@ class MembershipTokenAddresses(BaseResource):
         return validator.document
 
 
-# ------------------------------
-# [会員権]トークン詳細
-# ------------------------------
 class MembershipTokenDetails(BaseResource):
     """
     Endpoint: /v2/Token/Membership/{contract_address}
@@ -1282,9 +1433,6 @@ class MembershipTokenDetails(BaseResource):
                 return None
 
 
-# ------------------------------
-# [クーポン]トークン一覧
-# ------------------------------
 class CouponTokens(BaseResource):
     """
     Endpoint: /v2/Token/Coupon
@@ -1398,9 +1546,6 @@ class CouponTokens(BaseResource):
         return validator.document
 
 
-# ------------------------------
-# [クーポン]トークン一覧（トークンアドレス）
-# ------------------------------
 class CouponTokenAddresses(BaseResource):
     """
     Endpoint: /v2/Token/Coupon/Address
@@ -1497,9 +1642,6 @@ class CouponTokenAddresses(BaseResource):
         return validator.document
 
 
-# ------------------------------
-# [クーポン]トークン詳細
-# ------------------------------
 class CouponTokenDetails(BaseResource):
     """
     Endpoint: /v2/Token/Coupon/{contract_address}
@@ -1592,164 +1734,3 @@ class CouponTokenDetails(BaseResource):
             except Exception as e:
                 LOG.error(e)
                 return None
-
-
-class TokenHoldersCollection(BaseResource):
-
-    def on_post(self, req: Request, res: Response, *args, **kwargs):
-        """Token holders collection"""
-        LOG.info("v3.token.TokenHoldersCollection(POST)")
-
-        session: Session = req.context["session"]
-
-        # body部の入力値チェック
-        request_json = self.validate(req)
-        list_id = request_json["list_id"]
-        block_number = request_json["block_number"]
-
-        # contract_addressのフォーマットチェック
-        contract_address = kwargs.get("contract_address", "")
-        try:
-            if not Web3.isAddress(contract_address):
-                raise InvalidParameterError("Invalid contract address")
-        except Exception as err:
-            LOG.warning(f"invalid contract address: {err}")
-            raise InvalidParameterError("Invalid contract address")
-
-        # ブロックナンバーのチェック
-        if block_number > web3.eth.blockNumber or block_number < 1:
-            raise InvalidParameterError("Block number must be current or past one.")
-
-        # 取扱トークンチェック
-        # NOTE:非公開トークンも取扱対象とする
-        listed_token = session.query(Listing).\
-            filter(Listing.token_address == contract_address).\
-            first()
-        if listed_token is None:
-            raise DataNotExistsError('contract_address: %s' % contract_address)
-
-        # list_idの衝突チェック
-        _same_list_id_record = session.query(TokenHoldersList). \
-            filter(TokenHoldersList.list_id == list_id). \
-            first()
-        if _same_list_id_record is not None:
-            raise InvalidParameterError("list_id must be unique.")
-
-        _same_combi_record = session.query(TokenHoldersList).\
-            filter(TokenHoldersList.token_address == contract_address).\
-            filter(TokenHoldersList.block_number == block_number).\
-            filter(TokenHoldersList.batch_status != BatchStatus.FAILED.value).first()
-
-        if _same_combi_record is not None:
-            # 同じブロックナンバー・トークンアドレスのコレクションが、PENDINGかDONEで既に存在する場合、
-            # そのlist_idとstatusを返却する。
-            return self.on_success(res, {
-                "list_id": _same_combi_record.list_id,
-                "status": _same_combi_record.batch_status,
-            })
-
-        token_holder_list = TokenHoldersList()
-        token_holder_list.list_id = list_id
-        token_holder_list.batch_status = BatchStatus.PENDING.value
-        token_holder_list.block_number = block_number
-        token_holder_list.token_address = contract_address
-        session.add(token_holder_list)
-        session.commit()
-        return self.on_success(res, {
-            "list_id": token_holder_list.list_id,
-            "status": token_holder_list.batch_status,
-        })
-
-    @staticmethod
-    def validate(req):
-        request_json = req.context['data']
-        if request_json is None:
-            raise InvalidParameterError
-
-        validator = Validator({
-            "list_id": {
-                "type": "string",
-                "required": True
-            },
-            "block_number": {
-                "type": "integer",
-                "required": True
-            },
-        })
-
-        if not validator.validate(request_json):
-            raise InvalidParameterError(validator.errors)
-
-        # UUIDのフォーマットチェック
-        try:
-            if not uuid.UUID(request_json["list_id"]).version == 4:
-                description = "list_id must be UUIDv4."
-                raise InvalidParameterError(description=description)
-        except:
-            description = "list_id must be UUIDv4."
-            raise InvalidParameterError(description=description)
-        return request_json
-
-
-class TokenHoldersCollectionId(BaseResource):
-
-    def on_get(self, req: Request, res: Response, *args, **kwargs):
-        """Token holders collection Id"""
-        LOG.info("v3.token.TokenHoldersCollectionId(GET)")
-        contract_address = kwargs.get("contract_address", "")
-        list_id = kwargs.get("list_id", "")
-
-        # 入力アドレスフォーマットチェック
-        try:
-            contract_address = to_checksum_address(contract_address)
-            if not Web3.isAddress(contract_address):
-                description = 'invalid contract_address'
-                raise InvalidParameterError(description=description)
-        except:
-            description = 'invalid contract_address'
-            raise InvalidParameterError(description=description)
-        # 入力IDフォーマットチェック
-        try:
-            if not uuid.UUID(list_id).version == 4:
-                description = "list_id must be UUIDv4."
-                raise InvalidParameterError(description=description)
-        except:
-            description = "list_id must be UUIDv4."
-            raise InvalidParameterError(description=description)
-
-        session: Session = req.context["session"]
-
-        # 取扱トークンチェック
-        # NOTE:非公開トークンも取扱対象とする
-        listed_token = session.query(Listing).\
-            filter(Listing.token_address == contract_address).\
-            first()
-        if listed_token is None:
-            raise DataNotExistsError('contract_address: %s' % contract_address)
-
-        # 既存レコードの存在チェック
-        _same_list_id_record: TokenHoldersList = session.query(TokenHoldersList). \
-            filter(TokenHoldersList.list_id == list_id).first()
-
-        if not _same_list_id_record:
-            raise DataNotExistsError("list_id: %s"%list_id)
-        if _same_list_id_record.token_address != contract_address:
-            description = "list_id: %s is not collection for contract_address: %s"%(list_id, contract_address)
-            raise InvalidParameterError(description=description)
-
-        holders = []
-        if _same_list_id_record.batch_status == BatchStatus.PENDING.value:
-            return self.on_success(res, {
-                "status": _same_list_id_record.batch_status,
-                "holders": holders
-            })
-
-        token_holders = session.query(TokenHolder).filter(TokenHolder.holder_list_id == _same_list_id_record.id).all()
-
-        for th in token_holders:
-            holders.append(th.account_address)
-
-        return self.on_success(res, {
-            "status": _same_list_id_record.batch_status,
-            "holders": holders
-        })

--- a/app/api/v2/token.py
+++ b/app/api/v2/token.py
@@ -1744,7 +1744,7 @@ class TokenHoldersCollectionId(BaseResource):
                 "holders": holders
             })
 
-        token_holders = session.query(TokenHolder).filter(TokenHolder.holder_list == _same_list_id_record.id).all()
+        token_holders = session.query(TokenHolder).filter(TokenHolder.holder_list_id == _same_list_id_record.id).all()
 
         for th in token_holders:
             holders.append(th.account_address)

--- a/app/api/v2/token.py
+++ b/app/api/v2/token.py
@@ -1617,7 +1617,7 @@ class TokenHoldersCollection(BaseResource):
             raise InvalidParameterError("Invalid contract address")
 
         # ブロックナンバーのチェック
-        if block_number > web3.eth.blockNumber:
+        if block_number > web3.eth.blockNumber or block_number < 1:
             raise InvalidParameterError("Block number must be current or past one.")
 
         # 取扱トークンチェック

--- a/app/main.py
+++ b/app/main.py
@@ -109,6 +109,8 @@ class App(falcon.App):
         self.add_route('/v2/Token/Coupon/{contract_address}', v2_token.CouponTokenDetails())
         self.add_route('/v2/Token/{contract_address}/Status', v2_token.TokenStatus())
         self.add_route('/v2/Token/{contract_address}/Holders', v2_token.TokenHolders())
+        self.add_route('/v2/Token/{contract_address}/Holders/Collection', v2_token.TokenHoldersCollection())
+        self.add_route('/v2/Token/{contract_address}/Holders/Collection/{list_id}', v2_token.TokenHoldersCollectionId())
         self.add_route('/v2/Token/{contract_address}/TransferHistory', v2_token.TransferHistory())
         self.add_route('/v2/Token/{contract_address}/TransferApprovalHistory', v2_token.TransferApprovalHistory())
 

--- a/app/model/db/__init__.py
+++ b/app/model/db/__init__.py
@@ -34,3 +34,8 @@ from .idx_agreement import (
 )
 from .idx_consume_coupon import IDXConsumeCoupon
 from .idx_position import IDXPosition
+from .tokenholders import (
+    TokenHoldersList,
+    TokenHolderBatchStatus,
+    TokenHolder
+)

--- a/app/model/db/tokenholders.py
+++ b/app/model/db/tokenholders.py
@@ -1,0 +1,77 @@
+"""
+Copyright BOOSTRY Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+from enum import Enum
+
+from sqlalchemy import (
+    Column,
+    String,
+    BigInteger,
+)
+
+from app.model.db import Base
+
+
+class TokenHoldersList(Base):
+    """DEX Agreement Events (INDEX)"""
+    __tablename__ = "token_holders_list"
+
+    id = Column(BigInteger, primary_key=True, autoincrement=True)
+    # Token Address
+    token_address = Column(String(42))
+    # Block Number
+    block_number = Column(BigInteger)
+    # List id (UUID)
+    list_id = Column(String(36), index=False)
+    # batch processing status
+    batch_status = Column(String(256))
+
+
+class BatchStatus(Enum):
+    PENDING = "pending"
+    DONE = "done"
+    FAILED = "failed"
+
+
+class TokenHolder(Base):
+    """Token Holder (INDEX)"""
+    __tablename__ = "token_holder"
+
+    # Related list primary key
+    holder_list = Column(BigInteger, primary_key=True)
+
+    # Account Address
+    account_address = Column(String(42), primary_key=True)
+
+    # Amounts
+    balance = Column(BigInteger)
+    pending_transfer = Column(BigInteger)
+    exchange_balance = Column(BigInteger)
+    exchange_commitment = Column(BigInteger)
+
+    FIELDS = {
+        "holder_list": int,
+        "account_address": str,
+        "balance": int,
+        "pending_transfer": int,
+        "exchange_balance": int,
+        "exchange_commitment": int,
+    }
+
+    FIELDS.update(Base.FIELDS)
+

--- a/app/model/db/tokenholders.py
+++ b/app/model/db/tokenholders.py
@@ -58,28 +58,19 @@ class TokenHolder(Base):
     # Account Address
     account_address = Column(String(42), primary_key=True)
 
-    # Amounts
-    balance = Column(BigInteger)
-    pending_transfer = Column(BigInteger)
-    exchange_balance = Column(BigInteger)
-    exchange_commitment = Column(BigInteger)
+    # Amounts(including balance/pending_transfer/exchange_balance/exchange_commitment)
+    hold_balance = Column(BigInteger)
 
     def json(self):
         return {
             "account_address": self.account_address,
-            "balance": self.balance,
-            "pending_transfer": self.pending_transfer,
-            "exchange_balance": self.exchange_balance,
-            "exchange_commitment": self.exchange_commitment,
+            "hold_balance": self.hold_balance
         }
 
     FIELDS = {
         "holder_list_id": int,
         "account_address": str,
-        "balance": int,
-        "pending_transfer": int,
-        "exchange_balance": int,
-        "exchange_commitment": int,
+        "hold_balance": int
     }
 
     FIELDS.update(Base.FIELDS)

--- a/app/model/db/tokenholders.py
+++ b/app/model/db/tokenholders.py
@@ -64,8 +64,17 @@ class TokenHolder(Base):
     exchange_balance = Column(BigInteger)
     exchange_commitment = Column(BigInteger)
 
+    def json(self):
+        return {
+            "account_address": self.account_address,
+            "balance": self.balance,
+            "pending_transfer": self.pending_transfer,
+            "exchange_balance": self.exchange_balance,
+            "exchange_commitment": self.exchange_commitment,
+        }
+
     FIELDS = {
-        "holder_list": int,
+        "holder_list_id": int,
         "account_address": str,
         "balance": int,
         "pending_transfer": int,

--- a/app/model/db/tokenholders.py
+++ b/app/model/db/tokenholders.py
@@ -28,7 +28,7 @@ from app.model.db import Base
 
 
 class TokenHoldersList(Base):
-    """DEX Agreement Events (INDEX)"""
+    """Token Holder List"""
     __tablename__ = "token_holders_list"
 
     id = Column(BigInteger, primary_key=True, autoincrement=True)
@@ -42,14 +42,14 @@ class TokenHoldersList(Base):
     batch_status = Column(String(256))
 
 
-class BatchStatus(Enum):
+class TokenHolderBatchStatus(Enum):
     PENDING = "pending"
     DONE = "done"
     FAILED = "failed"
 
 
 class TokenHolder(Base):
-    """Token Holder (INDEX)"""
+    """Token Holder"""
     __tablename__ = "token_holder"
 
     # Related to TokenHoldersList primary key

--- a/app/model/db/tokenholders.py
+++ b/app/model/db/tokenholders.py
@@ -52,8 +52,8 @@ class TokenHolder(Base):
     """Token Holder (INDEX)"""
     __tablename__ = "token_holder"
 
-    # Related list primary key
-    holder_list = Column(BigInteger, primary_key=True)
+    # Related to TokenHoldersList primary key
+    holder_list_id = Column(BigInteger, primary_key=True)
 
     # Account Address
     account_address = Column(String(42), primary_key=True)

--- a/app/model/db/tokenholders.py
+++ b/app/model/db/tokenholders.py
@@ -74,4 +74,3 @@ class TokenHolder(Base):
     }
 
     FIELDS.update(Base.FIELDS)
-

--- a/batch/indexer_Token_Holders.py
+++ b/batch/indexer_Token_Holders.py
@@ -1,0 +1,729 @@
+"""
+Copyright BOOSTRY Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+from enum import Enum
+from typing import Optional, List, Dict
+import os
+import sys
+import time
+
+from web3.contract import (
+    Contract,
+)
+
+from sqlalchemy import create_engine
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
+import log
+from app.model.db.tokenholders import TokenHoldersList, BatchStatus, TokenHolder
+from app.contracts import Contract as ContractOperator
+from batch.lib.token_list import TokenList
+
+from app import config
+from app.config import (
+    DATABASE_URL,
+    ZERO_ADDRESS,
+)
+from app.errors import ServiceUnavailable
+from app.utils.web3_utils import Web3Wrapper
+
+path = os.path.join(os.path.dirname(__file__), "../")
+sys.path.append(path)
+
+process_name = "INDEXER-TOKENHOLDER"
+LOG = log.get_logger(process_name=process_name)
+
+web3 = Web3Wrapper()
+db_engine = create_engine(DATABASE_URL, echo=False, pool_pre_ping=True)
+
+
+class TokenType(Enum):
+    IbetStraightBond = "IbetStraightBond"
+    IbetShare = "IbetShare"
+    IbetCoupon = "IbetCoupon"
+    IbetMembership = "IbetMembership"
+
+
+class Processor:
+    """Processor for collecting Token Holders at given block number and token."""
+
+    class BalanceBook:
+        pages: Dict[str, TokenHolder]
+
+        def __init__(self):
+            self.pages = {}
+
+        def store(self, account_address: str, balance: int = 0, pending_transfer: int = 0, exchange_balance: int = 0, exchange_commitment: int = 0):
+            if account_address not in self.pages:
+                token_holder = TokenHolder()
+                token_holder.balance = balance
+                token_holder.pending_transfer = pending_transfer
+                token_holder.exchange_balance = exchange_balance
+                token_holder.exchange_commitment = exchange_commitment
+                token_holder.account_address = account_address
+                self.pages[account_address] = token_holder
+            else:
+                self.pages[account_address].balance += balance
+                self.pages[account_address].pending_transfer += pending_transfer
+                self.pages[account_address].exchange_balance += exchange_balance
+                self.pages[account_address].exchange_commitment += exchange_commitment
+
+    target: Optional[TokenHoldersList]
+    token_category: Optional[TokenType]
+    balance_book: BalanceBook
+
+    tradable_exchange_address: str
+    token_owner_address: str
+
+    block_from: int
+    block_to: int
+    checkpoint_used: bool
+
+    def __init__(self):
+        self.target = None
+        self.token_category = None
+        self.balance_book = self.BalanceBook()
+        self.tradable_exchange_address = ""
+        self.checkpoint_used = False
+
+    @staticmethod
+    def __get_db_session() -> Session:
+        return Session(autocommit=False, autoflush=True, bind=db_engine)
+
+    def __load_target(self, db_session: Session) -> bool:
+        self.target: TokenHoldersList = (
+            db_session.query(TokenHoldersList)
+            .filter(TokenHoldersList.batch_status == BatchStatus.PENDING.value)
+            .first()
+        )
+        return True if self.target else False
+
+    def __load_token_info(self) -> bool:
+        # Fetch token list information from TokenList Contract
+        list_contract = ContractOperator.get_contract(
+            contract_name="TokenList", address=config.TOKEN_LIST_CONTRACT_ADDRESS
+        )
+        token_info = TokenList(list_contract).get_token(self.target.token_address)
+        if token_info[1] == "" or token_info[1] not in [t.value for t in TokenType]:
+            return False
+        self.token_category = TokenType(token_info[1])
+        self.token_owner_address = token_info[2]
+        # Fetch token contract.
+        self.token_contract = ContractOperator.get_contract(
+            contract_name=self.token_category.value, address=self.target.token_address
+        )
+        # Fetch current tradable exchange.
+        self.tradable_exchange_address = ContractOperator.call_function(
+            contract=self.token_contract,
+            function_name="tradableExchange",
+            args=(),
+            default_returns=ZERO_ADDRESS,
+        )
+        return True
+
+    def __load_checkpoint(self, local_session: Session) -> bool:
+        _checkpoint: Optional[TokenHoldersList] = local_session.query(TokenHoldersList).\
+            filter(TokenHoldersList.token_address == self.target.token_address).\
+            filter(TokenHoldersList.block_number < self.target.block_number).\
+            filter(TokenHoldersList.batch_status == BatchStatus.DONE.value).\
+            order_by(TokenHoldersList.block_number.desc()).first()
+        if _checkpoint:
+            _holders: List[TokenHolder] = local_session.query(TokenHolder).filter(TokenHolder.holder_list == _checkpoint.id).all()
+            for holder in _holders:
+                self.balance_book.store(
+                    account_address = holder.account_address,
+                    balance= holder.balance,
+                    pending_transfer= holder.pending_transfer,
+                    exchange_balance= holder.exchange_balance,
+                    exchange_commitment= holder.exchange_commitment
+                )
+            self.block_from = _checkpoint.block_number + 1
+            self.checkpoint_used = True
+        return True
+
+    def collect(self):
+        local_session = self.__get_db_session()
+        try:
+            if not self.__load_target(local_session):
+                LOG.debug(f"There are no pending collect batch")
+                return
+            if not self.__load_token_info():
+                LOG.debug(f"Token contract must be listed to TokenList contract.")
+                self.__update_status(local_session, BatchStatus.FAILED)
+                local_session.commit()
+                return
+            self.block_from = 0
+            self.block_to = self.target.block_number
+            self.__load_checkpoint(local_session)
+            self.__sync_all(local_session, self.block_from, self.block_to)
+            self.__update_status(local_session, BatchStatus.DONE)
+            local_session.commit()
+        except Exception as e:
+            self.__update_status(local_session, BatchStatus.FAILED)
+            local_session.commit()
+        finally:
+            local_session.close()
+            LOG.info(f"<{process_name}> Collect job has been completed")
+
+    def __update_status(self, local_session: Session, status: BatchStatus):
+        self.target.batch_status = status.value
+        local_session.merge(self.target)
+        LOG.info(f"Token holder list({self.target.list_id}) status changes to be {status.value}.")
+
+        self.target = None
+        self.token_category = None
+        self.balance_book = self.BalanceBook()
+        self.tradable_exchange_address = ""
+        self.block_from = 0
+        self.checkpoint_used = False
+
+    def __sync_all(self, db_session: Session, block_from: int, block_to: int):
+        LOG.info("syncing from={}, to={}".format(block_from, block_to))
+        target_contract = self.token_contract
+
+        if target_contract:
+            self.__sync_transfer(block_from, block_to, target_contract)
+            self.__sync_exchange(block_from, block_to)
+            self.__sync_escrow(block_from, block_to)
+
+            if self.token_category in [TokenType.IbetStraightBond, TokenType.IbetShare]:
+                self.__sync_issue(block_from, block_to, target_contract)
+                self.__sync_redeem(block_from, block_to, target_contract)
+                self.__sync_lock(block_from, block_to, target_contract)
+                self.__sync_unlock(block_from, block_to, target_contract)
+                self.__sync_apply_for_transfer(block_from, block_to, target_contract)
+                self.__sync_cancel_transfer(block_from, block_to, target_contract)
+                self.__sync_approve_transfer(block_from, block_to, target_contract)
+
+            if self.token_category == TokenType.IbetCoupon:
+                self.__sync_consume(block_from, block_to, target_contract)
+
+            self.__save_holders(db_session, self.balance_book, self.target.id, self.target.token_address, self.token_owner_address)
+
+    def __sync_transfer(self, block_from: int, block_to: int, token: Contract):
+        """Sync Transfer Events
+
+        :param block_from: From block
+        :param block_to: To block
+        :param token: Token contract
+        :return: None
+        """
+        try:
+            events = token.events.Transfer.getLogs(fromBlock=block_from, toBlock=block_to)
+            for event in events:
+                args = event["args"]
+                _from = args.get("from", ZERO_ADDRESS)
+                _to = args.get("to", ZERO_ADDRESS)
+                _value = args.get("value", 0)
+
+                _from_exchange = _from == self.tradable_exchange_address
+                _to_exchange = _to == self.tradable_exchange_address
+                if _from_exchange and not _to_exchange:
+                    # exchange_address -> token_address => withdraw from exchange
+                    self.balance_book.store(
+                        account_address=_to,
+                        balance=+_value,
+                        exchange_balance=-_value
+                    )
+                elif not _from_exchange and _to_exchange:
+                    # token_address -> exchange_address => deposit to exchange
+                    self.balance_book.store(
+                        account_address=_from,
+                        balance=-_value,
+                        exchange_balance=+_value
+                    )
+                else:
+                    # token_address -> token_address => transfer
+                    self.balance_book.store(
+                        account_address=_from,
+                        balance=-_value,
+                    )
+                    self.balance_book.store(
+                        account_address=_to,
+                        balance=+_value,
+                    )
+        except Exception as e:
+            LOG.exception(e)
+
+    def __sync_consume(self, block_from: int, block_to: int, token: Contract):
+        """Sync Consume Events
+
+        :param block_from: From block
+        :param block_to: To block
+        :param token: Token contract
+        :return: None
+        """
+        try:
+            events = token.events.Consume.getLogs(fromBlock=block_from, toBlock=block_to)
+            for event in events:
+                args = event["args"]
+                _consumer = args.get("consumer", ZERO_ADDRESS)
+                _balance = args.get("balance", ZERO_ADDRESS)
+                _used = args.get("used", 0)
+                self.balance_book.store(
+                    account_address=_consumer,
+                    balance=-_used,
+                )
+        except Exception as e:
+            LOG.exception(e)
+
+    def __sync_lock(self, block_from: int, block_to: int, token: Contract):
+        """Sync Lock Events
+
+        :param block_from: From block
+        :param block_to: To block
+        :param token: Token contract
+        :return: None
+        """
+
+        try:
+            events = token.events.Lock.getLogs(fromBlock=block_from, toBlock=block_to)
+            for event in events:
+                # event Lock(
+                #     address indexed accountAddress,
+                #     address indexed lockAddress,
+                #     uint256 value
+                # );
+                # accountAddress
+                #   tokenBalance.sub(value)
+                #   lockedTokenBalance.add(value)
+                args = event["args"]
+                _account_address = args.get("accountAddress", ZERO_ADDRESS)
+                _lock_address = args.get("lockAddress", ZERO_ADDRESS)
+                _value = args.get("value", 0)
+                self.balance_book.store(
+                    account_address=_account_address,
+                    balance=-_value,
+                )
+        except Exception as e:
+            LOG.exception(e)
+
+    def __sync_unlock(self, block_from: int, block_to: int, token: Contract):
+        """Sync Unlock Events
+
+        :param block_from: From block
+        :param block_to: To block
+        :param token: Token contract
+        :return: None
+        """
+
+        try:
+            events = token.events.Unlock.getLogs(fromBlock=block_from, toBlock=block_to)
+            for event in events:
+                args = event["args"]
+                _account_address = args.get("accountAddress", ZERO_ADDRESS)
+                _lock_address = args.get("lockAddress", ZERO_ADDRESS)
+                _recipient_address = args.get("recipientAddress", ZERO_ADDRESS)
+                _value = args.get("value", 0)
+                self.balance_book.store(
+                    account_address=_recipient_address,
+                    balance=+_value,
+                )
+        except Exception as e:
+            LOG.exception(e)
+
+    def __sync_issue(self, block_from: int, block_to: int, token: Contract):
+        """Sync Issue Events
+
+        :param block_from: From block
+        :param block_to: To block
+        :param token: Token contract
+        :return: None
+        """
+        try:
+            events = token.events.Issue.getLogs(fromBlock=block_from, toBlock=block_to)
+            for event in events:
+                args = event["args"]
+                _from = args.get("from", ZERO_ADDRESS)
+                _target_address = args.get("targetAddress", ZERO_ADDRESS)
+                _lock_address = args.get("lockAddress", ZERO_ADDRESS)
+                _amount = args.get("amount", 0)
+                if _target_address == self.token_owner_address:
+                    pass
+                elif _lock_address == config.ZERO_ADDRESS:
+                    self.balance_book.store(
+                        account_address=_target_address,
+                        balance=+_amount,
+                    )
+        except Exception as e:
+            LOG.exception(e)
+
+    def __sync_redeem(self, block_from: int, block_to: int, token: Contract):
+        """Sync Redeem Events
+
+        :param block_from: From block
+        :param block_to: To block
+        :param token: Token contract
+        :return: None
+        """
+        try:
+            events = token.events.Redeem.getLogs(fromBlock=block_from, toBlock=block_to)
+
+            for event in events:
+                args = event["args"]
+                _from = args.get("from", ZERO_ADDRESS)
+                _target_address = args.get("targetAddress", ZERO_ADDRESS)
+                _lock_address = args.get("lockAddress", ZERO_ADDRESS)
+                _amount = args.get("amount", 0)
+                if _target_address == self.token_owner_address:
+                    pass
+                elif _lock_address == config.ZERO_ADDRESS:
+                    self.balance_book.store(
+                        account_address=_target_address,
+                        balance=-_amount,
+                    )
+        except Exception as e:
+            LOG.exception(e)
+
+    def __sync_apply_for_transfer(self, block_from: int, block_to: int, token: Contract):
+        """Sync ApplyForTransfer Events
+
+        :param block_from: From block
+        :param block_to: To block
+        :param token: Token contract
+        :return: None
+        """
+        try:
+            events = token.events.ApplyForTransfer.getLogs(fromBlock=block_from, toBlock=block_to)
+            for event in events:
+                args = event["args"]
+                _from = args.get("from", ZERO_ADDRESS)
+                _to = args.get("to", ZERO_ADDRESS)
+                _value = int(args.get("value", 0))
+                self.balance_book.store(
+                    account_address=_from,
+                    balance=-_value,
+                    pending_transfer=+_value
+                )
+        except Exception as e:
+            LOG.exception(e)
+
+    def __sync_cancel_transfer(self, block_from: int, block_to: int, token: Contract):
+        """Sync CancelTransfer Events
+
+        :param block_from: From block
+        :param block_to: To block
+        :param token: Token contract
+        :return: None
+        """
+        try:
+            events = token.events.CancelTransfer.getLogs(fromBlock=block_from, toBlock=block_to)
+            for event in events:
+                args = event["args"]
+                _index = args.get("index", ZERO_ADDRESS)
+                _from = args.get("from", ZERO_ADDRESS)
+                _to = args.get("to", ZERO_ADDRESS)
+                _, _, _value, _ = ContractOperator.call_function(
+                    contract=token, function_name="applicationsForTransfer", args=(_index,)
+                )
+                self.balance_book.store(
+                    account_address=_from,
+                    balance=+_value,
+                    pending_transfer=-_value
+                )
+        except Exception as e:
+            LOG.exception(e)
+
+    def __sync_approve_transfer(self, block_from: int, block_to: int, token: Contract):
+        """Sync ApproveTransfer Events
+
+        :param block_from: From block
+        :param block_to: To block
+        :param token: Token contract
+        :return: None
+        """
+        try:
+            events = token.events.ApproveTransfer.getLogs(fromBlock=block_from, toBlock=block_to)
+            for event in events:
+                args = event["args"]
+                _from = args.get("from", ZERO_ADDRESS)
+                _to = args.get("to", ZERO_ADDRESS)
+                _index = args.get("index", 0)
+                _, _, _value, _ = ContractOperator.call_function(
+                    contract=token, function_name="applicationsForTransfer", args=(_index,)
+                )
+                self.balance_book.store(
+                    account_address=_from,
+                    balance=+_value,
+                    pending_transfer=-_value
+                )
+        except Exception as e:
+            LOG.exception(e)
+
+    def __sync_exchange(self, block_from: int, block_to: int):
+        """Sync Events from IbetExchange
+
+        :param block_from: From block
+        :param block_to: To block
+        :return: None
+        """
+        exchange_address = self.tradable_exchange_address
+        try:
+            exchange = ContractOperator.get_contract(contract_name="IbetExchange", address=exchange_address)
+
+            # NewOrder event
+            _event_list = exchange.events.NewOrder.getLogs(fromBlock=block_from, toBlock=block_to)
+            for _event in _event_list:
+                args = _event["args"]
+                _token_address = args.get("tokenAddress", ZERO_ADDRESS)
+                if _token_address == self.target.token_address:
+                    _account_address = args.get("accountAddress", ZERO_ADDRESS)
+                    _is_buy = args.get("isBuy", False)
+                    _amount = args.get("amount", 0)
+                    if not _is_buy:
+                        # If order is made by sell side, seller assets is committed.
+                        self.balance_book.store(
+                            account_address=_account_address,
+                            exchange_balance=-_amount,
+                            exchange_commitment=+_amount,
+                        )
+
+            # CancelOrder event
+            _event_list = exchange.events.CancelOrder.getLogs(fromBlock=block_from, toBlock=block_to)
+            for _event in _event_list:
+                args = _event["args"]
+                _token_address = args.get("tokenAddress", ZERO_ADDRESS)
+                if _token_address == self.target.token_address:
+                    _account_address = args.get("accountAddress", ZERO_ADDRESS)
+                    _is_buy = args.get("isBuy", False)
+                    _amount = args.get("amount", 0)
+                    if not _is_buy:
+                        # If order made by sell side is cancelled, seller commitment is released.
+                        self.balance_book.store(
+                            account_address=_account_address,
+                            exchange_balance=+_amount,
+                            exchange_commitment=-_amount,
+                        )
+            # ForceCancelOrder event
+            _event_list = exchange.events.ForceCancelOrder.getLogs(fromBlock=block_from, toBlock=block_to)
+            for _event in _event_list:
+                args = _event["args"]
+                _token_address = args.get("tokenAddress", ZERO_ADDRESS)
+                if _token_address == self.target.token_address:
+                    _account_address = args.get("accountAddress", ZERO_ADDRESS)
+                    _is_buy = args.get("isBuy", False)
+                    _amount = args.get("amount", 0)
+                    if not _is_buy:
+                        # If order made by sell side is cancelled, seller commitment is released.
+                        self.balance_book.store(
+                            account_address=_account_address,
+                            exchange_balance=+_amount,
+                            exchange_commitment=-_amount,
+                        )
+            # Agree event
+            _event_list = exchange.events.Agree.getLogs(fromBlock=block_from, toBlock=block_to)
+            for _event in _event_list:
+                args = _event["args"]
+                _token_address = args.get("tokenAddress", ZERO_ADDRESS)
+                if _token_address == self.target.token_address:
+                    _sell_address = args.get("sellAddress", ZERO_ADDRESS)
+                    _amount = args.get("amount", 0)
+                    _order_id = args.get("orderId", 0)
+                    _, _, _, _, _order_is_buy, _, _ = ContractOperator.call_function(
+                        contract=exchange, function_name="getOrder", args=(_order_id,)
+                    )
+                    if _order_is_buy:
+                        # If order is taken by sell side, seller assets must be committed.
+                        self.balance_book.store(
+                            account_address=_sell_address,
+                            exchange_balance=-_amount,
+                            exchange_commitment=+_amount,
+                        )
+            # SettlementOK event
+            _event_list = exchange.events.SettlementOK.getLogs(fromBlock=block_from, toBlock=block_to)
+            for _event in _event_list:
+                args = _event["args"]
+                _token_address = args.get("tokenAddress", ZERO_ADDRESS)
+                if _token_address == self.target.token_address:
+                    # If settlementOK is emitted, seller commitment must be subtracted.
+                    _buy_address = args.get("buyAddress", ZERO_ADDRESS)
+                    _sell_address = args.get("sellAddress", ZERO_ADDRESS)
+                    _amount = args.get("amount", 0)
+                    self.balance_book.store(
+                        account_address=_sell_address,
+                        exchange_commitment=-_amount,
+                    )
+                    self.balance_book.store(
+                        account_address=_buy_address,
+                        exchange_balance=+_amount,
+                    )
+            # SettlementNG event
+            _event_list = exchange.events.SettlementNG.getLogs(fromBlock=block_from, toBlock=block_to)
+            for _event in _event_list:
+                args = _event["args"]
+                _token_address = args.get("tokenAddress", ZERO_ADDRESS)
+                if _token_address == self.target.token_address:
+                    _order_id = args.get("orderId", ZERO_ADDRESS)
+                    (
+                        _maker_address,
+                        _token_address,
+                        _,
+                        _,
+                        _order_is_buy,
+                        _,
+                        _,
+                    ) = ContractOperator.call_function(
+                        contract=exchange, function_name="getOrder", args=(_order_id,)
+                    )
+                    if _order_is_buy:
+                        # If settlementNG is emitted, seller commitment must be released.
+                        _sell_address = args.get("sellAddress", ZERO_ADDRESS)
+                        _buy_address = args.get("buyAddress", ZERO_ADDRESS)
+                        _amount = args.get("amount", 0)
+                        self.balance_book.store(
+                            account_address=_sell_address,
+                            exchange_balance=+_amount,
+                            exchange_commitment=-_amount,
+                        )
+        except Exception as e:
+            LOG.exception(e)
+
+    def __sync_escrow(self, block_from: int, block_to: int):
+        """Sync Events from IbetSecurityTokenEscrow/IbetEscrow
+
+        :param block_from: From block
+        :param block_to: To block
+        :return: None
+        """
+        exchange_address = self.tradable_exchange_address
+        escrow_type = "IbetSecurityTokenEscrow"
+        if self.token_category in [TokenType.IbetCoupon, TokenType.IbetMembership]:
+            escrow_type = "IbetEscrow"
+        try:
+            escrow = ContractOperator.get_contract(escrow_type, exchange_address)
+            _event_list = escrow.events.EscrowCreated.getLogs(fromBlock=block_from, toBlock=block_to)
+            for _event in _event_list:
+                args = _event["args"]
+                _token_address = args.get("token", ZERO_ADDRESS)
+                if _token_address == self.target.token_address:
+                    # 送り主の銀行残高を拘束する
+                    _account_address = args.get("sender", ZERO_ADDRESS)
+                    _amount = args.get("amount", 0)
+                    self.balance_book.store(
+                        account_address=_account_address,
+                        exchange_balance=-_amount,
+                        exchange_commitment=+_amount,
+                    )
+            # EscrowCanceled event
+            _event_list = escrow.events.EscrowCanceled.getLogs(fromBlock=block_from, toBlock=block_to)
+            for _event in _event_list:
+                args = _event["args"]
+                _token_address = args.get("token", ZERO_ADDRESS)
+                if _token_address == self.target.token_address:
+                    # If EscrowCanceled is emmited, sender commitment must be released.
+                    _account_address = args.get("sender", ZERO_ADDRESS)
+                    _amount = args.get("amount", 0)
+                    self.balance_book.store(
+                        account_address=_account_address,
+                        exchange_balance=+_amount,
+                        exchange_commitment=-_amount,
+                    )
+            # EscrowFinished event
+            _event_list = escrow.events.EscrowFinished.getLogs(fromBlock=block_from, toBlock=block_to)
+            for _event in _event_list:
+                args = _event["args"]
+                _token_address = args.get("token", ZERO_ADDRESS)
+                if _token_address == self.target.token_address:
+                    _transfer_approval_required = args.get("transferApprovalRequired", False)
+                    if not _transfer_approval_required:
+                        # If EscrowCanceled is emmited, sender commitment must be released.
+                        _sender = args.get("sender", ZERO_ADDRESS)
+                        _recipient = args.get("recipient", ZERO_ADDRESS)
+                        _amount = args.get("amount", 0)
+                        self.balance_book.store(
+                            account_address=_recipient,
+                            exchange_balance=+_amount,
+                        )
+                        self.balance_book.store(
+                            account_address=_sender,
+                            exchange_commitment=-_amount
+                        )
+            if escrow_type == "IbetSecurityTokenEscrow":
+                # ApproveTransfer event
+                _event_list = escrow.events.ApproveTransfer.getLogs(fromBlock=block_from, toBlock=block_to)
+                for _event in _event_list:
+                    args = _event["args"]
+                    _token_address = args.get("token", ZERO_ADDRESS)
+                    _escrow_id = args.get("escrowId", ZERO_ADDRESS)
+                    _, _sender, _recipient, _amount, _, _ = ContractOperator.call_function(
+                        contract=escrow, function_name="getEscrow", args=(_escrow_id,)
+                    )
+                    if _token_address == self.target.token_address:
+                        # 送り主の銀行残高拘束を減産し、受け取り側の残高を増やす
+                        self.balance_book.store(
+                            account_address=_recipient,
+                            exchange_balance=+_amount,
+                        )
+                        self.balance_book.store(
+                            account_address=_sender,
+                            exchange_commitment=-_amount
+                        )
+        except Exception as e:
+            LOG.exception(e)
+
+    @staticmethod
+    def __save_holders(db_session: Session, balance_book: BalanceBook, holder_list: int, token_address: str, token_owner_address: str):
+        for account_address, page in zip(balance_book.pages.keys(), balance_book.pages.values()):
+            if page.account_address == token_owner_address:
+                continue
+            token_holder: TokenHolder = (
+                db_session.query(TokenHolder)
+                .filter(TokenHolder.holder_list == holder_list)
+                .filter(TokenHolder.account_address == account_address)
+                .first()
+            )
+            if token_holder is not None:
+                if page.balance is not None:
+                    token_holder.balance += page.balance
+                if page.pending_transfer is not None:
+                    token_holder.pending_transfer += page.pending_transfer
+                if page.exchange_balance is not None:
+                    token_holder.exchange_balance += page.exchange_balance
+                if page.exchange_commitment is not None:
+                    token_holder.exchange_commitment += page.exchange_commitment
+                db_session.merge(token_holder)
+            elif any(
+                value is not None and value > 0
+                for value in [page.balance, page.pending_transfer, page.exchange_balance, page.exchange_commitment]
+            ):
+                LOG.debug(
+                    f"Collection record created : token_address={token_address}, account_address={account_address}"
+                )
+                page.holder_list = holder_list
+                db_session.add(page)
+
+def main():
+    LOG.info("Service started successfully")
+    processor = Processor()
+    processor.collect()
+    while True:
+        try:
+            processor.collect()
+            LOG.debug("Processed")
+        except ServiceUnavailable:
+            LOG.warning("An external service was unavailable")
+        except SQLAlchemyError as sa_err:
+            LOG.error(f"A database error has occurred: code={sa_err.code}\n{sa_err}")
+        except Exception as ex:
+            LOG.exception(ex)
+
+        time.sleep(10)
+
+
+if __name__ == "__main__":
+    main()

--- a/batch/indexer_Token_Holders.py
+++ b/batch/indexer_Token_Holders.py
@@ -30,6 +30,10 @@ from sqlalchemy import create_engine
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 import log
+
+path = os.path.join(os.path.dirname(__file__), "../")
+sys.path.append(path)
+
 from app.model.db.tokenholders import TokenHoldersList, BatchStatus, TokenHolder
 from app.contracts import Contract as ContractOperator
 from batch.lib.token_list import TokenList
@@ -41,9 +45,6 @@ from app.config import (
 )
 from app.errors import ServiceUnavailable
 from app.utils.web3_utils import Web3Wrapper
-
-path = os.path.join(os.path.dirname(__file__), "../")
-sys.path.append(path)
 
 process_name = "INDEXER-TOKEN_HOLDERS"
 LOG = log.get_logger(process_name=process_name)
@@ -691,7 +692,6 @@ class Processor:
 def main():
     LOG.info("Service started successfully")
     processor = Processor()
-    processor.collect()
     while True:
         try:
             processor.collect()

--- a/batch/indexer_Token_Holders.py
+++ b/batch/indexer_Token_Holders.py
@@ -155,7 +155,7 @@ class Processor:
             .first()
         )
         if _checkpoint:
-            _holders: List[TokenHolder] = local_session.query(TokenHolder).filter(TokenHolder.holder_list == _checkpoint.id).all()
+            _holders: List[TokenHolder] = local_session.query(TokenHolder).filter(TokenHolder.holder_list_id == _checkpoint.id).all()
             for holder in _holders:
                 self.balance_book.store(
                     account_address=holder.account_address,
@@ -658,14 +658,14 @@ class Processor:
 
     @staticmethod
     def __save_holders(
-        db_session: Session, balance_book: BalanceBook, holder_list: int, token_address: str, token_owner_address: str
+        db_session: Session, balance_book: BalanceBook, holder_list_id: int, token_address: str, token_owner_address: str
     ):
         for account_address, page in zip(balance_book.pages.keys(), balance_book.pages.values()):
             if page.account_address == token_owner_address:
                 continue
             token_holder: TokenHolder = (
                 db_session.query(TokenHolder)
-                .filter(TokenHolder.holder_list == holder_list)
+                .filter(TokenHolder.holder_list_id == holder_list_id)
                 .filter(TokenHolder.account_address == account_address)
                 .first()
             )
@@ -684,7 +684,7 @@ class Processor:
                 for value in [page.balance, page.pending_transfer, page.exchange_balance, page.exchange_commitment]
             ):
                 LOG.debug(f"Collection record created : token_address={token_address}, account_address={account_address}")
-                page.holder_list = holder_list
+                page.holder_list_id = holder_list_id
                 db_session.add(page)
 
 

--- a/batch/indexer_Token_Holders.py
+++ b/batch/indexer_Token_Holders.py
@@ -45,7 +45,7 @@ from app.utils.web3_utils import Web3Wrapper
 path = os.path.join(os.path.dirname(__file__), "../")
 sys.path.append(path)
 
-process_name = "INDEXER-TOKENHOLDER"
+process_name = "INDEXER-TOKEN_HOLDERS"
 LOG = log.get_logger(process_name=process_name)
 
 web3 = Web3Wrapper()

--- a/bin/healthcheck_indexer.sh
+++ b/bin/healthcheck_indexer.sh
@@ -22,6 +22,7 @@ if [[ "${APP_ENV:-}" != "local" && "${COMPANY_LIST_LOCAL_MODE:-}" -ne 1 ]]; then
 fi
 
 PROC_LIST="${PROC_LIST} batch/indexer_Transfer.py"
+PROC_LIST="${PROC_LIST} batch/indexer_Token_Holders.py"
 
 if [ "${SHARE_TOKEN_ENABLED}" = 1 ]; then
   PROC_LIST="${PROC_LIST} batch/indexer_Position_Share.py"

--- a/bin/run_indexer.sh
+++ b/bin/run_indexer.sh
@@ -39,6 +39,7 @@ if [[ "${APP_ENV:-}" != "local" && "${COMPANY_LIST_LOCAL_MODE:-}" -ne 1 ]]; then
 fi
 
 python batch/indexer_Transfer.py &
+python batch/indexer_Token_Holders.py &
 
 if [ $SHARE_TOKEN_ENABLED = 1 ]; then
   python batch/indexer_Position_Share.py &

--- a/docs/ibet_wallet_api_v2.yaml
+++ b/docs/ibet_wallet_api_v2.yaml
@@ -2002,7 +2002,6 @@ paths:
         description: token address
     post:
       tags:
-        - "Holder"
         - "Token"
       summary: "Execute Batch Getting Token Holders At Specific BlockNumber"
       operationId: "TokenHolderListAtSpecificBlockNumber"
@@ -2037,6 +2036,10 @@ paths:
                     description: |
                       Unique id to be assigned to each token holder list.
                       This must be Version4 UUID.
+                      eg.
+                      ```
+                      cfd83622-34dc-4efe-a68b-2cc275d3d824
+                      ```
                       If existing combinations of block_number and contract_address is given, 
                       existing list_id will be returned.
                     type: string
@@ -2072,9 +2075,12 @@ paths:
         description:  |
           Unique id to be assigned to each token holder list.
           This must be Version4 UUID.
+          eg.
+          ```
+          cfd83622-34dc-4efe-a68b-2cc275d3d824
+          ```
     get:
       tags:
-        - "Holder"
         - "Token"
       summary: "Token Holder At Specific BlockNumber"
       operationId: "TokenHolderList"

--- a/docs/ibet_wallet_api_v2.yaml
+++ b/docs/ibet_wallet_api_v2.yaml
@@ -1993,6 +1993,131 @@ paths:
             properties:
               meta:
                 $ref: "#/definitions/404NotFoundError"
+  /Token/{contract_address}/Holders/Collection:
+    parameters:
+      - type: string
+        name: contract_address
+        in: path
+        required: true
+        description: token address
+    post:
+      tags:
+        - "Holder"
+        - "Token"
+      summary: "Execute Batch Getting Token Holders At Specific BlockNumber"
+      operationId: "TokenHolderListAtSpecificBlockNumber"
+      parameters:
+        - name: "body"
+          in: "body"
+          required: true
+          schema:
+            type: "object"
+            properties:
+              list_id:
+                description: |
+                  Unique id to be assigned to each token holder list.
+                  This must be Version4 UUID.
+                example: "cfd83622-34dc-4efe-a68b-2cc275d3d824"
+                type: string
+              block_number:
+                description: block number
+                type: integer
+      responses:
+        200:
+          description: Successful Operation
+          schema:
+            type: object
+            properties:
+              meta:
+                $ref: "#/definitions/200Success"
+              data:
+                type: object
+                properties:
+                  list_id:
+                    description: |
+                      Unique id to be assigned to each token holder list.
+                      This must be Version4 UUID.
+                      If existing combinations of block_number and contract_address is given, 
+                      existing list_id will be returned.
+                    type: string
+                  status:
+                    description: status code of batch job
+                    type: string
+                    enum: [pending, done, failed]
+        400:
+          description: Invalid Parameter Error
+          schema:
+            type: object
+            properties:
+              meta:
+                $ref: "#/definitions/400InvalidParameterError"
+        404:
+          description: Not Found Error
+          schema:
+            type: object
+            properties:
+              meta:
+                $ref: "#/definitions/404NotFoundError"
+  /Token/{contract_address}/Holders/Collections/{list_id}:
+    parameters:
+      - type: string
+        name: contract_address
+        in: path
+        required: true
+        description: token address
+      - type: string
+        name: list_id
+        in: path
+        required: true
+        description:  |
+          Unique id to be assigned to each token holder list.
+          This must be Version4 UUID.
+    get:
+      tags:
+        - "Holder"
+        - "Token"
+      summary: "Token Holder At Specific BlockNumber"
+      operationId: "TokenHolderList"
+      responses:
+        200:
+          description: Successful Operation
+          schema:
+            type: object
+            properties:
+              meta:
+                $ref: "#/definitions/200Success"
+              data:
+                type: object
+                properties:
+                  result_set:
+                    description: Result set
+                    type: object
+                    properties:
+                      status:
+                        description: status code of batch job
+                        type: string
+                        enum: [pending, done, failed]
+                      holders:
+                        description: | 
+                          Token holder address list.
+                          This list is excluding token owner address.
+                        type: array
+                        items:
+                          type: string
+        400:
+          description: Invalid Parameter Error
+          schema:
+            type: object
+            properties:
+              meta:
+                $ref: "#/definitions/400InvalidParameterError"
+        404:
+          description: Not Found Error
+          schema:
+            type: object
+            properties:
+              meta:
+                $ref: "#/definitions/404NotFoundError"
   /Token/{contract_address}/TransferHistory:
     parameters:
       - type: string

--- a/docs/ibet_wallet_api_v2.yaml
+++ b/docs/ibet_wallet_api_v2.yaml
@@ -2111,17 +2111,13 @@ paths:
                         items:
                           type: object
                           properties:
-                            balance:
-                              description: Amount of balance
-                              type: integer
-                            pending_transfer:
-                              description: Amount of pending transfer
-                              type: integer
-                            exchange_balance:
-                              description: Amount of balance in exchange
-                              type: integer
-                            exchange_commitment:
-                              description: Amount of commitment in exchange
+                            account_address:
+                              description: Account address of token holder.
+                              type: string
+                            hold_balance:
+                              description: |
+                                Amount of balance.
+                                This includes balance/pending_transfer/exchange_balance/exchange_commitment.
                               type: integer
         400:
           description: Invalid Parameter Error

--- a/docs/ibet_wallet_api_v2.yaml
+++ b/docs/ibet_wallet_api_v2.yaml
@@ -2100,16 +2100,29 @@ paths:
                     type: object
                     properties:
                       status:
-                        description: status code of batch job
+                        description: Status code of token holders list batch job
                         type: string
                         enum: [pending, done, failed]
                       holders:
                         description: | 
-                          Token holder address list.
+                          Token holder list.
                           This list is excluding token owner address.
                         type: array
                         items:
-                          type: string
+                          type: object
+                          properties:
+                            balance:
+                              description: Amount of balance
+                              type: integer
+                            pending_transfer:
+                              description: Amount of pending transfer
+                              type: integer
+                            exchange_balance:
+                              description: Amount of balance in exchange
+                              type: integer
+                            exchange_commitment:
+                              description: Amount of commitment in exchange
+                              type: integer
         400:
           description: Invalid Parameter Error
           schema:

--- a/docs/ibet_wallet_api_v3.yaml
+++ b/docs/ibet_wallet_api_v3.yaml
@@ -1273,9 +1273,11 @@ paths:
           in: query
           description: |
             filter argument. serialize obj to a JSON formatted str required.
-          required: false
-          example: |
+            eg.
+            ```
             {"sender": "0x0000000000000000000000000000000000000000"}
+            ```
+          required: false
           type: string
       responses:
         200:
@@ -1341,12 +1343,14 @@ paths:
           in: query
           description: |
             filter argument. serialize obj to a JSON formatted str required.
-          required: false
-          example: |
+            eg.
+            ```
             {
               "escrowId": 0,
               "token": "0x0000000000000000000000000000000000000000" 
             }
+            ```
+          required: false
           type: string
       responses:
         200:
@@ -1422,12 +1426,14 @@ paths:
           in: query
           description: |
             filter argument. serialize obj to a JSON formatted str required.
-          required: false
-          example: |
+            eg.
+            ```
             {
               "escrowId": 0,
               "token": "0x0000000000000000000000000000000000000000" 
             }
+            ```
+          required: false
           type: string
       responses:
         200:

--- a/migrations/versions/028_create_token_holders_list.py
+++ b/migrations/versions/028_create_token_holders_list.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+import logging
+from datetime import datetime
+
+from sqlalchemy import *
+from sqlalchemy.exc import ProgrammingError
+from migrate import *
+
+
+meta = MetaData()
+
+table = Table(
+    "token_holders_list", meta,
+    Column("id", BigInteger, primary_key=True, autoincrement=True),
+    Column("token_address", String(42)),
+    Column("block_number", BigInteger),
+    Column("list_id", String(36), index=False),
+    Column("batch_status", String(256)),
+    Column("created", DateTime, default=datetime.utcnow),
+    Column("modified", DateTime, default=datetime.utcnow, onupdate=datetime.utcnow),
+)
+
+
+def upgrade(migrate_engine):
+    meta.bind = migrate_engine
+    try:
+        table.create()
+    except sqlalchemy.exc.ProgrammingError as err:
+        logging.warning(err)
+
+
+def downgrade(migrate_engine):
+    meta.bind = migrate_engine
+    table.drop()

--- a/migrations/versions/029_create_token_holder.py
+++ b/migrations/versions/029_create_token_holder.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+import logging
+from datetime import datetime
+
+from sqlalchemy import *
+from sqlalchemy.exc import ProgrammingError
+from migrate import *
+
+
+meta = MetaData()
+
+table = Table(
+    "token_holder", meta,
+    Column("holder_list", BigInteger, primary_key=True),
+    Column("account_address", String(42), primary_key=True),
+    Column("balance", BigInteger),
+    Column("pending_transfer", BigInteger),
+    Column("exchange_balance", BigInteger),
+    Column("exchange_commitment", BigInteger),
+    Column("created", DateTime, default=datetime.utcnow),
+    Column("modified", DateTime, default=datetime.utcnow, onupdate=datetime.utcnow),
+)
+
+
+def upgrade(migrate_engine):
+    meta.bind = migrate_engine
+    try:
+        table.create()
+    except sqlalchemy.exc.ProgrammingError as err:
+        logging.warning(err)
+
+
+def downgrade(migrate_engine):
+    meta.bind = migrate_engine
+    table.drop()

--- a/migrations/versions/029_create_token_holder.py
+++ b/migrations/versions/029_create_token_holder.py
@@ -13,10 +13,7 @@ table = Table(
     "token_holder", meta,
     Column("holder_list", BigInteger, primary_key=True),
     Column("account_address", String(42), primary_key=True),
-    Column("balance", BigInteger),
-    Column("pending_transfer", BigInteger),
-    Column("exchange_balance", BigInteger),
-    Column("exchange_commitment", BigInteger),
+    Column("hold_balance", BigInteger),
     Column("created", DateTime, default=datetime.utcnow),
     Column("modified", DateTime, default=datetime.utcnow, onupdate=datetime.utcnow),
 )

--- a/tests/app/v2_token_tokenholderscollection_test.py
+++ b/tests/app/v2_token_tokenholderscollection_test.py
@@ -1,0 +1,378 @@
+"""
+Copyright BOOSTRY Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+import json
+import uuid
+import pytest
+from app.contracts import Contract
+
+from app.model.db import (
+    Listing
+)
+from app import config
+
+from web3.middleware import geth_poa_middleware
+from web3 import Web3
+from app.model.db.tokenholders import BatchStatus, TokenHoldersList
+from batch.indexer_Token_Holders import LOG, Processor
+from tests.utils import PersonalInfoUtils
+web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
+web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+from sqlalchemy.orm import Session
+
+from tests.account_config import eth_account
+from tests.contract_modules import issue_bond_token, register_bond_list, transfer_token, bond_transfer_to_exchange, register_personalinfo
+
+
+@pytest.fixture(scope="session")
+def test_module(shared_contract):
+    return Processor
+
+
+@pytest.fixture(scope="function")
+def processor(test_module, session):
+    processor = test_module()
+    return processor
+
+
+class TestV2TokenHoldersCollection:
+    """
+    Test Case for v2.token.TokenHolders
+    """
+
+    # テスト対象API
+    apiurl_base = '/v2/Token/{contract_address}/Holders/Collection'
+    apiurl_after_post = '/v2/Token/{contract_address}/Holders/Collection/{list_id}'
+
+    token_address = "0xe883A6f441Ad5682d37DF31d34fc012bcB07A740"
+
+    issuer = eth_account["issuer"]
+    user1 = eth_account["user1"]
+    user2 = eth_account["user2"]
+    trader = eth_account["trader"]
+    agent = eth_account["agent"]
+
+    @staticmethod
+    def issue_token_bond(issuer, exchange_contract_address, personal_info_contract_address, token_list):
+        # Issue token
+        args = {
+            'name': 'テスト債券',
+            'symbol': 'BOND',
+            'totalSupply': 1000000,
+            'tradableExchange': exchange_contract_address,
+            'faceValue': 10000,
+            'interestRate': 602,
+            'interestPaymentDate1': '0101',
+            'interestPaymentDate2': '0201',
+            'interestPaymentDate3': '0301',
+            'interestPaymentDate4': '0401',
+            'interestPaymentDate5': '0501',
+            'interestPaymentDate6': '0601',
+            'interestPaymentDate7': '0701',
+            'interestPaymentDate8': '0801',
+            'interestPaymentDate9': '0901',
+            'interestPaymentDate10': '1001',
+            'interestPaymentDate11': '1101',
+            'interestPaymentDate12': '1201',
+            'redemptionDate': '20191231',
+            'redemptionValue': 10000,
+            'returnDate': '20191231',
+            'returnAmount': '商品券をプレゼント',
+            'purpose': '新商品の開発資金として利用。',
+            'memo': 'メモ',
+            'contactInformation': '問い合わせ先',
+            'privacyPolicy': 'プライバシーポリシー',
+            'personalInfoAddress': personal_info_contract_address,
+            'transferable': True,
+            'isRedeemed': False
+        }
+        token = issue_bond_token(issuer, args)
+        register_bond_list(issuer, token, token_list)
+
+        return token
+
+    @staticmethod
+    def listing_token(token_address, session):
+        _listing = Listing()
+        _listing.token_address = token_address
+        _listing.is_public = True
+        _listing.max_holding_quantity = 1000000
+        _listing.max_sell_amount = 1000000
+        _listing.owner_address = TestV2TokenHoldersCollection.issuer["account_address"]
+        session.add(_listing)
+        session.commit()
+
+    ####################################################################
+    # Normal
+    ####################################################################
+
+    # Normal_1
+    # POST collection request.
+    # After processor ran, GET generated data of token holders.
+    def test_normal_1(self, client, shared_contract, session: Session, processor: Processor, block_number: None):
+        # Issue Token
+        token_list_contract = shared_contract["TokenList"]
+        escrow_contract = shared_contract["IbetSecurityTokenEscrow"]
+        personal_info_contract = shared_contract["PersonalInfo"]
+        token = self.issue_token_bond(self.issuer, escrow_contract.address, personal_info_contract["address"], token_list_contract)
+
+        self.listing_token(token["address"], session)
+        config.TOKEN_LIST_CONTRACT_ADDRESS = token_list_contract["address"]
+        token_contract = Contract.get_contract("IbetStraightBond", token["address"])
+
+        register_personalinfo(self.trader, personal_info_contract)
+
+        # Transfer
+        bond_transfer_to_exchange(
+            self.issuer, {"address": escrow_contract.address}, token, 10000)
+        transfer_token(token_contract, self.issuer["account_address"], self.trader["account_address"], 30000)
+        block_number = web3.eth.blockNumber
+        list_id = str(uuid.uuid4())
+
+        # Request target API
+        apiurl = self.apiurl_base.format(contract_address=token["address"])
+
+        request_params = {
+            "block_number": block_number,
+            "list_id": list_id
+        }
+        headers = {'Content-Type': 'application/json'}
+        request_body = json.dumps(request_params)
+        resp = client.simulate_post(apiurl, headers=headers, body=request_body)
+
+        assert resp.status_code == 200
+        assert resp.json['meta'] == {'code': 200, 'message': 'OK'}
+        assert resp.json['data'] == {'list_id': list_id, 'status': BatchStatus.PENDING.value}
+
+        processor.collect()
+
+        apiurl = self.apiurl_after_post.format(contract_address=token["address"], list_id=list_id)
+        resp = client.simulate_get(apiurl)
+
+        holders = [self.trader["account_address"]]
+        assert resp.status_code == 200
+        assert resp.json['meta'] == {'code': 200, 'message': 'OK'}
+        assert resp.json['data'] == {'status': BatchStatus.DONE.value, "holders": holders}
+
+    # Normal_2
+    # POST collection request twice.
+    def test_normal_2(self, client, shared_contract, session: Session, processor: Processor, block_number: None):
+        # Issue Token
+        token_list_contract = shared_contract["TokenList"]
+        escrow_contract = shared_contract["IbetSecurityTokenEscrow"]
+        personal_info_contract = shared_contract["PersonalInfo"]
+
+        token1 = self.issue_token_bond(self.issuer, escrow_contract.address, personal_info_contract["address"], token_list_contract)
+        self.listing_token(token1["address"], session)
+        config.TOKEN_LIST_CONTRACT_ADDRESS = token_list_contract["address"]
+
+        token2 = self.issue_token_bond(self.issuer, escrow_contract.address, personal_info_contract["address"], token_list_contract)
+        self.listing_token(token2["address"], session)
+        config.TOKEN_LIST_CONTRACT_ADDRESS = token_list_contract["address"]
+
+        for i, address in enumerate([token1["address"], token2["address"]]):
+            block_number = web3.eth.blockNumber
+            list_id = str(uuid.uuid4())
+            # Request target API
+            apiurl = self.apiurl_base.format(contract_address=address)
+
+            request_params = {
+                "block_number": block_number - i,
+                "list_id": list_id
+            }
+            headers = {'Content-Type': 'application/json'}
+            request_body = json.dumps(request_params)
+            resp = client.simulate_post(apiurl, headers=headers, body=request_body)
+
+            assert resp.status_code == 200
+            assert resp.json['meta'] == {'code': 200, 'message': 'OK'}
+            assert resp.json['data'] == {'list_id': list_id, 'status': BatchStatus.PENDING.value}
+
+    # Normal_3
+    # POST collection request with same contract_address and block_number.
+    def test_normal_3(self, client, shared_contract, session: Session, processor: Processor, block_number: None):
+        # Issue Token
+        token_list_contract = shared_contract["TokenList"]
+        escrow_contract = shared_contract["IbetSecurityTokenEscrow"]
+        personal_info_contract = shared_contract["PersonalInfo"]
+
+        token = self.issue_token_bond(self.issuer, escrow_contract.address, personal_info_contract["address"], token_list_contract)
+        self.listing_token(token["address"], session)
+        config.TOKEN_LIST_CONTRACT_ADDRESS = token_list_contract["address"]
+
+        block_number = web3.eth.blockNumber
+        list_id1 = str(uuid.uuid4())
+        list_id2 = str(uuid.uuid4())
+
+        for list_id in [list_id1, list_id2]:
+            # Request target API
+            apiurl = self.apiurl_base.format(contract_address=token["address"])
+
+            request_params = {
+                "block_number": block_number,
+                "list_id": list_id
+            }
+            headers = {'Content-Type': 'application/json'}
+            request_body = json.dumps(request_params)
+            resp = client.simulate_post(apiurl, headers=headers, body=request_body)
+
+            assert resp.status_code == 200
+            assert resp.json['meta'] == {'code': 200, 'message': 'OK'}
+            assert resp.json['data'] == {'list_id': list_id1, 'status': BatchStatus.PENDING.value}
+
+    ####################################################################
+    # Error
+    ####################################################################
+
+    # Error_1
+    # 400: Invalid Parameter Error
+    # List id is empty.
+    def test_error_1(self, client, session):
+        apiurl = self.apiurl_base.format(contract_address="0xabcd")
+        block_number = web3.eth.blockNumber
+        request_params = {
+            "block_number": block_number
+        }
+        headers = {'Content-Type': 'application/json'}
+        request_body = json.dumps(request_params)
+        resp = client.simulate_post(apiurl, headers=headers, body=request_body)
+
+        assert resp.status_code == 400
+        assert resp.json["meta"] == {
+            "code": 88,
+            "message": "Invalid Parameter",
+            "description": {'list_id': ['required field']}
+        }
+
+    # Error_2
+    # 400: Invalid Parameter Error
+    # Invalid contract address
+    def test_error_2(self, client, session):
+        apiurl = self.apiurl_base.format(contract_address="0xabcd")
+        block_number = web3.eth.blockNumber
+        list_id = str(uuid.uuid4())
+        request_params = {
+            "block_number": block_number,
+            "list_id": list_id
+        }
+        headers = {'Content-Type': 'application/json'}
+        request_body = json.dumps(request_params)
+        resp = client.simulate_post(apiurl, headers=headers, body=request_body)
+
+        assert resp.status_code == 400
+        assert resp.json["meta"] == {
+            "code": 88,
+            "message": "Invalid Parameter",
+            "description": "Invalid contract address"
+        }
+
+    # Error_3
+    # 400: Invalid Parameter Error
+    # "list_id" is not UUID.
+    def test_error_3(self, client, session):
+        apiurl = self.apiurl_base.format(contract_address=config.ZERO_ADDRESS)
+        block_number = web3.eth.blockNumber
+        request_params = {
+            "block_number": block_number,
+            "list_id": "some_id"
+        }
+        headers = {'Content-Type': 'application/json'}
+        request_body = json.dumps(request_params)
+        resp = client.simulate_post(apiurl, headers=headers, body=request_body)
+
+        assert resp.status_code == 400
+        assert resp.json["meta"] == {
+            "code": 88,
+            "message": "Invalid Parameter",
+            "description": "list_id must be UUIDv4."
+        }
+
+    # Error_4
+    # 400: Invalid Parameter Error
+    # Block number is future one.
+    def test_error_4(self, client, session):
+        apiurl = self.apiurl_base.format(contract_address=config.ZERO_ADDRESS)
+        block_number = web3.eth.blockNumber + 100
+        request_params = {
+            "block_number": block_number,
+            "list_id": str(uuid.uuid4())
+        }
+        headers = {'Content-Type': 'application/json'}
+        request_body = json.dumps(request_params)
+        resp = client.simulate_post(apiurl, headers=headers, body=request_body)
+
+        assert resp.status_code == 400
+        assert resp.json["meta"] == {
+            "code": 88,
+            "message": "Invalid Parameter",
+            "description": "Block number must be current or past one."
+        }
+
+    # Error_5
+    # 400: Invalid Parameter Error
+    # Duplicate list_id is posted.
+    def test_error_5(self, client, session):
+        list_id = str(uuid.uuid4())
+        target_token_holders_list = TokenHoldersList()
+        target_token_holders_list.token_address = self.token_address
+        target_token_holders_list.list_id = list_id
+        target_token_holders_list.batch_status = BatchStatus.PENDING.value
+        target_token_holders_list.block_number = 1000
+        session.merge(target_token_holders_list)
+        session.commit()
+
+        self.listing_token(self.token_address, session)
+
+        apiurl = self.apiurl_base.format(contract_address=self.token_address)
+        block_number = web3.eth.blockNumber
+        request_params = {
+            "block_number": block_number,
+            "list_id": list_id
+        }
+        headers = {'Content-Type': 'application/json'}
+        request_body = json.dumps(request_params)
+        resp = client.simulate_post(apiurl, headers=headers, body=request_body)
+
+        assert resp.status_code == 400
+        assert resp.json["meta"] == {
+            "code": 88,
+            "message": "Invalid Parameter",
+            "description": "list_id must be unique."
+        }
+
+    # Error_6
+    # 400: Invalid Parameter Error
+    # Not listed token
+    def test_error_6(self, client, session):
+        list_id = str(uuid.uuid4())
+        apiurl = self.apiurl_base.format(contract_address=self.token_address)
+        block_number = web3.eth.blockNumber
+        request_params = {
+            "block_number": block_number,
+            "list_id": list_id
+        }
+        headers = {'Content-Type': 'application/json'}
+        request_body = json.dumps(request_params)
+        resp = client.simulate_post(apiurl, headers=headers, body=request_body)
+
+        assert resp.status_code == 404
+        assert resp.json["meta"] == {
+            "code": 30,
+            "message": "Data Not Exists",
+            "description": 'contract_address: ' + self.token_address
+        }

--- a/tests/app/v2_token_tokenholderscollection_test.py
+++ b/tests/app/v2_token_tokenholderscollection_test.py
@@ -26,7 +26,7 @@ from app import config
 
 from web3.middleware import geth_poa_middleware
 from web3 import Web3
-from app.model.db.tokenholders import BatchStatus, TokenHoldersList
+from app.model.db.tokenholders import TokenHolderBatchStatus, TokenHoldersList
 from batch.indexer_Token_Holders import Processor
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
@@ -159,7 +159,7 @@ class TestV2TokenHoldersCollection:
 
         assert resp.status_code == 200
         assert resp.json["meta"] == {"code": 200, "message": "OK"}
-        assert resp.json["data"] == {"list_id": list_id, "status": BatchStatus.PENDING.value}
+        assert resp.json["data"] == {"list_id": list_id, "status": TokenHolderBatchStatus.PENDING.value}
 
         processor.collect()
 
@@ -169,7 +169,7 @@ class TestV2TokenHoldersCollection:
         holders = [self.trader["account_address"]]
         assert resp.status_code == 200
         assert resp.json["meta"] == {"code": 200, "message": "OK"}
-        assert resp.json["data"] == {"status": BatchStatus.DONE.value, "holders": holders}
+        assert resp.json["data"] == {"status": TokenHolderBatchStatus.DONE.value, "holders": holders}
 
     # Normal_2
     # POST collection request twice.
@@ -204,7 +204,7 @@ class TestV2TokenHoldersCollection:
 
             assert resp.status_code == 200
             assert resp.json["meta"] == {"code": 200, "message": "OK"}
-            assert resp.json["data"] == {"list_id": list_id, "status": BatchStatus.PENDING.value}
+            assert resp.json["data"] == {"list_id": list_id, "status": TokenHolderBatchStatus.PENDING.value}
 
     # Normal_3
     # POST collection request with same contract_address and block_number.
@@ -235,7 +235,7 @@ class TestV2TokenHoldersCollection:
 
             assert resp.status_code == 200
             assert resp.json["meta"] == {"code": 200, "message": "OK"}
-            assert resp.json["data"] == {"list_id": list_id1, "status": BatchStatus.PENDING.value}
+            assert resp.json["data"] == {"list_id": list_id1, "status": TokenHolderBatchStatus.PENDING.value}
 
     ####################################################################
     # Error
@@ -324,7 +324,7 @@ class TestV2TokenHoldersCollection:
         target_token_holders_list = TokenHoldersList()
         target_token_holders_list.token_address = self.token_address
         target_token_holders_list.list_id = list_id
-        target_token_holders_list.batch_status = BatchStatus.PENDING.value
+        target_token_holders_list.batch_status = TokenHolderBatchStatus.PENDING.value
         target_token_holders_list.block_number = 1000
         session.merge(target_token_holders_list)
         session.commit()

--- a/tests/app/v2_token_tokenholderscollection_test.py
+++ b/tests/app/v2_token_tokenholderscollection_test.py
@@ -18,6 +18,7 @@ SPDX-License-Identifier: Apache-2.0
 """
 import json
 import uuid
+from unittest import mock
 import pytest
 
 from web3.middleware import geth_poa_middleware
@@ -159,7 +160,8 @@ class TestV2TokenHoldersCollection:
         assert resp.json["meta"] == {"code": 200, "message": "OK"}
         assert resp.json["data"] == {"list_id": list_id, "status": TokenHolderBatchStatus.PENDING.value}
 
-        processor.collect()
+        with mock.patch("batch.indexer_Token_Holders.TOKEN_LIST_CONTRACT_ADDRESS", token_list_contract["address"]):
+            processor.collect()
 
         apiurl = self.apiurl_after_post.format(contract_address=token["address"], list_id=list_id)
         resp = client.simulate_get(apiurl)

--- a/tests/app/v2_token_tokenholderscollection_test.py
+++ b/tests/app/v2_token_tokenholderscollection_test.py
@@ -286,10 +286,24 @@ class TestV2TokenHoldersCollection:
 
     # Error_4
     # 400: Invalid Parameter Error
-    # Block number is future one.
+    # Block number is future one or negative.
     def test_error_4(self, client, session):
         apiurl = self.apiurl_base.format(contract_address=config.ZERO_ADDRESS)
         block_number = web3.eth.blockNumber + 100
+        request_params = {"block_number": block_number, "list_id": str(uuid.uuid4())}
+        headers = {"Content-Type": "application/json"}
+        request_body = json.dumps(request_params)
+        resp = client.simulate_post(apiurl, headers=headers, body=request_body)
+
+        assert resp.status_code == 400
+        assert resp.json["meta"] == {
+            "code": 88,
+            "message": "Invalid Parameter",
+            "description": "Block number must be current or past one.",
+        }
+
+        apiurl = self.apiurl_base.format(contract_address=config.ZERO_ADDRESS)
+        block_number = 0
         request_params = {"block_number": block_number, "list_id": str(uuid.uuid4())}
         headers = {"Content-Type": "application/json"}
         request_body = json.dumps(request_params)

--- a/tests/app/v2_token_tokenholderscollection_test.py
+++ b/tests/app/v2_token_tokenholderscollection_test.py
@@ -19,14 +19,12 @@ SPDX-License-Identifier: Apache-2.0
 import json
 import uuid
 import pytest
-from app.contracts import Contract
-
-from app.model.db import Listing
-from app import config
 
 from web3.middleware import geth_poa_middleware
 from web3 import Web3
-from app.model.db.tokenholders import TokenHolderBatchStatus, TokenHoldersList
+from app import config
+from app.contracts import Contract
+from app.model.db import TokenHolderBatchStatus, TokenHoldersList, Listing
 from batch.indexer_Token_Holders import Processor
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
@@ -165,13 +163,7 @@ class TestV2TokenHoldersCollection:
 
         apiurl = self.apiurl_after_post.format(contract_address=token["address"], list_id=list_id)
         resp = client.simulate_get(apiurl)
-        holders = [{
-            "account_address": self.trader["account_address"],
-            "balance": 30000,
-            "pending_transfer": 0,
-            "exchange_balance": 0,
-            "exchange_commitment": 0
-        }]
+        holders = [{"account_address": self.trader["account_address"], "hold_balance": 30000}]
         assert resp.status_code == 200
         assert resp.json["meta"] == {"code": 200, "message": "OK"}
         assert resp.json["data"] == {"status": TokenHolderBatchStatus.DONE.value, "holders": holders}

--- a/tests/app/v2_token_tokenholderscollection_test.py
+++ b/tests/app/v2_token_tokenholderscollection_test.py
@@ -165,8 +165,13 @@ class TestV2TokenHoldersCollection:
 
         apiurl = self.apiurl_after_post.format(contract_address=token["address"], list_id=list_id)
         resp = client.simulate_get(apiurl)
-
-        holders = [self.trader["account_address"]]
+        holders = [{
+            "account_address": self.trader["account_address"],
+            "balance": 30000,
+            "pending_transfer": 0,
+            "exchange_balance": 0,
+            "exchange_commitment": 0
+        }]
         assert resp.status_code == 200
         assert resp.json["meta"] == {"code": 200, "message": "OK"}
         assert resp.json["data"] == {"status": TokenHolderBatchStatus.DONE.value, "holders": holders}

--- a/tests/app/v2_token_tokenholderscollectionid_test.py
+++ b/tests/app/v2_token_tokenholderscollectionid_test.py
@@ -185,22 +185,24 @@ class TestV2TokenHoldersCollectionId:
         resp = client.simulate_get(apiurl)
 
         holders = [{
-            "account_address": self.user1["account_address"],
-            "balance": 20000,
-            "pending_transfer": 0,
-            "exchange_balance": 30000,
-            "exchange_commitment": 0
-        }, {
             "account_address": self.trader["account_address"],
             "balance": 30000,
             "pending_transfer": 0,
             "exchange_balance": 0,
             "exchange_commitment": 0
+        }, {
+            "account_address": self.user1["account_address"],
+            "balance": 20000,
+            "pending_transfer": 0,
+            "exchange_balance": 30000,
+            "exchange_commitment": 0
         }]
+
+        sorted_holders = sorted(holders, key=lambda x: x['account_address'])
 
         assert resp.status_code == 200
         assert resp.json["meta"] == {"code": 200, "message": "OK"}
-        assert resp.json["data"] == {"status": TokenHolderBatchStatus.DONE.value, "holders": holders}
+        assert resp.json["data"] == {"status": TokenHolderBatchStatus.DONE.value, "holders": sorted_holders}
 
     ####################################################################
     # Error

--- a/tests/app/v2_token_tokenholderscollectionid_test.py
+++ b/tests/app/v2_token_tokenholderscollectionid_test.py
@@ -17,13 +17,13 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 import uuid
+from unittest import mock
 import pytest
-from app.contracts import Contract
-
 
 from web3.middleware import geth_poa_middleware
 from web3 import Web3
 from app import config
+from app.contracts import Contract
 from app.model.db import TokenHolderBatchStatus, TokenHoldersList, Listing
 from batch.indexer_Token_Holders import Processor
 
@@ -177,7 +177,8 @@ class TestV2TokenHoldersCollectionId:
         session.merge(target_token_holders_list)
         session.commit()
 
-        processor.collect()
+        with mock.patch("batch.indexer_Token_Holders.TOKEN_LIST_CONTRACT_ADDRESS", token_list_contract["address"]):
+            processor.collect()
 
         # Request target API
         apiurl = self.apiurl_base.format(contract_address=token["address"], list_id=target_token_holders_list.list_id)

--- a/tests/app/v2_token_tokenholderscollectionid_test.py
+++ b/tests/app/v2_token_tokenholderscollectionid_test.py
@@ -1,0 +1,237 @@
+"""
+Copyright BOOSTRY Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+import json
+import uuid
+import pytest
+from app.contracts import Contract
+
+from app.model.db import (
+    Listing
+)
+from app import config
+
+from web3.middleware import geth_poa_middleware
+from web3 import Web3
+from app.model.db.tokenholders import BatchStatus, TokenHoldersList
+from batch.indexer_Token_Holders import LOG, Processor
+from tests.utils import PersonalInfoUtils
+web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
+web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+from sqlalchemy.orm import Session
+
+from tests.account_config import eth_account
+from tests.contract_modules import issue_bond_token, register_bond_list, transfer_token, bond_transfer_to_exchange, register_personalinfo
+
+
+@pytest.fixture(scope="session")
+def test_module(shared_contract):
+    return Processor
+
+
+@pytest.fixture(scope="function")
+def processor(test_module, session):
+    processor = test_module()
+    return processor
+
+
+class TestV2TokenHoldersCollectionId:
+    """
+    Test Case for v2.token.TokenHolders
+    """
+
+    # テスト対象API
+    apiurl_base = '/v2/Token/{contract_address}/Holders/Collection/{list_id}'
+
+    token_address = "0xe883A6f441Ad5682d37DF31d34fc012bcB07A740"
+
+    issuer = eth_account["issuer"]
+    user1 = eth_account["user1"]
+    user2 = eth_account["user2"]
+    trader = eth_account["trader"]
+    agent = eth_account["agent"]
+
+    @staticmethod
+    def issue_token_bond(issuer, exchange_contract_address, personal_info_contract_address, token_list):
+        # Issue token
+        args = {
+            'name': 'テスト債券',
+            'symbol': 'BOND',
+            'totalSupply': 1000000,
+            'tradableExchange': exchange_contract_address,
+            'faceValue': 10000,
+            'interestRate': 602,
+            'interestPaymentDate1': '0101',
+            'interestPaymentDate2': '0201',
+            'interestPaymentDate3': '0301',
+            'interestPaymentDate4': '0401',
+            'interestPaymentDate5': '0501',
+            'interestPaymentDate6': '0601',
+            'interestPaymentDate7': '0701',
+            'interestPaymentDate8': '0801',
+            'interestPaymentDate9': '0901',
+            'interestPaymentDate10': '1001',
+            'interestPaymentDate11': '1101',
+            'interestPaymentDate12': '1201',
+            'redemptionDate': '20191231',
+            'redemptionValue': 10000,
+            'returnDate': '20191231',
+            'returnAmount': '商品券をプレゼント',
+            'purpose': '新商品の開発資金として利用。',
+            'memo': 'メモ',
+            'contactInformation': '問い合わせ先',
+            'privacyPolicy': 'プライバシーポリシー',
+            'personalInfoAddress': personal_info_contract_address,
+            'transferable': True,
+            'isRedeemed': False
+        }
+        token = issue_bond_token(issuer, args)
+        register_bond_list(issuer, token, token_list)
+
+        return token
+
+    @staticmethod
+    def listing_token(token_address, session):
+        _listing = Listing()
+        _listing.token_address = token_address
+        _listing.is_public = True
+        _listing.max_holding_quantity = 1000000
+        _listing.max_sell_amount = 1000000
+        _listing.owner_address = TestV2TokenHoldersCollectionId.issuer["account_address"]
+        session.add(_listing)
+        session.commit()
+
+    ####################################################################
+    # Normal
+    ####################################################################
+
+    # Normal_1
+    # GET
+    # Holders in response is empty.
+    def test_normal_1(self, client, shared_contract, session: Session, processor: Processor, block_number: None):
+        target_token_holders_list = TokenHoldersList()
+        target_token_holders_list.token_address = self.token_address
+        target_token_holders_list.list_id = str(uuid.uuid4())
+        target_token_holders_list.batch_status = BatchStatus.PENDING.value
+        target_token_holders_list.block_number = 1000
+        session.merge(target_token_holders_list)
+        session.commit()
+
+        self.listing_token(self.token_address, session)
+
+        # Request target API
+        apiurl = self.apiurl_base.format(contract_address=self.token_address, list_id=target_token_holders_list.list_id)
+
+        resp = client.simulate_get(apiurl)
+
+        assert resp.status_code == 200
+        assert resp.json['meta'] == {'code': 200, 'message': 'OK'}
+        assert resp.json['data'] == {'status': BatchStatus.PENDING.value, "holders": []}
+
+    # Normal_2
+    # GET
+    # Holders in response is filled after holders data is generated properly by batch.
+    def test_normal_2(self, client, shared_contract, session: Session, processor: Processor, block_number: None):
+        # Issue Token
+        token_list_contract = shared_contract["TokenList"]
+        escrow_contract = shared_contract["IbetSecurityTokenEscrow"]
+        personal_info_contract = shared_contract["PersonalInfo"]
+        token = self.issue_token_bond(self.issuer, escrow_contract.address, personal_info_contract["address"], token_list_contract)
+
+        self.listing_token(token["address"], session)
+        config.TOKEN_LIST_CONTRACT_ADDRESS = token_list_contract["address"]
+        token_contract = Contract.get_contract("IbetStraightBond", token["address"])
+        register_personalinfo(self.trader, personal_info_contract)
+
+        # Transfer
+        bond_transfer_to_exchange(
+            self.issuer, {"address": escrow_contract.address}, token, 10000)
+        transfer_token(token_contract, self.issuer["account_address"], self.trader["account_address"], 30000)
+
+        target_token_holders_list = TokenHoldersList()
+        target_token_holders_list.token_address = token["address"]
+        target_token_holders_list.list_id = str(uuid.uuid4())
+        target_token_holders_list.batch_status = BatchStatus.PENDING.value
+        target_token_holders_list.block_number = web3.eth.blockNumber
+        session.merge(target_token_holders_list)
+        session.commit()
+
+        processor.collect()
+
+        # Request target API
+        apiurl = self.apiurl_base.format(contract_address=token["address"], list_id= target_token_holders_list.list_id)
+        resp = client.simulate_get(apiurl)
+
+        holders = [self.trader["account_address"]]
+        assert resp.status_code == 200
+        assert resp.json['meta'] == {'code': 200, 'message': 'OK'}
+        assert resp.json['data'] == {'status': BatchStatus.DONE.value, "holders": holders}
+
+    ####################################################################
+    # Error
+    ####################################################################
+
+    # Error_1
+    # 400: Invalid Parameter Error
+    # Invalid contract address
+    def test_error_1(self, client, session):
+        list_id = str(uuid.uuid4())
+        apiurl = self.apiurl_base.format(contract_address="0xabcd", list_id=list_id)
+
+        query_string = ""
+        resp = client.simulate_get(apiurl, query_string=query_string)
+
+        assert resp.status_code == 400
+        assert resp.json["meta"] == {
+            "code": 88,
+            "message": "Invalid Parameter",
+            "description": "invalid contract_address"
+        }
+
+    # Error_2
+    # 400: Invalid Parameter Error
+    # Invalid list_id
+    def test_error_2(self, client, session):
+        apiurl = self.apiurl_base.format(contract_address=config.ZERO_ADDRESS, list_id="some_id")
+        query_string = ""
+        resp = client.simulate_get(apiurl, query_string=query_string)
+
+        assert resp.status_code == 400
+        assert resp.json["meta"] == {
+            "code": 88,
+            "message": "Invalid Parameter",
+            "description": "list_id must be UUIDv4."
+        }
+
+    # Error_3
+    # 404: Data Not Exists Error
+    # There is no record with given list_id.
+    def test_error_3(self, client, session):
+        self.listing_token(self.token_address, session)
+        list_id = str(uuid.uuid4())
+        apiurl = self.apiurl_base.format(contract_address=self.token_address, list_id=list_id)
+        query_string = ""
+        resp = client.simulate_get(apiurl, query_string=query_string)
+
+        assert resp.status_code == 404
+        assert resp.json["meta"] == {
+            "code": 30,
+            "message": "Data Not Exists",
+            "description": "list_id: " + list_id
+        }
+

--- a/tests/app/v2_token_tokenholderscollectionid_test.py
+++ b/tests/app/v2_token_tokenholderscollectionid_test.py
@@ -185,16 +185,16 @@ class TestV2TokenHoldersCollectionId:
         resp = client.simulate_get(apiurl)
 
         holders = [{
-            "account_address": self.trader["account_address"],
-            "balance": 30000,
-            "pending_transfer": 0,
-            "exchange_balance": 0,
-            "exchange_commitment": 0
-        }, {
             "account_address": self.user1["account_address"],
             "balance": 20000,
             "pending_transfer": 0,
             "exchange_balance": 30000,
+            "exchange_commitment": 0
+        }, {
+            "account_address": self.trader["account_address"],
+            "balance": 30000,
+            "pending_transfer": 0,
+            "exchange_balance": 0,
             "exchange_commitment": 0
         }]
 

--- a/tests/app/v2_token_tokenholderscollectionid_test.py
+++ b/tests/app/v2_token_tokenholderscollectionid_test.py
@@ -25,7 +25,7 @@ from app import config
 
 from web3.middleware import geth_poa_middleware
 from web3 import Web3
-from app.model.db.tokenholders import BatchStatus, TokenHoldersList
+from app.model.db.tokenholders import TokenHolderBatchStatus, TokenHoldersList
 from batch.indexer_Token_Holders import Processor
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
@@ -130,7 +130,7 @@ class TestV2TokenHoldersCollectionId:
         target_token_holders_list = TokenHoldersList()
         target_token_holders_list.token_address = self.token_address
         target_token_holders_list.list_id = str(uuid.uuid4())
-        target_token_holders_list.batch_status = BatchStatus.PENDING.value
+        target_token_holders_list.batch_status = TokenHolderBatchStatus.PENDING.value
         target_token_holders_list.block_number = 1000
         session.merge(target_token_holders_list)
         session.commit()
@@ -144,7 +144,7 @@ class TestV2TokenHoldersCollectionId:
 
         assert resp.status_code == 200
         assert resp.json["meta"] == {"code": 200, "message": "OK"}
-        assert resp.json["data"] == {"status": BatchStatus.PENDING.value, "holders": []}
+        assert resp.json["data"] == {"status": TokenHolderBatchStatus.PENDING.value, "holders": []}
 
     # Normal_2
     # GET
@@ -170,7 +170,7 @@ class TestV2TokenHoldersCollectionId:
         target_token_holders_list = TokenHoldersList()
         target_token_holders_list.token_address = token["address"]
         target_token_holders_list.list_id = str(uuid.uuid4())
-        target_token_holders_list.batch_status = BatchStatus.PENDING.value
+        target_token_holders_list.batch_status = TokenHolderBatchStatus.PENDING.value
         target_token_holders_list.block_number = web3.eth.blockNumber
         session.merge(target_token_holders_list)
         session.commit()
@@ -184,7 +184,7 @@ class TestV2TokenHoldersCollectionId:
         holders = [self.trader["account_address"]]
         assert resp.status_code == 200
         assert resp.json["meta"] == {"code": 200, "message": "OK"}
-        assert resp.json["data"] == {"status": BatchStatus.DONE.value, "holders": holders}
+        assert resp.json["data"] == {"status": TokenHolderBatchStatus.DONE.value, "holders": holders}
 
     ####################################################################
     # Error

--- a/tests/app/v2_token_tokenholderscollectionid_test.py
+++ b/tests/app/v2_token_tokenholderscollectionid_test.py
@@ -20,12 +20,11 @@ import uuid
 import pytest
 from app.contracts import Contract
 
-from app.model.db import Listing
-from app import config
 
 from web3.middleware import geth_poa_middleware
 from web3 import Web3
-from app.model.db.tokenholders import TokenHolderBatchStatus, TokenHoldersList
+from app import config
+from app.model.db import TokenHolderBatchStatus, TokenHoldersList, Listing
 from batch.indexer_Token_Holders import Processor
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
@@ -186,16 +185,10 @@ class TestV2TokenHoldersCollectionId:
 
         holders = [{
             "account_address": self.trader["account_address"],
-            "balance": 30000,
-            "pending_transfer": 0,
-            "exchange_balance": 0,
-            "exchange_commitment": 0
+            "hold_balance": 30000
         }, {
             "account_address": self.user1["account_address"],
-            "balance": 20000,
-            "pending_transfer": 0,
-            "exchange_balance": 30000,
-            "exchange_commitment": 0
+            "hold_balance": 50000
         }]
 
         sorted_holders = sorted(holders, key=lambda x: x['account_address'])

--- a/tests/batch/indexer_Token_Holders_test.py
+++ b/tests/batch/indexer_Token_Holders_test.py
@@ -17,6 +17,8 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 import logging
+import os
+import sys
 import uuid
 from typing import Type, List
 from unittest import mock
@@ -26,6 +28,9 @@ from sqlalchemy.orm import Session
 
 from web3 import Web3
 from web3.middleware import geth_poa_middleware
+
+path = os.path.join(os.path.dirname(__file__), "../")
+sys.path.append(path)
 
 from app import config
 from app.config import ZERO_ADDRESS
@@ -1950,8 +1955,14 @@ class TestProcessor:
 
     # <Normal_14>
     # StraightBond
-    # Pending jobs are to be processed one by one.
+    # Jobs are queued and pending jobs are to be processed one by one.
     def test_normal_14(self, processor: Processor, shared_contract, session: Session, caplog, block_number: None):
+        processor.collect()
+        LOG.addHandler(caplog.handler)
+        with caplog.at_level(logging.DEBUG):
+            processor.collect()
+            assert f"There are no pending collect batch" in caplog.text
+
         token_list_contract = shared_contract["TokenList"]
         personal_info_contract = shared_contract["PersonalInfo"]
         exchange_contract = shared_contract["IbetStraightBondExchange"]

--- a/tests/batch/indexer_Token_Holders_test.py
+++ b/tests/batch/indexer_Token_Holders_test.py
@@ -828,21 +828,16 @@ class TestProcessor:
         assert trader_record.exchange_balance == _trader_record_validator.exchange_balance
         assert trader_record.exchange_commitment == _trader_record_validator.exchange_commitment
 
-    # <Normal 5>
+    # <Normal_5>
     # Share
     # Events
-    # - Transfer
-    # - Lock
-    # - Unlock
-    # - Exchange
-    #   - MakeOrder
-    #   - CancelOrder
-    #   - ForceCancelOrder
-    #   - TakeOrder
-    #   - CancelAgreement
-    #   - ConfirmAgreement
-    # - IssueFrom
-    # - RedeemFrom
+    # - ApplyForTransfer
+    # - CancelForTransfer
+    # - ApproveTransfer
+    # - Escrow
+    #   - CreateEscrow
+    #   - FinishEscrow
+    #   - ApproveTransfer
     def test_normal_5(
         self,
         processor: Processor,
@@ -965,7 +960,7 @@ class TestProcessor:
         assert trader_record.exchange_commitment == _trader_record_validator.exchange_commitment
 
     # <Normal_6>
-    # StraightBond
+    # Share
     # Events
     # - ApplyForTransfer - pending
     # - Escrow - pending

--- a/tests/batch/indexer_Token_Holders_test.py
+++ b/tests/batch/indexer_Token_Holders_test.py
@@ -407,13 +407,13 @@ class TestProcessor:
 
         user1_record: TokenHolder = (
             session.query(TokenHolder)
-            .filter(TokenHolder.holder_list == target_token_holders_list.id)
+            .filter(TokenHolder.holder_list_id == target_token_holders_list.id)
             .filter(TokenHolder.account_address == self.user1["account_address"])
             .first()
         )
         trader_record: TokenHolder = (
             session.query(TokenHolder)
-            .filter(TokenHolder.holder_list == target_token_holders_list.id)
+            .filter(TokenHolder.holder_list_id == target_token_holders_list.id)
             .filter(TokenHolder.account_address == self.trader["account_address"])
             .first()
         )
@@ -428,7 +428,7 @@ class TestProcessor:
         assert trader_record.exchange_commitment == 0
         assert trader_record.pending_transfer == 0
 
-        assert len(list(session.query(TokenHolder).filter(TokenHolder.holder_list == target_token_holders_list.id))) == 2
+        assert len(list(session.query(TokenHolder).filter(TokenHolder.holder_list_id == target_token_holders_list.id))) == 2
 
         _user1_record_validator: IDXPosition = (
             session.query(IDXPosition)
@@ -537,13 +537,13 @@ class TestProcessor:
         processor.collect()
         user1_record: TokenHolder = (
             session.query(TokenHolder)
-            .filter(TokenHolder.holder_list == target_token_holders_list.id)
+            .filter(TokenHolder.holder_list_id == target_token_holders_list.id)
             .filter(TokenHolder.account_address == self.user1["account_address"])
             .first()
         )
         trader_record: TokenHolder = (
             session.query(TokenHolder)
-            .filter(TokenHolder.holder_list == target_token_holders_list.id)
+            .filter(TokenHolder.holder_list_id == target_token_holders_list.id)
             .filter(TokenHolder.account_address == self.trader["account_address"])
             .first()
         )
@@ -558,7 +558,7 @@ class TestProcessor:
         assert trader_record.exchange_commitment == 0
         assert trader_record.pending_transfer == 0
 
-        assert len(list(session.query(TokenHolder).filter(TokenHolder.holder_list == target_token_holders_list.id))) == 2
+        assert len(list(session.query(TokenHolder).filter(TokenHolder.holder_list_id == target_token_holders_list.id))) == 2
 
         _user1_record_validator: IDXPosition = (
             session.query(IDXPosition)
@@ -657,13 +657,13 @@ class TestProcessor:
 
         user1_record: TokenHolder = (
             session.query(TokenHolder)
-            .filter(TokenHolder.holder_list == target_token_holders_list.id)
+            .filter(TokenHolder.holder_list_id == target_token_holders_list.id)
             .filter(TokenHolder.account_address == self.user1["account_address"])
             .first()
         )
         trader_record: TokenHolder = (
             session.query(TokenHolder)
-            .filter(TokenHolder.holder_list == target_token_holders_list.id)
+            .filter(TokenHolder.holder_list_id == target_token_holders_list.id)
             .filter(TokenHolder.account_address == self.trader["account_address"])
             .first()
         )
@@ -678,7 +678,7 @@ class TestProcessor:
         assert trader_record.exchange_commitment == 0
         assert trader_record.pending_transfer == 0
 
-        assert len(list(session.query(TokenHolder).filter(TokenHolder.holder_list == target_token_holders_list.id))) == 2
+        assert len(list(session.query(TokenHolder).filter(TokenHolder.holder_list_id == target_token_holders_list.id))) == 2
 
         _user1_record_validator: IDXPosition = (
             session.query(IDXPosition)
@@ -782,13 +782,13 @@ class TestProcessor:
 
         user1_record: TokenHolder = (
             session.query(TokenHolder)
-            .filter(TokenHolder.holder_list == target_token_holders_list.id)
+            .filter(TokenHolder.holder_list_id == target_token_holders_list.id)
             .filter(TokenHolder.account_address == self.user1["account_address"])
             .first()
         )
         trader_record: TokenHolder = (
             session.query(TokenHolder)
-            .filter(TokenHolder.holder_list == target_token_holders_list.id)
+            .filter(TokenHolder.holder_list_id == target_token_holders_list.id)
             .filter(TokenHolder.account_address == self.trader["account_address"])
             .first()
         )
@@ -803,7 +803,7 @@ class TestProcessor:
         assert trader_record.exchange_commitment == 0
         assert trader_record.pending_transfer == 0
 
-        assert len(list(session.query(TokenHolder).filter(TokenHolder.holder_list == target_token_holders_list.id))) == 2
+        assert len(list(session.query(TokenHolder).filter(TokenHolder.holder_list_id == target_token_holders_list.id))) == 2
 
         _user1_record_validator: IDXPosition = (
             session.query(IDXPosition)
@@ -918,13 +918,13 @@ class TestProcessor:
 
         user1_record: TokenHolder = (
             session.query(TokenHolder)
-            .filter(TokenHolder.holder_list == target_token_holders_list.id)
+            .filter(TokenHolder.holder_list_id == target_token_holders_list.id)
             .filter(TokenHolder.account_address == self.user1["account_address"])
             .first()
         )
         trader_record: TokenHolder = (
             session.query(TokenHolder)
-            .filter(TokenHolder.holder_list == target_token_holders_list.id)
+            .filter(TokenHolder.holder_list_id == target_token_holders_list.id)
             .filter(TokenHolder.account_address == self.trader["account_address"])
             .first()
         )
@@ -939,7 +939,7 @@ class TestProcessor:
         assert trader_record.exchange_commitment == 0
         assert trader_record.pending_transfer == 0
 
-        assert len(list(session.query(TokenHolder).filter(TokenHolder.holder_list == target_token_holders_list.id))) == 2
+        assert len(list(session.query(TokenHolder).filter(TokenHolder.holder_list_id == target_token_holders_list.id))) == 2
 
         _user1_record_validator: IDXPosition = (
             session.query(IDXPosition)
@@ -1038,13 +1038,13 @@ class TestProcessor:
 
         user1_record: TokenHolder = (
             session.query(TokenHolder)
-            .filter(TokenHolder.holder_list == target_token_holders_list.id)
+            .filter(TokenHolder.holder_list_id == target_token_holders_list.id)
             .filter(TokenHolder.account_address == self.user1["account_address"])
             .first()
         )
         trader_record: TokenHolder = (
             session.query(TokenHolder)
-            .filter(TokenHolder.holder_list == target_token_holders_list.id)
+            .filter(TokenHolder.holder_list_id == target_token_holders_list.id)
             .filter(TokenHolder.account_address == self.trader["account_address"])
             .first()
         )
@@ -1059,7 +1059,7 @@ class TestProcessor:
         assert trader_record.exchange_commitment == 0
         assert trader_record.pending_transfer == 0
 
-        assert len(list(session.query(TokenHolder).filter(TokenHolder.holder_list == target_token_holders_list.id))) == 2
+        assert len(list(session.query(TokenHolder).filter(TokenHolder.holder_list_id == target_token_holders_list.id))) == 2
 
         _user1_record_validator: IDXPosition = (
             session.query(IDXPosition)
@@ -1146,13 +1146,13 @@ class TestProcessor:
 
         user1_record: TokenHolder = (
             session.query(TokenHolder)
-            .filter(TokenHolder.holder_list == target_token_holders_list.id)
+            .filter(TokenHolder.holder_list_id == target_token_holders_list.id)
             .filter(TokenHolder.account_address == self.user1["account_address"])
             .first()
         )
         trader_record: TokenHolder = (
             session.query(TokenHolder)
-            .filter(TokenHolder.holder_list == target_token_holders_list.id)
+            .filter(TokenHolder.holder_list_id == target_token_holders_list.id)
             .filter(TokenHolder.account_address == self.trader["account_address"])
             .first()
         )
@@ -1167,7 +1167,7 @@ class TestProcessor:
         assert trader_record.exchange_commitment == 0
         assert trader_record.pending_transfer == 0
 
-        assert len(list(session.query(TokenHolder).filter(TokenHolder.holder_list == target_token_holders_list.id))) == 2
+        assert len(list(session.query(TokenHolder).filter(TokenHolder.holder_list_id == target_token_holders_list.id))) == 2
 
         _user1_record_validator: IDXPosition = (
             session.query(IDXPosition)
@@ -1261,13 +1261,13 @@ class TestProcessor:
 
         user1_record: TokenHolder = (
             session.query(TokenHolder)
-            .filter(TokenHolder.holder_list == target_token_holders_list.id)
+            .filter(TokenHolder.holder_list_id == target_token_holders_list.id)
             .filter(TokenHolder.account_address == self.user1["account_address"])
             .first()
         )
         trader_record: TokenHolder = (
             session.query(TokenHolder)
-            .filter(TokenHolder.holder_list == target_token_holders_list.id)
+            .filter(TokenHolder.holder_list_id == target_token_holders_list.id)
             .filter(TokenHolder.account_address == self.trader["account_address"])
             .first()
         )
@@ -1282,7 +1282,7 @@ class TestProcessor:
         assert trader_record.exchange_commitment == 0
         assert trader_record.pending_transfer == 0
 
-        assert len(list(session.query(TokenHolder).filter(TokenHolder.holder_list == target_token_holders_list.id))) == 2
+        assert len(list(session.query(TokenHolder).filter(TokenHolder.holder_list_id == target_token_holders_list.id))) == 2
 
         _user1_record_validator: IDXPosition = (
             session.query(IDXPosition)
@@ -1373,13 +1373,13 @@ class TestProcessor:
 
         user1_record: TokenHolder = (
             session.query(TokenHolder)
-            .filter(TokenHolder.holder_list == target_token_holders_list.id)
+            .filter(TokenHolder.holder_list_id == target_token_holders_list.id)
             .filter(TokenHolder.account_address == self.user1["account_address"])
             .first()
         )
         trader_record: TokenHolder = (
             session.query(TokenHolder)
-            .filter(TokenHolder.holder_list == target_token_holders_list.id)
+            .filter(TokenHolder.holder_list_id == target_token_holders_list.id)
             .filter(TokenHolder.account_address == self.trader["account_address"])
             .first()
         )
@@ -1394,7 +1394,7 @@ class TestProcessor:
         assert trader_record.exchange_commitment == 0
         assert trader_record.pending_transfer == 0
 
-        assert len(list(session.query(TokenHolder).filter(TokenHolder.holder_list == target_token_holders_list.id))) == 2
+        assert len(list(session.query(TokenHolder).filter(TokenHolder.holder_list_id == target_token_holders_list.id))) == 2
 
         _user1_record_validator: IDXPosition = (
             session.query(IDXPosition)
@@ -1481,19 +1481,19 @@ class TestProcessor:
 
         issuer_record: TokenHolder = (
             session.query(TokenHolder)
-            .filter(TokenHolder.holder_list == target_token_holders_list.id)
+            .filter(TokenHolder.holder_list_id == target_token_holders_list.id)
             .filter(TokenHolder.account_address == self.issuer["account_address"])
             .first()
         )
         user1_record: TokenHolder = (
             session.query(TokenHolder)
-            .filter(TokenHolder.holder_list == target_token_holders_list.id)
+            .filter(TokenHolder.holder_list_id == target_token_holders_list.id)
             .filter(TokenHolder.account_address == self.user1["account_address"])
             .first()
         )
         trader_record: TokenHolder = (
             session.query(TokenHolder)
-            .filter(TokenHolder.holder_list == target_token_holders_list.id)
+            .filter(TokenHolder.holder_list_id == target_token_holders_list.id)
             .filter(TokenHolder.account_address == self.trader["account_address"])
             .first()
         )
@@ -1508,7 +1508,7 @@ class TestProcessor:
         assert trader_record.exchange_commitment == 0
         assert trader_record.pending_transfer == 0
 
-        assert len(list(session.query(TokenHolder).filter(TokenHolder.holder_list == target_token_holders_list.id))) == 2
+        assert len(list(session.query(TokenHolder).filter(TokenHolder.holder_list_id == target_token_holders_list.id))) == 2
 
         _user1_record_validator: IDXPosition = (
             session.query(IDXPosition)
@@ -1601,13 +1601,13 @@ class TestProcessor:
 
         user1_record: TokenHolder = (
             session.query(TokenHolder)
-            .filter(TokenHolder.holder_list == target_token_holders_list.id)
+            .filter(TokenHolder.holder_list_id == target_token_holders_list.id)
             .filter(TokenHolder.account_address == self.user1["account_address"])
             .first()
         )
         trader_record: TokenHolder = (
             session.query(TokenHolder)
-            .filter(TokenHolder.holder_list == target_token_holders_list.id)
+            .filter(TokenHolder.holder_list_id == target_token_holders_list.id)
             .filter(TokenHolder.account_address == self.trader["account_address"])
             .first()
         )
@@ -1622,7 +1622,7 @@ class TestProcessor:
         assert trader_record.exchange_commitment == 0
         assert trader_record.pending_transfer == 0
 
-        assert len(list(session.query(TokenHolder).filter(TokenHolder.holder_list == target_token_holders_list.id))) == 2
+        assert len(list(session.query(TokenHolder).filter(TokenHolder.holder_list_id == target_token_holders_list.id))) == 2
 
         _user1_record_validator: IDXPosition = (
             session.query(IDXPosition)
@@ -1711,13 +1711,13 @@ class TestProcessor:
 
         user1_record: TokenHolder = (
             session.query(TokenHolder)
-            .filter(TokenHolder.holder_list == target_token_holders_list.id)
+            .filter(TokenHolder.holder_list_id == target_token_holders_list.id)
             .filter(TokenHolder.account_address == self.user1["account_address"])
             .first()
         )
         trader_record: TokenHolder = (
             session.query(TokenHolder)
-            .filter(TokenHolder.holder_list == target_token_holders_list.id)
+            .filter(TokenHolder.holder_list_id == target_token_holders_list.id)
             .filter(TokenHolder.account_address == self.trader["account_address"])
             .first()
         )
@@ -1732,7 +1732,7 @@ class TestProcessor:
         assert trader_record.exchange_commitment == 0
         assert trader_record.pending_transfer == 0
 
-        assert len(list(session.query(TokenHolder).filter(TokenHolder.holder_list == target_token_holders_list.id))) == 2
+        assert len(list(session.query(TokenHolder).filter(TokenHolder.holder_list_id == target_token_holders_list.id))) == 2
 
         _user1_record_validator: IDXPosition = (
             session.query(IDXPosition)
@@ -1799,13 +1799,13 @@ class TestProcessor:
 
         user1_record: TokenHolder = (
             session.query(TokenHolder)
-            .filter(TokenHolder.holder_list == target_token_holders_list1.id)
+            .filter(TokenHolder.holder_list_id == target_token_holders_list1.id)
             .filter(TokenHolder.account_address == self.user1["account_address"])
             .first()
         )
         trader_record: TokenHolder = (
             session.query(TokenHolder)
-            .filter(TokenHolder.holder_list == target_token_holders_list1.id)
+            .filter(TokenHolder.holder_list_id == target_token_holders_list1.id)
             .filter(TokenHolder.account_address == self.trader["account_address"])
             .first()
         )
@@ -1856,13 +1856,13 @@ class TestProcessor:
 
         user1_record: TokenHolder = (
             session.query(TokenHolder)
-            .filter(TokenHolder.holder_list == target_token_holders_list2.id)
+            .filter(TokenHolder.holder_list_id == target_token_holders_list2.id)
             .filter(TokenHolder.account_address == self.user1["account_address"])
             .first()
         )
         trader_record: TokenHolder = (
             session.query(TokenHolder)
-            .filter(TokenHolder.holder_list == target_token_holders_list2.id)
+            .filter(TokenHolder.holder_list_id == target_token_holders_list2.id)
             .filter(TokenHolder.account_address == self.trader["account_address"])
             .first()
         )
@@ -1919,13 +1919,13 @@ class TestProcessor:
 
         user1_record: TokenHolder = (
             session.query(TokenHolder)
-            .filter(TokenHolder.holder_list == target_token_holders_list3.id)
+            .filter(TokenHolder.holder_list_id == target_token_holders_list3.id)
             .filter(TokenHolder.account_address == self.user1["account_address"])
             .first()
         )
         trader_record: TokenHolder = (
             session.query(TokenHolder)
-            .filter(TokenHolder.holder_list == target_token_holders_list3.id)
+            .filter(TokenHolder.holder_list_id == target_token_holders_list3.id)
             .filter(TokenHolder.account_address == self.trader["account_address"])
             .first()
         )
@@ -2073,6 +2073,6 @@ class TestProcessor:
             __sync_all_mock.return_value = None
             processor.collect()
             _records: List[TokenHolder] = (
-                session.query(TokenHolder).filter(TokenHolder.holder_list == target_token_holders_list.id).all()
+                session.query(TokenHolder).filter(TokenHolder.holder_list_id == target_token_holders_list.id).all()
             )
             assert len(_records) == 0

--- a/tests/batch/indexer_Token_Holders_test.py
+++ b/tests/batch/indexer_Token_Holders_test.py
@@ -2068,9 +2068,9 @@ class TestProcessor:
         session.commit()
 
         mock_lib = MagicMock()
-        with mock.patch.object(Processor, "_Processor__sync_all", return_value=mock_lib) as __sync_initial_issue_mock:
+        with mock.patch.object(Processor, "_Processor__sync_all", return_value=mock_lib) as __sync_all_mock:
             # Then execute processor.
-            __sync_initial_issue_mock.return_value = None
+            __sync_all_mock.return_value = None
             processor.collect()
             _records: List[TokenHolder] = (
                 session.query(TokenHolder).filter(TokenHolder.holder_list == target_token_holders_list.id).all()

--- a/tests/batch/indexer_Token_Holders_test.py
+++ b/tests/batch/indexer_Token_Holders_test.py
@@ -36,7 +36,7 @@ from app import config
 from app.config import ZERO_ADDRESS
 from app.contracts import Contract
 from app.model.db import Listing, IDXPosition
-from app.model.db.tokenholders import TokenHoldersList, BatchStatus, TokenHolder
+from app.model.db.tokenholders import TokenHoldersList, TokenHolderBatchStatus, TokenHolder
 from batch import (
     indexer_Position_Bond,
     indexer_Position_Share,
@@ -298,7 +298,7 @@ class TestProcessor:
         target_token_holders_list = TokenHoldersList()
         target_token_holders_list.list_id = str(uuid.uuid4())
         target_token_holders_list.token_address = token["address"]
-        target_token_holders_list.batch_status = BatchStatus.PENDING.value
+        target_token_holders_list.batch_status = TokenHolderBatchStatus.PENDING.value
         target_token_holders_list.block_number = block_number
         return target_token_holders_list
 
@@ -2019,7 +2019,7 @@ class TestProcessor:
         target_token_holders_list = TokenHoldersList()
         target_token_holders_list.token_address = ZERO_ADDRESS
         target_token_holders_list.list_id = str(uuid.uuid4())
-        target_token_holders_list.batch_status = BatchStatus.PENDING.value
+        target_token_holders_list.batch_status = TokenHolderBatchStatus.PENDING.value
         target_token_holders_list.block_number = 1000
         session.add(target_token_holders_list)
         session.commit()
@@ -2033,7 +2033,7 @@ class TestProcessor:
 
         # Batch status of token holders list expects to be "ERROR"
         error_record_num = len(
-            list(session.query(TokenHoldersList).filter(TokenHoldersList.batch_status == BatchStatus.FAILED.value))
+            list(session.query(TokenHoldersList).filter(TokenHoldersList.batch_status == TokenHolderBatchStatus.FAILED.value))
         )
         assert error_record_num == 1
 

--- a/tests/batch/indexer_Token_Holders_test.py
+++ b/tests/batch/indexer_Token_Holders_test.py
@@ -163,6 +163,7 @@ def coupon_position_indexer(coupon_validator_module: Type[CouponIndexer]):
     coupon_validator.initial_sync()
     return coupon_validator
 
+
 class TestProcessor:
     issuer = eth_account["issuer"]
     user1 = eth_account["user1"]
@@ -369,7 +370,9 @@ class TestProcessor:
         make_buy(self.trader, exchange_contract, token, 4000, 100)
         _latest_order_id = get_latest_orderid(exchange_contract)
         take_sell(self.user1, exchange_contract, _latest_order_id, 4000)
-        cancel_agreement(self.agent, exchange_contract, _latest_order_id, get_latest_agreementid(exchange_contract, _latest_order_id))
+        cancel_agreement(
+            self.agent, exchange_contract, _latest_order_id, get_latest_agreementid(exchange_contract, _latest_order_id)
+        )
 
         bond_transfer_to_exchange(self.user1, exchange_contract, token, 4000)
         make_buy(self.trader, exchange_contract, token, 4000, 100)
@@ -420,16 +423,7 @@ class TestProcessor:
         assert trader_record.exchange_commitment == 0
         assert trader_record.pending_transfer == 0
 
-        assert (
-            len(
-                list(
-                    session.query(TokenHolder).filter(
-                        TokenHolder.holder_list == target_token_holders_list.id
-                    )
-                )
-            )
-            == 2
-        )
+        assert len(list(session.query(TokenHolder).filter(TokenHolder.holder_list == target_token_holders_list.id))) == 2
 
         _user1_record_validator: IDXPosition = (
             session.query(IDXPosition)
@@ -509,12 +503,8 @@ class TestProcessor:
             7000,
         )
         _latest_security_escrow_id = get_latest_security_escrow_id({"address": escrow_contract.address})
-        finish_security_token_escrow(
-            self.agent, {"address": escrow_contract.address}, _latest_security_escrow_id
-        )
-        approve_transfer_security_token_escrow(
-            self.issuer, {"address": escrow_contract.address}, _latest_security_escrow_id, ""
-        )
+        finish_security_token_escrow(self.agent, {"address": escrow_contract.address}, _latest_security_escrow_id)
+        approve_transfer_security_token_escrow(self.issuer, {"address": escrow_contract.address}, _latest_security_escrow_id, "")
 
         create_security_token_escrow(
             self.user1,
@@ -525,9 +515,7 @@ class TestProcessor:
             2000,
         )
         _latest_security_escrow_id = get_latest_security_escrow_id({"address": escrow_contract.address})
-        finish_security_token_escrow(
-            self.agent, {"address": escrow_contract.address}, _latest_security_escrow_id
-        )
+        finish_security_token_escrow(self.agent, {"address": escrow_contract.address}, _latest_security_escrow_id)
 
         # Insert collection record with above token and current block number
         target_token_holders_list = self.token_holders_list(token, web3.eth.blockNumber)
@@ -565,16 +553,7 @@ class TestProcessor:
         assert trader_record.exchange_commitment == 0
         assert trader_record.pending_transfer == 0
 
-        assert (
-            len(
-                list(
-                    session.query(TokenHolder).filter(
-                        TokenHolder.holder_list == target_token_holders_list.id
-                    )
-                )
-            )
-            == 2
-        )
+        assert len(list(session.query(TokenHolder).filter(TokenHolder.holder_list == target_token_holders_list.id))) == 2
 
         _user1_record_validator: IDXPosition = (
             session.query(IDXPosition)
@@ -654,12 +633,8 @@ class TestProcessor:
             3000,
         )
         _latest_security_escrow_id = get_latest_security_escrow_id({"address": escrow_contract.address})
-        finish_security_token_escrow(
-            self.agent, {"address": escrow_contract.address}, _latest_security_escrow_id
-        )
-        approve_transfer_security_token_escrow(
-            self.issuer, {"address": escrow_contract.address}, _latest_security_escrow_id, ""
-        )
+        finish_security_token_escrow(self.agent, {"address": escrow_contract.address}, _latest_security_escrow_id)
+        approve_transfer_security_token_escrow(self.issuer, {"address": escrow_contract.address}, _latest_security_escrow_id, "")
 
         # Insert collection record with above token and current block number
         target_token_holders_list = self.token_holders_list(token, web3.eth.blockNumber)
@@ -698,16 +673,7 @@ class TestProcessor:
         assert trader_record.exchange_commitment == 0
         assert trader_record.pending_transfer == 0
 
-        assert (
-            len(
-                list(
-                    session.query(TokenHolder).filter(
-                        TokenHolder.holder_list == target_token_holders_list.id
-                    )
-                )
-            )
-            == 2
-        )
+        assert len(list(session.query(TokenHolder).filter(TokenHolder.holder_list == target_token_holders_list.id))) == 2
 
         _user1_record_validator: IDXPosition = (
             session.query(IDXPosition)
@@ -760,9 +726,7 @@ class TestProcessor:
         exchange = shared_contract["IbetShareExchange"]
 
         # Issuer issues share token.
-        token = self.issue_token_share(
-            self.issuer, exchange["address"], personal_info_contract["address"], token_list_contract
-        )
+        token = self.issue_token_share(self.issuer, exchange["address"], personal_info_contract["address"], token_list_contract)
         self.listing_token(token["address"], session)
         config.TOKEN_LIST_CONTRACT_ADDRESS = token_list_contract["address"]
         token_contract = Contract.get_contract("IbetShare", token["address"])
@@ -791,9 +755,7 @@ class TestProcessor:
         make_sell(self.user1, exchange, token, 10000, 100)
         _latest_order_id = get_latest_orderid(exchange)
         take_buy(self.trader, exchange, _latest_order_id, 10000)
-        confirm_agreement(
-            self.agent, exchange, _latest_order_id, get_latest_agreementid(exchange, _latest_order_id)
-        )
+        confirm_agreement(self.agent, exchange, _latest_order_id, get_latest_agreementid(exchange, _latest_order_id))
 
         share_issue_from(self.issuer, token, self.issuer["account_address"], 40000)
         share_redeem_from(self.issuer, token, self.trader["account_address"], 10000)
@@ -836,16 +798,7 @@ class TestProcessor:
         assert trader_record.exchange_commitment == 0
         assert trader_record.pending_transfer == 0
 
-        assert (
-            len(
-                list(
-                    session.query(TokenHolder).filter(
-                        TokenHolder.holder_list == target_token_holders_list.id
-                    )
-                )
-            )
-            == 2
-        )
+        assert len(list(session.query(TokenHolder).filter(TokenHolder.holder_list == target_token_holders_list.id))) == 2
 
         _user1_record_validator: IDXPosition = (
             session.query(IDXPosition)
@@ -930,12 +883,8 @@ class TestProcessor:
             7000,
         )
         _latest_security_escrow_id = get_latest_security_escrow_id({"address": escrow_contract.address})
-        finish_security_token_escrow(
-            self.agent, {"address": escrow_contract.address}, _latest_security_escrow_id
-        )
-        approve_transfer_security_token_escrow(
-            self.issuer, {"address": escrow_contract.address}, _latest_security_escrow_id, ""
-        )
+        finish_security_token_escrow(self.agent, {"address": escrow_contract.address}, _latest_security_escrow_id)
+        approve_transfer_security_token_escrow(self.issuer, {"address": escrow_contract.address}, _latest_security_escrow_id, "")
 
         create_security_token_escrow(
             self.user1,
@@ -946,9 +895,7 @@ class TestProcessor:
             2000,
         )
         _latest_security_escrow_id = get_latest_security_escrow_id({"address": escrow_contract.address})
-        finish_security_token_escrow(
-            self.agent, {"address": escrow_contract.address}, _latest_security_escrow_id
-        )
+        finish_security_token_escrow(self.agent, {"address": escrow_contract.address}, _latest_security_escrow_id)
 
         # Insert collection record with above token and current block number
         target_token_holders_list = self.token_holders_list(token, web3.eth.blockNumber)
@@ -987,16 +934,7 @@ class TestProcessor:
         assert trader_record.exchange_commitment == 0
         assert trader_record.pending_transfer == 0
 
-        assert (
-            len(
-                list(
-                    session.query(TokenHolder).filter(
-                        TokenHolder.holder_list == target_token_holders_list.id
-                    )
-                )
-            )
-            == 2
-        )
+        assert len(list(session.query(TokenHolder).filter(TokenHolder.holder_list == target_token_holders_list.id))) == 2
 
         _user1_record_validator: IDXPosition = (
             session.query(IDXPosition)
@@ -1076,12 +1014,8 @@ class TestProcessor:
             3000,
         )
         _latest_security_escrow_id = get_latest_security_escrow_id({"address": escrow_contract.address})
-        finish_security_token_escrow(
-            self.agent, {"address": escrow_contract.address}, _latest_security_escrow_id
-        )
-        approve_transfer_security_token_escrow(
-            self.issuer, {"address": escrow_contract.address}, _latest_security_escrow_id, ""
-        )
+        finish_security_token_escrow(self.agent, {"address": escrow_contract.address}, _latest_security_escrow_id)
+        approve_transfer_security_token_escrow(self.issuer, {"address": escrow_contract.address}, _latest_security_escrow_id, "")
 
         # Insert collection record with above token and current block number
         target_token_holders_list = self.token_holders_list(token, web3.eth.blockNumber)
@@ -1120,16 +1054,7 @@ class TestProcessor:
         assert trader_record.exchange_commitment == 0
         assert trader_record.pending_transfer == 0
 
-        assert (
-            len(
-                list(
-                    session.query(TokenHolder).filter(
-                        TokenHolder.holder_list == target_token_holders_list.id
-                    )
-                )
-            )
-            == 2
-        )
+        assert len(list(session.query(TokenHolder).filter(TokenHolder.holder_list == target_token_holders_list.id))) == 2
 
         _user1_record_validator: IDXPosition = (
             session.query(IDXPosition)
@@ -1200,9 +1125,7 @@ class TestProcessor:
         make_sell(self.user1, exchange, token, 10000, 100)
         _latest_order_id = get_latest_orderid(exchange)
         take_buy(self.trader, exchange, _latest_order_id, 10000)
-        confirm_agreement(
-            self.agent, exchange, _latest_order_id, get_latest_agreementid(exchange, _latest_order_id)
-        )
+        confirm_agreement(self.agent, exchange, _latest_order_id, get_latest_agreementid(exchange, _latest_order_id))
 
         # Insert collection record with above token and current block number
         target_token_holders_list = self.token_holders_list(token, web3.eth.blockNumber)
@@ -1239,16 +1162,7 @@ class TestProcessor:
         assert trader_record.exchange_commitment == 0
         assert trader_record.pending_transfer == 0
 
-        assert (
-            len(
-                list(
-                    session.query(TokenHolder).filter(
-                        TokenHolder.holder_list == target_token_holders_list.id
-                    )
-                )
-            )
-            == 2
-        )
+        assert len(list(session.query(TokenHolder).filter(TokenHolder.holder_list == target_token_holders_list.id))) == 2
 
         _user1_record_validator: IDXPosition = (
             session.query(IDXPosition)
@@ -1363,16 +1277,7 @@ class TestProcessor:
         assert trader_record.exchange_commitment == 0
         assert trader_record.pending_transfer == 0
 
-        assert (
-            len(
-                list(
-                    session.query(TokenHolder).filter(
-                        TokenHolder.holder_list == target_token_holders_list.id
-                    )
-                )
-            )
-            == 2
-        )
+        assert len(list(session.query(TokenHolder).filter(TokenHolder.holder_list == target_token_holders_list.id))) == 2
 
         _user1_record_validator: IDXPosition = (
             session.query(IDXPosition)
@@ -1484,16 +1389,7 @@ class TestProcessor:
         assert trader_record.exchange_commitment == 0
         assert trader_record.pending_transfer == 0
 
-        assert (
-            len(
-                list(
-                    session.query(TokenHolder).filter(
-                        TokenHolder.holder_list == target_token_holders_list.id
-                    )
-                )
-            )
-            == 2
-        )
+        assert len(list(session.query(TokenHolder).filter(TokenHolder.holder_list == target_token_holders_list.id))) == 2
 
         _user1_record_validator: IDXPosition = (
             session.query(IDXPosition)
@@ -1564,9 +1460,7 @@ class TestProcessor:
         make_sell(self.user1, exchange, token, 10000, 100)
         _latest_order_id = get_latest_orderid(exchange)
         take_buy(self.trader, exchange, _latest_order_id, 10000)
-        confirm_agreement(
-            self.agent, exchange, _latest_order_id, get_latest_agreementid(exchange, _latest_order_id)
-        )
+        confirm_agreement(self.agent, exchange, _latest_order_id, get_latest_agreementid(exchange, _latest_order_id))
 
         # Insert collection record with above token and current block number
         target_token_holders_list = self.token_holders_list(token, web3.eth.blockNumber)
@@ -1609,16 +1503,7 @@ class TestProcessor:
         assert trader_record.exchange_commitment == 0
         assert trader_record.pending_transfer == 0
 
-        assert (
-            len(
-                list(
-                    session.query(TokenHolder).filter(
-                        TokenHolder.holder_list == target_token_holders_list.id
-                    )
-                )
-            )
-            == 2
-        )
+        assert len(list(session.query(TokenHolder).filter(TokenHolder.holder_list == target_token_holders_list.id))) == 2
 
         _user1_record_validator: IDXPosition = (
             session.query(IDXPosition)
@@ -1732,16 +1617,7 @@ class TestProcessor:
         assert trader_record.exchange_commitment == 0
         assert trader_record.pending_transfer == 0
 
-        assert (
-            len(
-                list(
-                    session.query(TokenHolder).filter(
-                        TokenHolder.holder_list == target_token_holders_list.id
-                    )
-                )
-            )
-            == 2
-        )
+        assert len(list(session.query(TokenHolder).filter(TokenHolder.holder_list == target_token_holders_list.id))) == 2
 
         _user1_record_validator: IDXPosition = (
             session.query(IDXPosition)
@@ -1851,16 +1727,7 @@ class TestProcessor:
         assert trader_record.exchange_commitment == 0
         assert trader_record.pending_transfer == 0
 
-        assert (
-            len(
-                list(
-                    session.query(TokenHolder).filter(
-                        TokenHolder.holder_list == target_token_holders_list.id
-                    )
-                )
-            )
-            == 2
-        )
+        assert len(list(session.query(TokenHolder).filter(TokenHolder.holder_list == target_token_holders_list.id))) == 2
 
         _user1_record_validator: IDXPosition = (
             session.query(IDXPosition)
@@ -1919,12 +1786,12 @@ class TestProcessor:
         bond_authorize_lock_address(self.issuer, token, self.trader["account_address"], True)
         bond_lock(self.user1, token, self.trader["account_address"], 10000)
         bond_unlock(self.trader, token, self.user1["account_address"], self.user1["account_address"], 5000)
-        target_token_holders_list1 = self.token_holders_list(token, web3.eth.blockNumber)        
+        target_token_holders_list1 = self.token_holders_list(token, web3.eth.blockNumber)
         session.add(target_token_holders_list1)
         session.commit()
         bond_position_indexer.sync_new_logs()
         processor.collect()
-        
+
         user1_record: TokenHolder = (
             session.query(TokenHolder)
             .filter(TokenHolder.holder_list == target_token_holders_list1.id)
@@ -1981,7 +1848,7 @@ class TestProcessor:
         session.commit()
         bond_position_indexer.sync_new_logs()
         processor.collect()
-        
+
         user1_record: TokenHolder = (
             session.query(TokenHolder)
             .filter(TokenHolder.holder_list == target_token_holders_list2.id)
@@ -2017,12 +1884,14 @@ class TestProcessor:
         assert trader_record.pending_transfer == _trader_record_validator.pending_transfer
         assert trader_record.exchange_balance == _trader_record_validator.exchange_balance
         assert trader_record.exchange_commitment == _trader_record_validator.exchange_commitment
-        
+
         bond_transfer_to_exchange(self.user1, exchange_contract, token, 4000)
         make_buy(self.trader, exchange_contract, token, 4000, 100)
         _latest_order_id = get_latest_orderid(exchange_contract)
         take_sell(self.user1, exchange_contract, _latest_order_id, 4000)
-        cancel_agreement(self.agent, exchange_contract, _latest_order_id, get_latest_agreementid(exchange_contract, _latest_order_id))
+        cancel_agreement(
+            self.agent, exchange_contract, _latest_order_id, get_latest_agreementid(exchange_contract, _latest_order_id)
+        )
 
         bond_transfer_to_exchange(self.user1, exchange_contract, token, 4000)
         make_buy(self.trader, exchange_contract, token, 4000, 100)
@@ -2042,7 +1911,7 @@ class TestProcessor:
         session.commit()
         bond_position_indexer.sync_new_logs()
         processor.collect()
-        
+
         user1_record: TokenHolder = (
             session.query(TokenHolder)
             .filter(TokenHolder.holder_list == target_token_holders_list3.id)
@@ -2077,14 +1946,12 @@ class TestProcessor:
         assert trader_record.balance == _trader_record_validator.balance
         assert trader_record.pending_transfer == _trader_record_validator.pending_transfer
         assert trader_record.exchange_balance == _trader_record_validator.exchange_balance
-        assert trader_record.exchange_commitment == _trader_record_validator.exchange_commitment        
+        assert trader_record.exchange_commitment == _trader_record_validator.exchange_commitment
 
     # <Normal_14>
     # StraightBond
     # Pending jobs are to be processed one by one.
-    def test_normal_14(
-        self, processor: Processor, shared_contract, session: Session, caplog, block_number: None
-    ):
+    def test_normal_14(self, processor: Processor, shared_contract, session: Session, caplog, block_number: None):
         token_list_contract = shared_contract["TokenList"]
         personal_info_contract = shared_contract["PersonalInfo"]
         exchange_contract = shared_contract["IbetStraightBondExchange"]
@@ -2123,9 +1990,7 @@ class TestProcessor:
 
     # <Error_1>
     # There is no target token holders list id with batch_status PENDING.
-    def test_error_1(
-        self, processor: Processor, shared_contract, session: Session, caplog, block_number: None
-    ):
+    def test_error_1(self, processor: Processor, shared_contract, session: Session, caplog, block_number: None):
         LOG.addHandler(caplog.handler)
         with caplog.at_level(logging.DEBUG):
             processor.collect()
@@ -2135,9 +2000,7 @@ class TestProcessor:
     # <Error_2>
     # There is target token holders list id with batch_status PENDING.
     # And target token is not contained in "TokenList" contract.
-    def test_error_2(
-        self, processor: Processor, shared_contract, session: Session, caplog, block_number: None
-    ):
+    def test_error_2(self, processor: Processor, shared_contract, session: Session, caplog, block_number: None):
         token_list_contract = shared_contract["TokenList"]
         config.TOKEN_LIST_CONTRACT_ADDRESS = token_list_contract["address"]
 
@@ -2159,20 +2022,14 @@ class TestProcessor:
 
         # Batch status of token holders list expects to be "ERROR"
         error_record_num = len(
-            list(
-                session.query(TokenHoldersList).filter(
-                    TokenHoldersList.batch_status == BatchStatus.FAILED.value
-                )
-            )
+            list(session.query(TokenHoldersList).filter(TokenHoldersList.batch_status == BatchStatus.FAILED.value))
         )
         assert error_record_num == 1
 
     # <Error_3>
     # Failed to get Logs from blockchain.
     @mock.patch("web3.contract.ContractEvent.getLogs", MagicMock(side_effect=Exception()))
-    def test_error_3(
-        self, processor: Processor, shared_contract, session: Session, caplog, block_number: None
-    ):
+    def test_error_3(self, processor: Processor, shared_contract, session: Session, caplog, block_number: None):
         token_list_contract = shared_contract["TokenList"]
         personal_info_contract = shared_contract["PersonalInfo"]
         escrow_contract = shared_contract["IbetSecurityTokenEscrow"]

--- a/tests/batch/indexer_Token_Holders_test.py
+++ b/tests/batch/indexer_Token_Holders_test.py
@@ -1,0 +1,2210 @@
+"""
+Copyright BOOSTRY Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+import logging
+import uuid
+from typing import Type, List
+from unittest import mock
+from unittest.mock import MagicMock
+import pytest
+from sqlalchemy.orm import Session
+
+from web3 import Web3
+from web3.middleware import geth_poa_middleware
+
+from app import config
+from app.config import ZERO_ADDRESS
+from app.contracts import Contract
+from app.model.db import Listing, IDXPosition
+from app.model.db.tokenholders import TokenHoldersList, BatchStatus, TokenHolder
+from batch import (
+    indexer_Position_Bond,
+    indexer_Position_Share,
+    indexer_Position_Membership,
+    indexer_Position_Coupon,
+)
+from batch.indexer_Token_Holders import LOG, Processor
+from batch.indexer_Position_Bond import Processor as BondIndexer
+from batch.indexer_Position_Share import Processor as ShareIndexer
+from batch.indexer_Position_Membership import Processor as MembershipIndexer
+from batch.indexer_Position_Coupon import Processor as CouponIndexer
+from tests.account_config import eth_account
+from tests.contract_modules import (
+    issue_bond_token,
+    register_bond_list,
+    bond_transfer_to_exchange,
+    create_security_token_escrow,
+    finish_security_token_escrow,
+    cancel_order,
+    force_cancel_order,
+    make_sell,
+    take_sell,
+    get_latest_agreementid,
+    get_latest_orderid,
+    get_latest_security_escrow_id,
+    transfer_token,
+    take_buy,
+    confirm_agreement,
+    make_buy,
+    cancel_agreement,
+    register_personalinfo,
+    approve_transfer_security_token_escrow,
+    register_share_list,
+    issue_share_token,
+    share_transfer_to_exchange,
+    membership_issue,
+    membership_register_list,
+    membership_transfer_to_exchange,
+    coupon_transfer_to_exchange,
+    issue_coupon_token,
+    coupon_register_list,
+    consume_coupon_token,
+    bond_apply_for_transfer,
+    bond_cancel_transfer,
+    bond_approve_transfer,
+    bond_lock,
+    bond_unlock,
+    bond_authorize_lock_address,
+    bond_issue_from,
+    share_set_transfer_approval_required,
+    bond_redeem_from,
+    bond_set_transfer_approval_required,
+    share_authorize_lock_address,
+    share_lock,
+    share_unlock,
+    share_issue_from,
+    share_redeem_from,
+    share_apply_for_transfer,
+    share_cancel_transfer,
+    share_approve_transfer,
+    finish_token_escrow,
+    create_token_escrow,
+    get_latest_escrow_id,
+)
+
+web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
+web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+
+
+@pytest.fixture(scope="session")
+def test_module(shared_contract):
+    return Processor
+
+
+@pytest.fixture(scope="function")
+def processor(test_module, session):
+    processor = test_module()
+    return processor
+
+
+@pytest.fixture(scope="session")
+def bond_validator_module(shared_contract):
+    indexer_Position_Bond.TOKEN_LIST_CONTRACT_ADDRESS = shared_contract["TokenList"]["address"]
+    return BondIndexer
+
+
+@pytest.fixture(scope="function")
+def bond_position_indexer(bond_validator_module, session):
+    bond_validator = bond_validator_module()
+    bond_validator.initial_sync()
+    return bond_validator
+
+
+@pytest.fixture(scope="session")
+def share_validator_module(shared_contract):
+    indexer_Position_Share.TOKEN_LIST_CONTRACT_ADDRESS = shared_contract["TokenList"]["address"]
+    return ShareIndexer
+
+
+@pytest.fixture(scope="function")
+def share_position_indexer(share_validator_module: Type[ShareIndexer]):
+    share_validator = share_validator_module()
+    share_validator.initial_sync()
+    return share_validator
+
+
+@pytest.fixture(scope="session")
+def membership_validator_module(shared_contract):
+    indexer_Position_Membership.TOKEN_LIST_CONTRACT_ADDRESS = shared_contract["TokenList"]["address"]
+    return MembershipIndexer
+
+
+@pytest.fixture(scope="function")
+def membership_position_indexer(membership_validator_module: Type[MembershipIndexer]):
+    membership_validator = membership_validator_module()
+    membership_validator.initial_sync()
+    return membership_validator
+
+
+@pytest.fixture(scope="session")
+def coupon_validator_module(shared_contract):
+    indexer_Position_Coupon.TOKEN_LIST_CONTRACT_ADDRESS = shared_contract["TokenList"]["address"]
+    return CouponIndexer
+
+
+@pytest.fixture(scope="function")
+def coupon_position_indexer(coupon_validator_module: Type[CouponIndexer]):
+    coupon_validator = coupon_validator_module()
+    coupon_validator.initial_sync()
+    return coupon_validator
+
+class TestProcessor:
+    issuer = eth_account["issuer"]
+    user1 = eth_account["user1"]
+    user2 = eth_account["user2"]
+    trader = eth_account["trader"]
+    agent = eth_account["agent"]
+
+    @staticmethod
+    def listing_token(token_address, session):
+        _listing = Listing()
+        _listing.token_address = token_address
+        _listing.is_public = True
+        _listing.max_holding_quantity = 1000000
+        _listing.max_sell_amount = 1000000
+        _listing.owner_address = TestProcessor.issuer["account_address"]
+        session.add(_listing)
+        session.commit()
+
+    @staticmethod
+    def issue_token_bond(issuer, exchange_contract_address, personal_info_contract_address, token_list):
+        # Issue token
+        args = {
+            "name": "テスト債券",
+            "symbol": "BOND",
+            "totalSupply": 1000000,
+            "tradableExchange": exchange_contract_address,
+            "faceValue": 10000,
+            "interestRate": 602,
+            "interestPaymentDate1": "0101",
+            "interestPaymentDate2": "0201",
+            "interestPaymentDate3": "0301",
+            "interestPaymentDate4": "0401",
+            "interestPaymentDate5": "0501",
+            "interestPaymentDate6": "0601",
+            "interestPaymentDate7": "0701",
+            "interestPaymentDate8": "0801",
+            "interestPaymentDate9": "0901",
+            "interestPaymentDate10": "1001",
+            "interestPaymentDate11": "1101",
+            "interestPaymentDate12": "1201",
+            "redemptionDate": "20191231",
+            "redemptionValue": 10000,
+            "returnDate": "20191231",
+            "returnAmount": "商品券をプレゼント",
+            "purpose": "新商品の開発資金として利用。",
+            "memo": "メモ",
+            "contactInformation": "問い合わせ先",
+            "privacyPolicy": "プライバシーポリシー",
+            "personalInfoAddress": personal_info_contract_address,
+            "transferable": True,
+            "isRedeemed": False,
+        }
+        token = issue_bond_token(issuer, args)
+        register_bond_list(issuer, token, token_list)
+
+        return token
+
+    @staticmethod
+    def issue_token_share(issuer, exchange_contract_address, personal_info_contract_address, token_list):
+        # Issue token
+        args = {
+            "name": "テスト株式",
+            "symbol": "SHARE",
+            "tradableExchange": exchange_contract_address,
+            "personalInfoAddress": personal_info_contract_address,
+            "issuePrice": 1000,
+            "principalValue": 1000,
+            "totalSupply": 1000000,
+            "dividends": 101,
+            "dividendRecordDate": "20200401",
+            "dividendPaymentDate": "20200502",
+            "cancellationDate": "20200603",
+            "contactInformation": "問い合わせ先",
+            "privacyPolicy": "プライバシーポリシー",
+            "memo": "メモ",
+            "transferable": True,
+        }
+        token = issue_share_token(issuer, args)
+        register_share_list(issuer, token, token_list)
+
+        return token
+
+    @staticmethod
+    def issue_token_coupon(issuer, exchange_contract_address, token_list):
+        # Issue token
+        args = {
+            "name": "テストクーポン",
+            "symbol": "COUPON",
+            "totalSupply": 1000000,
+            "tradableExchange": exchange_contract_address,
+            "details": "クーポン詳細",
+            "returnDetails": "リターン詳細",
+            "memo": "クーポンメモ欄",
+            "expirationDate": "20191231",
+            "transferable": True,
+            "contactInformation": "問い合わせ先",
+            "privacyPolicy": "プライバシーポリシー",
+        }
+        token = issue_coupon_token(issuer, args)
+        coupon_register_list(issuer, token, token_list)
+
+        return token
+
+    @staticmethod
+    def issue_token_membership(issuer, exchange_contract_address, token_list):
+        # Issue token
+        args = {
+            "name": "テスト会員権",
+            "symbol": "MEMBERSHIP",
+            "initialSupply": 1000000,
+            "tradableExchange": exchange_contract_address,
+            "details": "詳細",
+            "returnDetails": "リターン詳細",
+            "expirationDate": "20191231",
+            "memo": "メモ",
+            "transferable": True,
+            "contactInformation": "問い合わせ先",
+            "privacyPolicy": "プライバシーポリシー",
+        }
+        token = membership_issue(issuer, args)
+        membership_register_list(issuer, token, token_list)
+
+        return token
+
+    @staticmethod
+    def token_holders_list(token, block_number) -> TokenHoldersList:
+        target_token_holders_list = TokenHoldersList()
+        target_token_holders_list.list_id = str(uuid.uuid4())
+        target_token_holders_list.token_address = token["address"]
+        target_token_holders_list.batch_status = BatchStatus.PENDING.value
+        target_token_holders_list.block_number = block_number
+        return target_token_holders_list
+
+    ###########################################################################
+    # Normal Case
+    ###########################################################################
+
+    # <Normal_1>
+    # StraightBond
+    # Events
+    # - Transfer
+    # - Lock
+    # - Unlock
+    # - Exchange
+    #   - MakeOrder
+    #   - CancelOrder
+    #   - ForceCancelOrder
+    #   - TakeOrder
+    #   - CancelAgreement
+    #   - ConfirmAgreement
+    # - IssueFrom
+    # - RedeemFrom
+    def test_normal_1(
+        self,
+        processor: Processor,
+        shared_contract,
+        session: Session,
+        bond_position_indexer: BondIndexer,
+        block_number: None,
+    ):
+        token_list_contract = shared_contract["TokenList"]
+        personal_info_contract = shared_contract["PersonalInfo"]
+        exchange_contract = shared_contract["IbetStraightBondExchange"]
+
+        # Issuer issues bond token.
+        token = self.issue_token_bond(
+            self.issuer, exchange_contract["address"], personal_info_contract["address"], token_list_contract
+        )
+        self.listing_token(token["address"], session)
+        config.TOKEN_LIST_CONTRACT_ADDRESS = token_list_contract["address"]
+        token_contract = Contract.get_contract("IbetStraightBond", token["address"])
+
+        # User1 and trader must register personal information before they receive token.
+        register_personalinfo(self.user1, personal_info_contract)
+        register_personalinfo(self.trader, personal_info_contract)
+
+        # Issuer transfers issued token to user1, trader and exchange.
+        transfer_token(token_contract, self.issuer["account_address"], self.user1["account_address"], 20000)
+        transfer_token(token_contract, self.issuer["account_address"], self.trader["account_address"], 10000)
+        bond_transfer_to_exchange(self.issuer, {"address": exchange_contract["address"]}, token, 10000)
+
+        bond_authorize_lock_address(self.issuer, token, self.user1["account_address"], True)
+        bond_authorize_lock_address(self.issuer, token, self.trader["account_address"], True)
+        bond_lock(self.user1, token, self.trader["account_address"], 10000)
+        bond_unlock(self.trader, token, self.user1["account_address"], self.user1["account_address"], 5000)
+
+        bond_transfer_to_exchange(self.user1, {"address": exchange_contract["address"]}, token, 10000)
+        make_sell(self.user1, exchange_contract, token, 10000, 100)
+        cancel_order(self.user1, exchange_contract, get_latest_orderid(exchange_contract))
+
+        bond_transfer_to_exchange(self.user1, exchange_contract, token, 10000)
+        make_sell(self.user1, exchange_contract, token, 10000, 100)
+        force_cancel_order(self.agent, exchange_contract, get_latest_orderid(exchange_contract))
+
+        bond_transfer_to_exchange(self.user1, exchange_contract, token, 10000)
+        make_sell(self.user1, exchange_contract, token, 10000, 100)
+        _latest_order_id = get_latest_orderid(exchange_contract)
+        take_buy(self.trader, exchange_contract, _latest_order_id, 10000)
+        confirm_agreement(
+            self.agent, exchange_contract, _latest_order_id, get_latest_agreementid(exchange_contract, _latest_order_id)
+        )
+
+        bond_transfer_to_exchange(self.user1, exchange_contract, token, 4000)
+        make_buy(self.trader, exchange_contract, token, 4000, 100)
+        _latest_order_id = get_latest_orderid(exchange_contract)
+        take_sell(self.user1, exchange_contract, _latest_order_id, 4000)
+        cancel_agreement(self.agent, exchange_contract, _latest_order_id, get_latest_agreementid(exchange_contract, _latest_order_id))
+
+        bond_transfer_to_exchange(self.user1, exchange_contract, token, 4000)
+        make_buy(self.trader, exchange_contract, token, 4000, 100)
+        _latest_order_id = get_latest_orderid(exchange_contract)
+        take_sell(self.user1, exchange_contract, _latest_order_id, 4000)
+        confirm_agreement(
+            self.agent, exchange_contract, _latest_order_id, get_latest_agreementid(exchange_contract, _latest_order_id)
+        )
+
+        bond_issue_from(self.issuer, token, self.issuer["account_address"], 40000)
+        bond_redeem_from(self.issuer, token, self.trader["account_address"], 10000)
+
+        bond_issue_from(self.issuer, token, self.trader["account_address"], 30000)
+        bond_redeem_from(self.issuer, token, self.issuer["account_address"], 10000)
+
+        # Insert collection record with above token and current block number
+        target_token_holders_list = self.token_holders_list(token, web3.eth.blockNumber)
+        session.add(target_token_holders_list)
+        session.commit()
+        bond_position_indexer.sync_new_logs()
+
+        # Issuer transfers issued token to user1 again to proceed block_number on chain.
+        transfer_token(token_contract, self.issuer["account_address"], self.user1["account_address"], 100000)
+
+        # Then execute processor.
+        processor.collect()
+
+        user1_record: TokenHolder = (
+            session.query(TokenHolder)
+            .filter(TokenHolder.holder_list == target_token_holders_list.id)
+            .filter(TokenHolder.account_address == self.user1["account_address"])
+            .first()
+        )
+        trader_record: TokenHolder = (
+            session.query(TokenHolder)
+            .filter(TokenHolder.holder_list == target_token_holders_list.id)
+            .filter(TokenHolder.account_address == self.trader["account_address"])
+            .first()
+        )
+
+        assert user1_record.exchange_balance == 0
+        assert user1_record.balance == 1000
+        assert user1_record.exchange_commitment == 0
+        assert user1_record.pending_transfer == 0
+
+        assert trader_record.exchange_balance == 0
+        assert trader_record.balance == 44000
+        assert trader_record.exchange_commitment == 0
+        assert trader_record.pending_transfer == 0
+
+        assert (
+            len(
+                list(
+                    session.query(TokenHolder).filter(
+                        TokenHolder.holder_list == target_token_holders_list.id
+                    )
+                )
+            )
+            == 2
+        )
+
+        _user1_record_validator: IDXPosition = (
+            session.query(IDXPosition)
+            .filter(IDXPosition.account_address == user1_record.account_address)
+            .order_by(IDXPosition.created)
+            .first()
+        )
+        _trader_record_validator: IDXPosition = (
+            session.query(IDXPosition)
+            .filter(IDXPosition.account_address == trader_record.account_address)
+            .order_by(IDXPosition.created)
+            .first()
+        )
+
+        assert user1_record.balance == _user1_record_validator.balance
+        assert user1_record.pending_transfer == _user1_record_validator.pending_transfer
+        assert user1_record.exchange_balance == _user1_record_validator.exchange_balance
+        assert user1_record.exchange_commitment == _user1_record_validator.exchange_commitment
+
+        assert trader_record.balance == _trader_record_validator.balance
+        assert trader_record.pending_transfer == _trader_record_validator.pending_transfer
+        assert trader_record.exchange_balance == _trader_record_validator.exchange_balance
+        assert trader_record.exchange_commitment == _trader_record_validator.exchange_commitment
+
+    # <Normal_2>
+    # StraightBond
+    # Events
+    # - ApplyForTransfer
+    # - CancelForTransfer
+    # - ApproveTransfer
+    # - Escrow
+    #   - CreateEscrow
+    #   - FinishEscrow
+    #   - ApproveTransfer
+    def test_normal_2(
+        self,
+        processor: Processor,
+        shared_contract,
+        session: Session,
+        bond_position_indexer: BondIndexer,
+        block_number: None,
+    ):
+        token_list_contract = shared_contract["TokenList"]
+        personal_info_contract = shared_contract["PersonalInfo"]
+        escrow_contract = shared_contract["IbetSecurityTokenEscrow"]
+
+        # Issuer issues bond token.
+        token = self.issue_token_bond(
+            self.issuer, escrow_contract.address, personal_info_contract["address"], token_list_contract
+        )
+        self.listing_token(token["address"], session)
+
+        config.TOKEN_LIST_CONTRACT_ADDRESS = token_list_contract["address"]
+        token_contract = Contract.get_contract("IbetStraightBond", token["address"])
+
+        # User1 and trader must register personal information before they receive token.
+        register_personalinfo(self.user1, personal_info_contract)
+        register_personalinfo(self.trader, personal_info_contract)
+
+        transfer_token(token_contract, self.issuer["account_address"], self.user1["account_address"], 20000)
+        bond_transfer_to_exchange(self.user1, {"address": escrow_contract.address}, token, 10000)
+
+        # Issuer transfers issued token to user1 and trader.
+        bond_set_transfer_approval_required(self.issuer, token, True)
+        bond_apply_for_transfer(self.issuer, token, self.user1, 10000, "to user1#1")
+        bond_apply_for_transfer(self.issuer, token, self.trader, 10000, "to trader#1")
+
+        bond_cancel_transfer(self.issuer, token, 0, "to user1#1")
+        bond_approve_transfer(self.issuer, token, 1, "to trader#1")
+
+        create_security_token_escrow(
+            self.user1,
+            {"address": escrow_contract.address},
+            token,
+            self.trader["account_address"],
+            self.agent["account_address"],
+            7000,
+        )
+        _latest_security_escrow_id = get_latest_security_escrow_id({"address": escrow_contract.address})
+        finish_security_token_escrow(
+            self.agent, {"address": escrow_contract.address}, _latest_security_escrow_id
+        )
+        approve_transfer_security_token_escrow(
+            self.issuer, {"address": escrow_contract.address}, _latest_security_escrow_id, ""
+        )
+
+        create_security_token_escrow(
+            self.user1,
+            {"address": escrow_contract.address},
+            token,
+            self.trader["account_address"],
+            self.agent["account_address"],
+            2000,
+        )
+        _latest_security_escrow_id = get_latest_security_escrow_id({"address": escrow_contract.address})
+        finish_security_token_escrow(
+            self.agent, {"address": escrow_contract.address}, _latest_security_escrow_id
+        )
+
+        # Insert collection record with above token and current block number
+        target_token_holders_list = self.token_holders_list(token, web3.eth.blockNumber)
+        session.add(target_token_holders_list)
+        session.commit()
+
+        bond_position_indexer.sync_new_logs()
+
+        # Issuer transfers issued token to user1 again to proceed block_number on chain.
+        bond_set_transfer_approval_required(self.issuer, token, False)
+        transfer_token(token_contract, self.issuer["account_address"], self.user1["account_address"], 100000)
+
+        # Then execute processor.
+        processor.collect()
+        user1_record: TokenHolder = (
+            session.query(TokenHolder)
+            .filter(TokenHolder.holder_list == target_token_holders_list.id)
+            .filter(TokenHolder.account_address == self.user1["account_address"])
+            .first()
+        )
+        trader_record: TokenHolder = (
+            session.query(TokenHolder)
+            .filter(TokenHolder.holder_list == target_token_holders_list.id)
+            .filter(TokenHolder.account_address == self.trader["account_address"])
+            .first()
+        )
+
+        assert user1_record.exchange_balance == 1000
+        assert user1_record.balance == 10000  # 20000
+        assert user1_record.exchange_commitment == 2000
+        assert user1_record.pending_transfer == 0
+
+        assert trader_record.exchange_balance == 7000
+        assert trader_record.balance == 10000
+        assert trader_record.exchange_commitment == 0
+        assert trader_record.pending_transfer == 0
+
+        assert (
+            len(
+                list(
+                    session.query(TokenHolder).filter(
+                        TokenHolder.holder_list == target_token_holders_list.id
+                    )
+                )
+            )
+            == 2
+        )
+
+        _user1_record_validator: IDXPosition = (
+            session.query(IDXPosition)
+            .filter(IDXPosition.account_address == user1_record.account_address)
+            .order_by(IDXPosition.created)
+            .first()
+        )
+        _trader_record_validator: IDXPosition = (
+            session.query(IDXPosition)
+            .filter(IDXPosition.account_address == trader_record.account_address)
+            .order_by(IDXPosition.created)
+            .first()
+        )
+
+        assert user1_record.balance == _user1_record_validator.balance
+        assert user1_record.pending_transfer == _user1_record_validator.pending_transfer
+        assert user1_record.exchange_balance == _user1_record_validator.exchange_balance
+        assert user1_record.exchange_commitment == _user1_record_validator.exchange_commitment
+
+        assert trader_record.balance == _trader_record_validator.balance
+        assert trader_record.pending_transfer == _trader_record_validator.pending_transfer
+        assert trader_record.exchange_balance == _trader_record_validator.exchange_balance
+        assert trader_record.exchange_commitment == _trader_record_validator.exchange_commitment
+
+    # <Normal_3>
+    # StraightBond
+    # Events
+    # - ApplyForTransfer - pending
+    # - Escrow - pending
+    def test_normal_3(
+        self,
+        processor: Processor,
+        shared_contract,
+        session: Session,
+        bond_position_indexer: BondIndexer,
+        block_number: None,
+    ):
+        token_list_contract = shared_contract["TokenList"]
+        personal_info_contract = shared_contract["PersonalInfo"]
+        escrow_contract = shared_contract["IbetSecurityTokenEscrow"]
+
+        # Issuer issues bond token.
+        token = self.issue_token_bond(
+            self.issuer, escrow_contract.address, personal_info_contract["address"], token_list_contract
+        )
+        self.listing_token(token["address"], session)
+
+        config.TOKEN_LIST_CONTRACT_ADDRESS = token_list_contract["address"]
+        token_contract = Contract.get_contract("IbetStraightBond", token["address"])
+
+        # User1 and trader must register personal information before they receive token.
+        register_personalinfo(self.user1, personal_info_contract)
+        register_personalinfo(self.trader, personal_info_contract)
+
+        # Issuer transfers issued token to user1 and trader.
+        transfer_token(token_contract, self.issuer["account_address"], self.user1["account_address"], 20000)
+        transfer_token(token_contract, self.issuer["account_address"], self.trader["account_address"], 10000)
+        transfer_token(token_contract, self.user1["account_address"], escrow_contract.address, 10000)
+
+        bond_set_transfer_approval_required(self.issuer, token, True)
+        bond_apply_for_transfer(self.user1, token, self.trader, 10000, "to user1#1")
+
+        create_security_token_escrow(
+            self.user1,
+            {"address": escrow_contract.address},
+            token,
+            self.trader["account_address"],
+            self.agent["account_address"],
+            7000,
+        )
+        create_security_token_escrow(
+            self.user1,
+            {"address": escrow_contract.address},
+            token,
+            self.trader["account_address"],
+            self.agent["account_address"],
+            3000,
+        )
+        _latest_security_escrow_id = get_latest_security_escrow_id({"address": escrow_contract.address})
+        finish_security_token_escrow(
+            self.agent, {"address": escrow_contract.address}, _latest_security_escrow_id
+        )
+        approve_transfer_security_token_escrow(
+            self.issuer, {"address": escrow_contract.address}, _latest_security_escrow_id, ""
+        )
+
+        # Insert collection record with above token and current block number
+        target_token_holders_list = self.token_holders_list(token, web3.eth.blockNumber)
+        session.add(target_token_holders_list)
+        session.commit()
+
+        bond_position_indexer.sync_new_logs()
+
+        # Issuer transfers issued token to user1 again to proceed block_number on chain.
+        bond_set_transfer_approval_required(self.issuer, token, False)
+        transfer_token(token_contract, self.issuer["account_address"], self.user1["account_address"], 100000)
+
+        # Then execute processor.
+        processor.collect()
+
+        user1_record: TokenHolder = (
+            session.query(TokenHolder)
+            .filter(TokenHolder.holder_list == target_token_holders_list.id)
+            .filter(TokenHolder.account_address == self.user1["account_address"])
+            .first()
+        )
+        trader_record: TokenHolder = (
+            session.query(TokenHolder)
+            .filter(TokenHolder.holder_list == target_token_holders_list.id)
+            .filter(TokenHolder.account_address == self.trader["account_address"])
+            .first()
+        )
+
+        assert user1_record.exchange_balance == 0
+        assert user1_record.balance == 0
+        assert user1_record.exchange_commitment == 7000
+        assert user1_record.pending_transfer == 10000
+
+        assert trader_record.exchange_balance == 3000
+        assert trader_record.balance == 10000
+        assert trader_record.exchange_commitment == 0
+        assert trader_record.pending_transfer == 0
+
+        assert (
+            len(
+                list(
+                    session.query(TokenHolder).filter(
+                        TokenHolder.holder_list == target_token_holders_list.id
+                    )
+                )
+            )
+            == 2
+        )
+
+        _user1_record_validator: IDXPosition = (
+            session.query(IDXPosition)
+            .filter(IDXPosition.account_address == user1_record.account_address)
+            .order_by(IDXPosition.created)
+            .first()
+        )
+        _trader_record_validator: IDXPosition = (
+            session.query(IDXPosition)
+            .filter(IDXPosition.account_address == trader_record.account_address)
+            .order_by(IDXPosition.created)
+            .first()
+        )
+
+        assert user1_record.balance == _user1_record_validator.balance
+        assert user1_record.pending_transfer == _user1_record_validator.pending_transfer
+        assert user1_record.exchange_balance == _user1_record_validator.exchange_balance
+        assert user1_record.exchange_commitment == _user1_record_validator.exchange_commitment
+
+        assert trader_record.balance == _trader_record_validator.balance
+        assert trader_record.pending_transfer == _trader_record_validator.pending_transfer
+        assert trader_record.exchange_balance == _trader_record_validator.exchange_balance
+        assert trader_record.exchange_commitment == _trader_record_validator.exchange_commitment
+
+    # <Normal_4>
+    # Share
+    # Events
+    # - Transfer
+    # - Lock
+    # - Unlock
+    # - Exchange
+    #   - MakeOrder
+    #   - CancelOrder
+    #   - ForceCancelOrder
+    #   - TakeOrder
+    #   - CancelAgreement
+    #   - ConfirmAgreement
+    # - IssueFrom
+    # - RedeemFrom
+    def test_normal_4(
+        self,
+        processor: Processor,
+        shared_contract,
+        session: Session,
+        share_position_indexer: ShareIndexer,
+        block_number: None,
+    ):
+        token_list_contract = shared_contract["TokenList"]
+        personal_info_contract = shared_contract["PersonalInfo"]
+        exchange = shared_contract["IbetShareExchange"]
+
+        # Issuer issues share token.
+        token = self.issue_token_share(
+            self.issuer, exchange["address"], personal_info_contract["address"], token_list_contract
+        )
+        self.listing_token(token["address"], session)
+        config.TOKEN_LIST_CONTRACT_ADDRESS = token_list_contract["address"]
+        token_contract = Contract.get_contract("IbetShare", token["address"])
+
+        # User1 and trader must register personal information before they receive token.
+        register_personalinfo(self.user1, personal_info_contract)
+        register_personalinfo(self.trader, personal_info_contract)
+
+        # Issuer transfers issued token to user1, trader and exchange.
+        transfer_token(token_contract, self.issuer["account_address"], self.user1["account_address"], 20000)
+        transfer_token(token_contract, self.issuer["account_address"], self.trader["account_address"], 10000)
+        share_transfer_to_exchange(self.issuer, {"address": exchange["address"]}, token, 10000)
+
+        share_authorize_lock_address(self.issuer, token, self.user1["account_address"], True)
+        share_authorize_lock_address(self.issuer, token, self.trader["account_address"], True)
+        share_lock(self.user1, token, self.trader["account_address"], 10000)
+        share_unlock(self.trader, token, self.user1["account_address"], self.user1["account_address"], 5000)
+
+        share_transfer_to_exchange(self.user1, {"address": exchange["address"]}, token, 10000)
+        make_sell(self.user1, exchange, token, 10000, 100)
+        cancel_order(self.user1, exchange, get_latest_orderid(exchange))
+        share_transfer_to_exchange(self.user1, exchange, token, 10000)
+        make_sell(self.user1, exchange, token, 10000, 100)
+        force_cancel_order(self.agent, exchange, get_latest_orderid(exchange))
+        share_transfer_to_exchange(self.user1, exchange, token, 10000)
+        make_sell(self.user1, exchange, token, 10000, 100)
+        _latest_order_id = get_latest_orderid(exchange)
+        take_buy(self.trader, exchange, _latest_order_id, 10000)
+        confirm_agreement(
+            self.agent, exchange, _latest_order_id, get_latest_agreementid(exchange, _latest_order_id)
+        )
+
+        share_issue_from(self.issuer, token, self.issuer["account_address"], 40000)
+        share_redeem_from(self.issuer, token, self.trader["account_address"], 10000)
+
+        share_issue_from(self.issuer, token, self.trader["account_address"], 30000)
+        share_redeem_from(self.issuer, token, self.issuer["account_address"], 10000)
+
+        # Insert collection record with above token and current block number
+        target_token_holders_list = self.token_holders_list(token, web3.eth.blockNumber)
+        session.add(target_token_holders_list)
+        session.commit()
+        share_position_indexer.sync_new_logs()
+
+        # Issuer transfers issued token to user1 again to proceed block_number on chain.
+        transfer_token(token_contract, self.issuer["account_address"], self.user1["account_address"], 100000)
+
+        # Then execute processor.
+        processor.collect()
+
+        user1_record: TokenHolder = (
+            session.query(TokenHolder)
+            .filter(TokenHolder.holder_list == target_token_holders_list.id)
+            .filter(TokenHolder.account_address == self.user1["account_address"])
+            .first()
+        )
+        trader_record: TokenHolder = (
+            session.query(TokenHolder)
+            .filter(TokenHolder.holder_list == target_token_holders_list.id)
+            .filter(TokenHolder.account_address == self.trader["account_address"])
+            .first()
+        )
+
+        assert user1_record.exchange_balance == 0
+        assert user1_record.balance == 5000
+        assert user1_record.exchange_commitment == 0
+        assert user1_record.pending_transfer == 0
+
+        assert trader_record.exchange_balance == 0
+        assert trader_record.balance == 40000
+        assert trader_record.exchange_commitment == 0
+        assert trader_record.pending_transfer == 0
+
+        assert (
+            len(
+                list(
+                    session.query(TokenHolder).filter(
+                        TokenHolder.holder_list == target_token_holders_list.id
+                    )
+                )
+            )
+            == 2
+        )
+
+        _user1_record_validator: IDXPosition = (
+            session.query(IDXPosition)
+            .filter(IDXPosition.account_address == user1_record.account_address)
+            .order_by(IDXPosition.created)
+            .first()
+        )
+        _trader_record_validator: IDXPosition = (
+            session.query(IDXPosition)
+            .filter(IDXPosition.account_address == trader_record.account_address)
+            .order_by(IDXPosition.created)
+            .first()
+        )
+
+        assert user1_record.balance == _user1_record_validator.balance
+        assert user1_record.pending_transfer == _user1_record_validator.pending_transfer
+        assert user1_record.exchange_balance == _user1_record_validator.exchange_balance
+        assert user1_record.exchange_commitment == _user1_record_validator.exchange_commitment
+
+        assert trader_record.balance == _trader_record_validator.balance
+        assert trader_record.pending_transfer == _trader_record_validator.pending_transfer
+        assert trader_record.exchange_balance == _trader_record_validator.exchange_balance
+        assert trader_record.exchange_commitment == _trader_record_validator.exchange_commitment
+
+    # <Normal 5>
+    # Share
+    # Events
+    # - Transfer
+    # - Lock
+    # - Unlock
+    # - Exchange
+    #   - MakeOrder
+    #   - CancelOrder
+    #   - ForceCancelOrder
+    #   - TakeOrder
+    #   - CancelAgreement
+    #   - ConfirmAgreement
+    # - IssueFrom
+    # - RedeemFrom
+    def test_normal_5(
+        self,
+        processor: Processor,
+        shared_contract,
+        session: Session,
+        share_position_indexer: ShareIndexer,
+        block_number: None,
+    ):
+        token_list_contract = shared_contract["TokenList"]
+        personal_info_contract = shared_contract["PersonalInfo"]
+        escrow_contract = shared_contract["IbetSecurityTokenEscrow"]
+
+        # Issuer issues share token.
+        token = self.issue_token_share(
+            self.issuer, escrow_contract.address, personal_info_contract["address"], token_list_contract
+        )
+        self.listing_token(token["address"], session)
+
+        config.TOKEN_LIST_CONTRACT_ADDRESS = token_list_contract["address"]
+        token_contract = Contract.get_contract("IbetShare", token["address"])
+
+        # User1 and trader must register personal information before they receive token.
+        register_personalinfo(self.user1, personal_info_contract)
+        register_personalinfo(self.trader, personal_info_contract)
+
+        transfer_token(token_contract, self.issuer["account_address"], self.user1["account_address"], 20000)
+        share_transfer_to_exchange(self.user1, {"address": escrow_contract.address}, token, 10000)
+
+        # Issuer transfers issued token to user1 and trader.
+        share_set_transfer_approval_required(self.issuer, token, True)
+        share_apply_for_transfer(self.issuer, token, self.user1, 10000, "to user1#1")
+        share_apply_for_transfer(self.issuer, token, self.trader, 10000, "to trader#1")
+
+        share_cancel_transfer(self.issuer, token, 0, "to user1#1")
+        share_approve_transfer(self.issuer, token, 1, "to trader#1")
+
+        create_security_token_escrow(
+            self.user1,
+            {"address": escrow_contract.address},
+            token,
+            self.trader["account_address"],
+            self.agent["account_address"],
+            7000,
+        )
+        _latest_security_escrow_id = get_latest_security_escrow_id({"address": escrow_contract.address})
+        finish_security_token_escrow(
+            self.agent, {"address": escrow_contract.address}, _latest_security_escrow_id
+        )
+        approve_transfer_security_token_escrow(
+            self.issuer, {"address": escrow_contract.address}, _latest_security_escrow_id, ""
+        )
+
+        create_security_token_escrow(
+            self.user1,
+            {"address": escrow_contract.address},
+            token,
+            self.trader["account_address"],
+            self.agent["account_address"],
+            2000,
+        )
+        _latest_security_escrow_id = get_latest_security_escrow_id({"address": escrow_contract.address})
+        finish_security_token_escrow(
+            self.agent, {"address": escrow_contract.address}, _latest_security_escrow_id
+        )
+
+        # Insert collection record with above token and current block number
+        target_token_holders_list = self.token_holders_list(token, web3.eth.blockNumber)
+        session.add(target_token_holders_list)
+        session.commit()
+
+        share_position_indexer.sync_new_logs()
+
+        # Issuer transfers issued token to user1 again to proceed block_number on chain.
+        share_set_transfer_approval_required(self.issuer, token, False)
+        transfer_token(token_contract, self.issuer["account_address"], self.user1["account_address"], 100000)
+
+        # Then execute processor.
+        processor.collect()
+
+        user1_record: TokenHolder = (
+            session.query(TokenHolder)
+            .filter(TokenHolder.holder_list == target_token_holders_list.id)
+            .filter(TokenHolder.account_address == self.user1["account_address"])
+            .first()
+        )
+        trader_record: TokenHolder = (
+            session.query(TokenHolder)
+            .filter(TokenHolder.holder_list == target_token_holders_list.id)
+            .filter(TokenHolder.account_address == self.trader["account_address"])
+            .first()
+        )
+
+        assert user1_record.exchange_balance == 1000
+        assert user1_record.balance == 10000  # 20000
+        assert user1_record.exchange_commitment == 2000
+        assert user1_record.pending_transfer == 0
+
+        assert trader_record.exchange_balance == 7000
+        assert trader_record.balance == 10000
+        assert trader_record.exchange_commitment == 0
+        assert trader_record.pending_transfer == 0
+
+        assert (
+            len(
+                list(
+                    session.query(TokenHolder).filter(
+                        TokenHolder.holder_list == target_token_holders_list.id
+                    )
+                )
+            )
+            == 2
+        )
+
+        _user1_record_validator: IDXPosition = (
+            session.query(IDXPosition)
+            .filter(IDXPosition.account_address == user1_record.account_address)
+            .order_by(IDXPosition.created)
+            .first()
+        )
+        _trader_record_validator: IDXPosition = (
+            session.query(IDXPosition)
+            .filter(IDXPosition.account_address == trader_record.account_address)
+            .order_by(IDXPosition.created)
+            .first()
+        )
+
+        assert user1_record.balance == _user1_record_validator.balance
+        assert user1_record.pending_transfer == _user1_record_validator.pending_transfer
+        assert user1_record.exchange_balance == _user1_record_validator.exchange_balance
+        assert user1_record.exchange_commitment == _user1_record_validator.exchange_commitment
+
+        assert trader_record.balance == _trader_record_validator.balance
+        assert trader_record.pending_transfer == _trader_record_validator.pending_transfer
+        assert trader_record.exchange_balance == _trader_record_validator.exchange_balance
+        assert trader_record.exchange_commitment == _trader_record_validator.exchange_commitment
+
+    # <Normal_6>
+    # StraightBond
+    # Events
+    # - ApplyForTransfer - pending
+    # - Escrow - pending
+    def test_normal_6(
+        self,
+        processor: Processor,
+        shared_contract,
+        session: Session,
+        share_position_indexer: ShareIndexer,
+        block_number: None,
+    ):
+        token_list_contract = shared_contract["TokenList"]
+        personal_info_contract = shared_contract["PersonalInfo"]
+        escrow_contract = shared_contract["IbetSecurityTokenEscrow"]
+
+        # Issuer issues share token.
+        token = self.issue_token_share(
+            self.issuer, escrow_contract.address, personal_info_contract["address"], token_list_contract
+        )
+        self.listing_token(token["address"], session)
+
+        config.TOKEN_LIST_CONTRACT_ADDRESS = token_list_contract["address"]
+        token_contract = Contract.get_contract("IbetShare", token["address"])
+
+        # User1 and trader must register personal information before they receive token.
+        register_personalinfo(self.user1, personal_info_contract)
+        register_personalinfo(self.trader, personal_info_contract)
+
+        # Issuer transfers issued token to user1 and trader.
+        transfer_token(token_contract, self.issuer["account_address"], self.user1["account_address"], 20000)
+        transfer_token(token_contract, self.issuer["account_address"], self.trader["account_address"], 10000)
+        transfer_token(token_contract, self.user1["account_address"], escrow_contract.address, 10000)
+
+        share_set_transfer_approval_required(self.issuer, token, True)
+        share_apply_for_transfer(self.user1, token, self.trader, 10000, "to user1#1")
+
+        create_security_token_escrow(
+            self.user1,
+            {"address": escrow_contract.address},
+            token,
+            self.trader["account_address"],
+            self.agent["account_address"],
+            7000,
+        )
+        create_security_token_escrow(
+            self.user1,
+            {"address": escrow_contract.address},
+            token,
+            self.trader["account_address"],
+            self.agent["account_address"],
+            3000,
+        )
+        _latest_security_escrow_id = get_latest_security_escrow_id({"address": escrow_contract.address})
+        finish_security_token_escrow(
+            self.agent, {"address": escrow_contract.address}, _latest_security_escrow_id
+        )
+        approve_transfer_security_token_escrow(
+            self.issuer, {"address": escrow_contract.address}, _latest_security_escrow_id, ""
+        )
+
+        # Insert collection record with above token and current block number
+        target_token_holders_list = self.token_holders_list(token, web3.eth.blockNumber)
+        session.add(target_token_holders_list)
+        session.commit()
+
+        share_position_indexer.sync_new_logs()
+
+        # Issuer transfers issued token to user1 again to proceed block_number on chain.
+        share_set_transfer_approval_required(self.issuer, token, False)
+        transfer_token(token_contract, self.issuer["account_address"], self.user1["account_address"], 100000)
+
+        # Then execute processor.
+        processor.collect()
+
+        user1_record: TokenHolder = (
+            session.query(TokenHolder)
+            .filter(TokenHolder.holder_list == target_token_holders_list.id)
+            .filter(TokenHolder.account_address == self.user1["account_address"])
+            .first()
+        )
+        trader_record: TokenHolder = (
+            session.query(TokenHolder)
+            .filter(TokenHolder.holder_list == target_token_holders_list.id)
+            .filter(TokenHolder.account_address == self.trader["account_address"])
+            .first()
+        )
+
+        assert user1_record.exchange_balance == 0
+        assert user1_record.balance == 0
+        assert user1_record.exchange_commitment == 7000
+        assert user1_record.pending_transfer == 10000
+
+        assert trader_record.exchange_balance == 3000
+        assert trader_record.balance == 10000
+        assert trader_record.exchange_commitment == 0
+        assert trader_record.pending_transfer == 0
+
+        assert (
+            len(
+                list(
+                    session.query(TokenHolder).filter(
+                        TokenHolder.holder_list == target_token_holders_list.id
+                    )
+                )
+            )
+            == 2
+        )
+
+        _user1_record_validator: IDXPosition = (
+            session.query(IDXPosition)
+            .filter(IDXPosition.account_address == user1_record.account_address)
+            .order_by(IDXPosition.created)
+            .first()
+        )
+        _trader_record_validator: IDXPosition = (
+            session.query(IDXPosition)
+            .filter(IDXPosition.account_address == trader_record.account_address)
+            .order_by(IDXPosition.created)
+            .first()
+        )
+
+        assert user1_record.balance == _user1_record_validator.balance
+        assert user1_record.exchange_balance == _user1_record_validator.exchange_balance
+        assert user1_record.exchange_commitment == _user1_record_validator.exchange_commitment
+
+        assert trader_record.balance == _trader_record_validator.balance
+        assert trader_record.exchange_balance == _trader_record_validator.exchange_balance
+        assert trader_record.exchange_commitment == _trader_record_validator.exchange_commitment
+
+    # <Normal_7>
+    # Coupon
+    # Events
+    # - Transfer
+    # - Exchange
+    #   - MakeOrder
+    #   - CancelOrder
+    #   - ForceCancelOrder
+    #   - TakeOrder
+    #   - CancelAgreement
+    #   - ConfirmAgreement
+    def test_normal_7(
+        self,
+        processor: Processor,
+        shared_contract,
+        session: Session,
+        coupon_position_indexer: CouponIndexer,
+        block_number: None,
+    ):
+        token_list_contract = shared_contract["TokenList"]
+        personal_info_contract = shared_contract["PersonalInfo"]
+        exchange = shared_contract["IbetCouponExchange"]
+
+        # Issuer issues coupon token.
+        token = self.issue_token_coupon(self.issuer, exchange["address"], token_list_contract)
+        self.listing_token(token["address"], session)
+        config.TOKEN_LIST_CONTRACT_ADDRESS = token_list_contract["address"]
+        token_contract = Contract.get_contract("IbetCoupon", token["address"])
+
+        # User1 and trader must register personal information before they receive token.
+        register_personalinfo(self.user1, personal_info_contract)
+        register_personalinfo(self.trader, personal_info_contract)
+
+        # Issuer transfers issued token to user1, trader and exchange.
+        transfer_token(token_contract, self.issuer["account_address"], self.user1["account_address"], 20000)
+        transfer_token(token_contract, self.issuer["account_address"], self.trader["account_address"], 10000)
+        coupon_transfer_to_exchange(self.issuer, {"address": exchange["address"]}, token, 10000)
+
+        coupon_transfer_to_exchange(self.user1, {"address": exchange["address"]}, token, 10000)
+        make_sell(self.user1, exchange, token, 10000, 100)
+        cancel_order(self.user1, exchange, get_latest_orderid(exchange))
+        coupon_transfer_to_exchange(self.user1, exchange, token, 10000)
+        make_sell(self.user1, exchange, token, 10000, 100)
+        force_cancel_order(self.agent, exchange, get_latest_orderid(exchange))
+        coupon_transfer_to_exchange(self.user1, exchange, token, 10000)
+        make_sell(self.user1, exchange, token, 10000, 100)
+        _latest_order_id = get_latest_orderid(exchange)
+        take_buy(self.trader, exchange, _latest_order_id, 10000)
+        confirm_agreement(
+            self.agent, exchange, _latest_order_id, get_latest_agreementid(exchange, _latest_order_id)
+        )
+
+        # Insert collection record with above token and current block number
+        target_token_holders_list = self.token_holders_list(token, web3.eth.blockNumber)
+        session.add(target_token_holders_list)
+        session.commit()
+        coupon_position_indexer.sync_new_logs()
+
+        # Issuer transfers issued token to user1 again to proceed block_number on chain.
+        transfer_token(token_contract, self.issuer["account_address"], self.user1["account_address"], 100000)
+
+        # Then execute processor.
+        processor.collect()
+
+        user1_record: TokenHolder = (
+            session.query(TokenHolder)
+            .filter(TokenHolder.holder_list == target_token_holders_list.id)
+            .filter(TokenHolder.account_address == self.user1["account_address"])
+            .first()
+        )
+        trader_record: TokenHolder = (
+            session.query(TokenHolder)
+            .filter(TokenHolder.holder_list == target_token_holders_list.id)
+            .filter(TokenHolder.account_address == self.trader["account_address"])
+            .first()
+        )
+
+        assert user1_record.exchange_balance == 0
+        assert user1_record.balance == 10000
+        assert user1_record.exchange_commitment == 0
+        assert user1_record.pending_transfer == 0
+
+        assert trader_record.exchange_balance == 0
+        assert trader_record.balance == 20000
+        assert trader_record.exchange_commitment == 0
+        assert trader_record.pending_transfer == 0
+
+        assert (
+            len(
+                list(
+                    session.query(TokenHolder).filter(
+                        TokenHolder.holder_list == target_token_holders_list.id
+                    )
+                )
+            )
+            == 2
+        )
+
+        _user1_record_validator: IDXPosition = (
+            session.query(IDXPosition)
+            .filter(IDXPosition.account_address == user1_record.account_address)
+            .order_by(IDXPosition.created)
+            .first()
+        )
+        _trader_record_validator: IDXPosition = (
+            session.query(IDXPosition)
+            .filter(IDXPosition.account_address == trader_record.account_address)
+            .order_by(IDXPosition.created)
+            .first()
+        )
+
+        assert user1_record.balance == _user1_record_validator.balance
+        assert user1_record.exchange_balance == _user1_record_validator.exchange_balance
+        assert user1_record.exchange_commitment == _user1_record_validator.exchange_commitment
+
+        assert trader_record.balance == _trader_record_validator.balance
+        assert trader_record.exchange_balance == _trader_record_validator.exchange_balance
+        assert trader_record.exchange_commitment == _trader_record_validator.exchange_commitment
+
+    # <Normal_8>
+    # Coupon
+    # Events
+    # - Escrow
+    #   - CreateEscrow
+    #   - FinishEscrow
+    def test_normal_8(
+        self,
+        processor: Processor,
+        shared_contract,
+        session: Session,
+        coupon_position_indexer: CouponIndexer,
+        block_number: None,
+    ):
+        token_list_contract = shared_contract["TokenList"]
+        personal_info_contract = shared_contract["PersonalInfo"]
+        escrow_contract = shared_contract["IbetEscrow"]
+
+        # Issuer issues coupon token.
+        token = self.issue_token_coupon(self.issuer, escrow_contract.address, token_list_contract)
+        self.listing_token(token["address"], session)
+
+        config.TOKEN_LIST_CONTRACT_ADDRESS = token_list_contract["address"]
+        token_contract = Contract.get_contract("IbetCoupon", token["address"])
+
+        # User1 and trader must register personal information before they receive token.
+        register_personalinfo(self.user1, personal_info_contract)
+        register_personalinfo(self.trader, personal_info_contract)
+
+        transfer_token(token_contract, self.issuer["account_address"], self.user1["account_address"], 20000)
+        coupon_transfer_to_exchange(self.user1, {"address": escrow_contract.address}, token, 10000)
+
+        # Issuer transfers issued token to user1 and trader.
+
+        create_token_escrow(
+            self.user1,
+            {"address": escrow_contract.address},
+            token,
+            self.trader["account_address"],
+            self.agent["account_address"],
+            7000,
+        )
+        _latest_escrow_id = get_latest_security_escrow_id({"address": escrow_contract.address})
+        finish_token_escrow(self.agent, {"address": escrow_contract.address}, _latest_escrow_id)
+
+        create_token_escrow(
+            self.user1,
+            {"address": escrow_contract.address},
+            token,
+            self.trader["account_address"],
+            self.agent["account_address"],
+            2000,
+        )
+        _latest_escrow_id = get_latest_security_escrow_id({"address": escrow_contract.address})
+        finish_token_escrow(self.agent, {"address": escrow_contract.address}, _latest_escrow_id)
+
+        # Insert collection record with above token and current block number
+        target_token_holders_list = self.token_holders_list(token, web3.eth.blockNumber)
+        session.add(target_token_holders_list)
+        session.commit()
+
+        coupon_position_indexer.sync_new_logs()
+
+        # Issuer transfers issued token to user1 again to proceed block_number on chain.
+        transfer_token(token_contract, self.issuer["account_address"], self.user1["account_address"], 100000)
+
+        # Then execute processor.
+        processor.collect()
+
+        user1_record: TokenHolder = (
+            session.query(TokenHolder)
+            .filter(TokenHolder.holder_list == target_token_holders_list.id)
+            .filter(TokenHolder.account_address == self.user1["account_address"])
+            .first()
+        )
+        trader_record: TokenHolder = (
+            session.query(TokenHolder)
+            .filter(TokenHolder.holder_list == target_token_holders_list.id)
+            .filter(TokenHolder.account_address == self.trader["account_address"])
+            .first()
+        )
+
+        assert user1_record.exchange_balance == 1000
+        assert user1_record.balance == 10000
+        assert user1_record.exchange_commitment == 0
+        assert user1_record.pending_transfer == 0
+
+        assert trader_record.exchange_balance == 9000
+        assert trader_record.balance == 0
+        assert trader_record.exchange_commitment == 0
+        assert trader_record.pending_transfer == 0
+
+        assert (
+            len(
+                list(
+                    session.query(TokenHolder).filter(
+                        TokenHolder.holder_list == target_token_holders_list.id
+                    )
+                )
+            )
+            == 2
+        )
+
+        _user1_record_validator: IDXPosition = (
+            session.query(IDXPosition)
+            .filter(IDXPosition.account_address == user1_record.account_address)
+            .order_by(IDXPosition.created)
+            .first()
+        )
+        _trader_record_validator: IDXPosition = (
+            session.query(IDXPosition)
+            .filter(IDXPosition.account_address == trader_record.account_address)
+            .order_by(IDXPosition.created)
+            .first()
+        )
+
+        assert user1_record.balance == _user1_record_validator.balance
+        assert user1_record.exchange_balance == _user1_record_validator.exchange_balance
+        assert user1_record.exchange_commitment == _user1_record_validator.exchange_commitment
+
+        assert trader_record.balance == _trader_record_validator.balance
+        assert trader_record.exchange_balance == _trader_record_validator.exchange_balance
+        assert trader_record.exchange_commitment == _trader_record_validator.exchange_commitment
+
+    # <Normal_9>
+    # Coupon
+    # Events
+    # - Escrow - pending
+    # - Consume
+    def test_normal_9(
+        self,
+        processor: Processor,
+        shared_contract,
+        session: Session,
+        coupon_position_indexer: CouponIndexer,
+        block_number: None,
+    ):
+        token_list_contract = shared_contract["TokenList"]
+        personal_info_contract = shared_contract["PersonalInfo"]
+        escrow_contract = shared_contract["IbetEscrow"]
+
+        # Issuer issues coupon token.
+        token = self.issue_token_coupon(self.issuer, escrow_contract.address, token_list_contract)
+        self.listing_token(token["address"], session)
+
+        config.TOKEN_LIST_CONTRACT_ADDRESS = token_list_contract["address"]
+        token_contract = Contract.get_contract("IbetCoupon", token["address"])
+
+        # User1 and trader must register personal information before they receive token.
+        register_personalinfo(self.user1, personal_info_contract)
+        register_personalinfo(self.trader, personal_info_contract)
+
+        # Issuer transfers issued token to user1 and trader.
+        transfer_token(token_contract, self.issuer["account_address"], self.user1["account_address"], 10000)
+        transfer_token(token_contract, self.issuer["account_address"], self.trader["account_address"], 10000)
+        transfer_token(token_contract, self.user1["account_address"], escrow_contract.address, 10000)
+
+        create_token_escrow(
+            self.user1,
+            {"address": escrow_contract.address},
+            token,
+            self.trader["account_address"],
+            self.agent["account_address"],
+            7000,
+        )
+        create_token_escrow(
+            self.user1,
+            {"address": escrow_contract.address},
+            token,
+            self.trader["account_address"],
+            self.agent["account_address"],
+            3000,
+        )
+        _latest_escrow_id = get_latest_escrow_id({"address": escrow_contract.address})
+        finish_token_escrow(self.agent, {"address": escrow_contract.address}, _latest_escrow_id)
+
+        consume_coupon_token(self.trader, token, 9000)
+        # Insert collection record with above token and current block number
+        target_token_holders_list = self.token_holders_list(token, web3.eth.blockNumber)
+        session.add(target_token_holders_list)
+        session.commit()
+
+        coupon_position_indexer.sync_new_logs()
+
+        # Issuer transfers issued token to user1 again to proceed block_number on chain.
+        transfer_token(token_contract, self.issuer["account_address"], self.user1["account_address"], 100000)
+
+        # Then execute processor.
+        processor.collect()
+
+        user1_record: TokenHolder = (
+            session.query(TokenHolder)
+            .filter(TokenHolder.holder_list == target_token_holders_list.id)
+            .filter(TokenHolder.account_address == self.user1["account_address"])
+            .first()
+        )
+        trader_record: TokenHolder = (
+            session.query(TokenHolder)
+            .filter(TokenHolder.holder_list == target_token_holders_list.id)
+            .filter(TokenHolder.account_address == self.trader["account_address"])
+            .first()
+        )
+
+        assert user1_record.exchange_balance == 0
+        assert user1_record.balance == 0
+        assert user1_record.exchange_commitment == 7000
+        assert user1_record.pending_transfer == 0
+
+        assert trader_record.exchange_balance == 3000
+        assert trader_record.balance == 1000
+        assert trader_record.exchange_commitment == 0
+        assert trader_record.pending_transfer == 0
+
+        assert (
+            len(
+                list(
+                    session.query(TokenHolder).filter(
+                        TokenHolder.holder_list == target_token_holders_list.id
+                    )
+                )
+            )
+            == 2
+        )
+
+        _user1_record_validator: IDXPosition = (
+            session.query(IDXPosition)
+            .filter(IDXPosition.account_address == user1_record.account_address)
+            .order_by(IDXPosition.created)
+            .first()
+        )
+        _trader_record_validator: IDXPosition = (
+            session.query(IDXPosition)
+            .filter(IDXPosition.account_address == trader_record.account_address)
+            .order_by(IDXPosition.created)
+            .first()
+        )
+
+        assert user1_record.balance == _user1_record_validator.balance
+        assert user1_record.exchange_balance == _user1_record_validator.exchange_balance
+        assert user1_record.exchange_commitment == _user1_record_validator.exchange_commitment
+
+        assert trader_record.balance == _trader_record_validator.balance
+        assert trader_record.exchange_balance == _trader_record_validator.exchange_balance
+        assert trader_record.exchange_commitment == _trader_record_validator.exchange_commitment
+
+    # <Normal_10>
+    # Membership
+    # Events
+    # - Transfer
+    # - Exchange
+    #   - MakeOrder
+    #   - CancelOrder
+    #   - ForceCancelOrder
+    #   - TakeOrder
+    #   - CancelAgreement
+    #   - ConfirmAgreement
+    def test_normal_10(
+        self,
+        processor: Processor,
+        shared_contract,
+        session: Session,
+        membership_position_indexer: MembershipIndexer,
+        block_number: None,
+    ):
+        token_list_contract = shared_contract["TokenList"]
+        personal_info_contract = shared_contract["PersonalInfo"]
+        exchange = shared_contract["IbetMembershipExchange"]
+
+        # Issuer issues membership token.
+        token = self.issue_token_membership(self.issuer, exchange["address"], token_list_contract)
+        self.listing_token(token["address"], session)
+        config.TOKEN_LIST_CONTRACT_ADDRESS = token_list_contract["address"]
+        token_contract = Contract.get_contract("IbetMembership", token["address"])
+
+        # User1 and trader must register personal information before they receive token.
+        register_personalinfo(self.user1, personal_info_contract)
+        register_personalinfo(self.trader, personal_info_contract)
+
+        # Issuer transfers issued token to user1, trader and exchange.
+        transfer_token(token_contract, self.issuer["account_address"], self.user1["account_address"], 20000)
+        transfer_token(token_contract, self.issuer["account_address"], self.trader["account_address"], 10000)
+        membership_transfer_to_exchange(self.issuer, {"address": exchange["address"]}, token, 10000)
+
+        membership_transfer_to_exchange(self.user1, {"address": exchange["address"]}, token, 10000)
+        make_sell(self.user1, exchange, token, 10000, 100)
+        cancel_order(self.user1, exchange, get_latest_orderid(exchange))
+        membership_transfer_to_exchange(self.user1, exchange, token, 10000)
+        make_sell(self.user1, exchange, token, 10000, 100)
+        force_cancel_order(self.agent, exchange, get_latest_orderid(exchange))
+        membership_transfer_to_exchange(self.user1, exchange, token, 10000)
+        make_sell(self.user1, exchange, token, 10000, 100)
+        _latest_order_id = get_latest_orderid(exchange)
+        take_buy(self.trader, exchange, _latest_order_id, 10000)
+        confirm_agreement(
+            self.agent, exchange, _latest_order_id, get_latest_agreementid(exchange, _latest_order_id)
+        )
+
+        # Insert collection record with above token and current block number
+        target_token_holders_list = self.token_holders_list(token, web3.eth.blockNumber)
+        session.add(target_token_holders_list)
+        session.commit()
+        membership_position_indexer.sync_new_logs()
+
+        # Issuer transfers issued token to user1 again to proceed block_number on chain.
+        transfer_token(token_contract, self.issuer["account_address"], self.user1["account_address"], 100000)
+
+        # Then execute processor.
+        processor.collect()
+
+        issuer_record: TokenHolder = (
+            session.query(TokenHolder)
+            .filter(TokenHolder.holder_list == target_token_holders_list.id)
+            .filter(TokenHolder.account_address == self.issuer["account_address"])
+            .first()
+        )
+        user1_record: TokenHolder = (
+            session.query(TokenHolder)
+            .filter(TokenHolder.holder_list == target_token_holders_list.id)
+            .filter(TokenHolder.account_address == self.user1["account_address"])
+            .first()
+        )
+        trader_record: TokenHolder = (
+            session.query(TokenHolder)
+            .filter(TokenHolder.holder_list == target_token_holders_list.id)
+            .filter(TokenHolder.account_address == self.trader["account_address"])
+            .first()
+        )
+
+        assert user1_record.exchange_balance == 0
+        assert user1_record.balance == 10000
+        assert user1_record.exchange_commitment == 0
+        assert user1_record.pending_transfer == 0
+
+        assert trader_record.exchange_balance == 0
+        assert trader_record.balance == 20000
+        assert trader_record.exchange_commitment == 0
+        assert trader_record.pending_transfer == 0
+
+        assert (
+            len(
+                list(
+                    session.query(TokenHolder).filter(
+                        TokenHolder.holder_list == target_token_holders_list.id
+                    )
+                )
+            )
+            == 2
+        )
+
+        _user1_record_validator: IDXPosition = (
+            session.query(IDXPosition)
+            .filter(IDXPosition.account_address == user1_record.account_address)
+            .order_by(IDXPosition.created)
+            .first()
+        )
+        _trader_record_validator: IDXPosition = (
+            session.query(IDXPosition)
+            .filter(IDXPosition.account_address == trader_record.account_address)
+            .order_by(IDXPosition.created)
+            .first()
+        )
+
+        assert user1_record.balance == _user1_record_validator.balance
+        assert user1_record.exchange_balance == _user1_record_validator.exchange_balance
+        assert user1_record.exchange_commitment == _user1_record_validator.exchange_commitment
+
+        assert trader_record.balance == _trader_record_validator.balance
+        assert trader_record.exchange_balance == _trader_record_validator.exchange_balance
+        assert trader_record.exchange_commitment == _trader_record_validator.exchange_commitment
+
+    # <Normal_11>
+    # Membership
+    # Events
+    # - Escrow
+    #   - CreateEscrow
+    #   - FinishEscrow
+    def test_normal_11(
+        self,
+        processor: Processor,
+        shared_contract,
+        session: Session,
+        membership_position_indexer: MembershipIndexer,
+        block_number: None,
+    ):
+        token_list_contract = shared_contract["TokenList"]
+        personal_info_contract = shared_contract["PersonalInfo"]
+        escrow_contract = shared_contract["IbetEscrow"]
+
+        # Issuer issues membership token.
+        token = self.issue_token_membership(self.issuer, escrow_contract.address, token_list_contract)
+        self.listing_token(token["address"], session)
+
+        config.TOKEN_LIST_CONTRACT_ADDRESS = token_list_contract["address"]
+        token_contract = Contract.get_contract("IbetMembership", token["address"])
+
+        # User1 and trader must register personal information before they receive token.
+        register_personalinfo(self.user1, personal_info_contract)
+        register_personalinfo(self.trader, personal_info_contract)
+
+        transfer_token(token_contract, self.issuer["account_address"], self.user1["account_address"], 20000)
+        membership_transfer_to_exchange(self.user1, {"address": escrow_contract.address}, token, 10000)
+
+        # Issuer transfers issued token to user1 and trader.
+        create_token_escrow(
+            self.user1,
+            {"address": escrow_contract.address},
+            token,
+            self.trader["account_address"],
+            self.agent["account_address"],
+            7000,
+        )
+        _latest_escrow_id = get_latest_security_escrow_id({"address": escrow_contract.address})
+        finish_token_escrow(self.agent, {"address": escrow_contract.address}, _latest_escrow_id)
+
+        create_token_escrow(
+            self.user1,
+            {"address": escrow_contract.address},
+            token,
+            self.trader["account_address"],
+            self.agent["account_address"],
+            2000,
+        )
+        _latest_escrow_id = get_latest_security_escrow_id({"address": escrow_contract.address})
+        finish_token_escrow(self.agent, {"address": escrow_contract.address}, _latest_escrow_id)
+
+        # Insert collection record with above token and current block number
+        target_token_holders_list = self.token_holders_list(token, web3.eth.blockNumber)
+        session.add(target_token_holders_list)
+        session.commit()
+
+        membership_position_indexer.sync_new_logs()
+
+        # Issuer transfers issued token to user1 again to proceed block_number on chain.
+        transfer_token(token_contract, self.issuer["account_address"], self.user1["account_address"], 100000)
+
+        # Then execute processor.
+        processor.collect()
+
+        user1_record: TokenHolder = (
+            session.query(TokenHolder)
+            .filter(TokenHolder.holder_list == target_token_holders_list.id)
+            .filter(TokenHolder.account_address == self.user1["account_address"])
+            .first()
+        )
+        trader_record: TokenHolder = (
+            session.query(TokenHolder)
+            .filter(TokenHolder.holder_list == target_token_holders_list.id)
+            .filter(TokenHolder.account_address == self.trader["account_address"])
+            .first()
+        )
+
+        assert user1_record.exchange_balance == 1000
+        assert user1_record.balance == 10000
+        assert user1_record.exchange_commitment == 0
+        assert user1_record.pending_transfer == 0
+
+        assert trader_record.exchange_balance == 9000
+        assert trader_record.balance == 0
+        assert trader_record.exchange_commitment == 0
+        assert trader_record.pending_transfer == 0
+
+        assert (
+            len(
+                list(
+                    session.query(TokenHolder).filter(
+                        TokenHolder.holder_list == target_token_holders_list.id
+                    )
+                )
+            )
+            == 2
+        )
+
+        _user1_record_validator: IDXPosition = (
+            session.query(IDXPosition)
+            .filter(IDXPosition.account_address == user1_record.account_address)
+            .order_by(IDXPosition.created)
+            .first()
+        )
+        _trader_record_validator: IDXPosition = (
+            session.query(IDXPosition)
+            .filter(IDXPosition.account_address == trader_record.account_address)
+            .order_by(IDXPosition.created)
+            .first()
+        )
+
+        assert user1_record.balance == _user1_record_validator.balance
+        assert user1_record.exchange_balance == _user1_record_validator.exchange_balance
+        assert user1_record.exchange_commitment == _user1_record_validator.exchange_commitment
+
+        assert trader_record.balance == _trader_record_validator.balance
+        assert trader_record.exchange_balance == _trader_record_validator.exchange_balance
+        assert trader_record.exchange_commitment == _trader_record_validator.exchange_commitment
+
+    # <Normal_12>
+    # Membership
+    # Events
+    # - Escrow - pending
+    def test_normal_12(
+        self,
+        processor: Processor,
+        shared_contract,
+        session: Session,
+        membership_position_indexer: MembershipIndexer,
+        block_number: None,
+    ):
+        token_list_contract = shared_contract["TokenList"]
+        personal_info_contract = shared_contract["PersonalInfo"]
+        escrow_contract = shared_contract["IbetEscrow"]
+
+        # Issuer issues membership token.
+        token = self.issue_token_membership(self.issuer, escrow_contract.address, token_list_contract)
+        self.listing_token(token["address"], session)
+
+        config.TOKEN_LIST_CONTRACT_ADDRESS = token_list_contract["address"]
+        token_contract = Contract.get_contract("IbetMembership", token["address"])
+
+        # User1 and trader must register personal information before they receive token.
+        register_personalinfo(self.user1, personal_info_contract)
+        register_personalinfo(self.trader, personal_info_contract)
+
+        # Issuer transfers issued token to user1 and trader.
+        transfer_token(token_contract, self.issuer["account_address"], self.user1["account_address"], 10000)
+        transfer_token(token_contract, self.issuer["account_address"], self.trader["account_address"], 10000)
+        transfer_token(token_contract, self.user1["account_address"], escrow_contract.address, 10000)
+
+        create_token_escrow(
+            self.user1,
+            {"address": escrow_contract.address},
+            token,
+            self.trader["account_address"],
+            self.agent["account_address"],
+            7000,
+        )
+        create_token_escrow(
+            self.user1,
+            {"address": escrow_contract.address},
+            token,
+            self.trader["account_address"],
+            self.agent["account_address"],
+            3000,
+        )
+        _latest_escrow_id = get_latest_escrow_id({"address": escrow_contract.address})
+        finish_token_escrow(self.agent, {"address": escrow_contract.address}, _latest_escrow_id)
+
+        # Insert collection record with above token and current block number
+        target_token_holders_list = self.token_holders_list(token, web3.eth.blockNumber)
+        session.add(target_token_holders_list)
+        session.commit()
+
+        membership_position_indexer.sync_new_logs()
+
+        # Issuer transfers issued token to user1 again to proceed block_number on chain.
+        transfer_token(token_contract, self.issuer["account_address"], self.user1["account_address"], 100000)
+
+        # Then execute processor.
+        processor.collect()
+
+        user1_record: TokenHolder = (
+            session.query(TokenHolder)
+            .filter(TokenHolder.holder_list == target_token_holders_list.id)
+            .filter(TokenHolder.account_address == self.user1["account_address"])
+            .first()
+        )
+        trader_record: TokenHolder = (
+            session.query(TokenHolder)
+            .filter(TokenHolder.holder_list == target_token_holders_list.id)
+            .filter(TokenHolder.account_address == self.trader["account_address"])
+            .first()
+        )
+
+        assert user1_record.exchange_balance == 0
+        assert user1_record.balance == 0
+        assert user1_record.exchange_commitment == 7000
+        assert user1_record.pending_transfer == 0
+
+        assert trader_record.exchange_balance == 3000
+        assert trader_record.balance == 10000
+        assert trader_record.exchange_commitment == 0
+        assert trader_record.pending_transfer == 0
+
+        assert (
+            len(
+                list(
+                    session.query(TokenHolder).filter(
+                        TokenHolder.holder_list == target_token_holders_list.id
+                    )
+                )
+            )
+            == 2
+        )
+
+        _user1_record_validator: IDXPosition = (
+            session.query(IDXPosition)
+            .filter(IDXPosition.account_address == user1_record.account_address)
+            .order_by(IDXPosition.created)
+            .first()
+        )
+        _trader_record_validator: IDXPosition = (
+            session.query(IDXPosition)
+            .filter(IDXPosition.account_address == trader_record.account_address)
+            .order_by(IDXPosition.created)
+            .first()
+        )
+
+        assert user1_record.balance == _user1_record_validator.balance
+        assert user1_record.exchange_balance == _user1_record_validator.exchange_balance
+        assert user1_record.exchange_commitment == _user1_record_validator.exchange_commitment
+
+        assert trader_record.balance == _trader_record_validator.balance
+        assert trader_record.exchange_balance == _trader_record_validator.exchange_balance
+        assert trader_record.exchange_commitment == _trader_record_validator.exchange_commitment
+
+    # <Normal_13>
+    # StraightBond
+    # Use checkpoint.
+    def test_normal_13(
+        self,
+        processor: Processor,
+        shared_contract,
+        session: Session,
+        bond_position_indexer: BondIndexer,
+        block_number: None,
+    ):
+        token_list_contract = shared_contract["TokenList"]
+        personal_info_contract = shared_contract["PersonalInfo"]
+        exchange_contract = shared_contract["IbetStraightBondExchange"]
+
+        # Issuer issues bond token.
+        token = self.issue_token_bond(
+            self.issuer, exchange_contract["address"], personal_info_contract["address"], token_list_contract
+        )
+        self.listing_token(token["address"], session)
+        config.TOKEN_LIST_CONTRACT_ADDRESS = token_list_contract["address"]
+        token_contract = Contract.get_contract("IbetStraightBond", token["address"])
+
+        # User1 and trader must register personal information before they receive token.
+        register_personalinfo(self.user1, personal_info_contract)
+        register_personalinfo(self.trader, personal_info_contract)
+
+        # Issuer transfers issued token to user1, trader and exchange.
+        transfer_token(token_contract, self.issuer["account_address"], self.user1["account_address"], 20000)
+        transfer_token(token_contract, self.issuer["account_address"], self.trader["account_address"], 10000)
+        bond_transfer_to_exchange(self.issuer, {"address": exchange_contract["address"]}, token, 10000)
+
+        bond_authorize_lock_address(self.issuer, token, self.user1["account_address"], True)
+        bond_authorize_lock_address(self.issuer, token, self.trader["account_address"], True)
+        bond_lock(self.user1, token, self.trader["account_address"], 10000)
+        bond_unlock(self.trader, token, self.user1["account_address"], self.user1["account_address"], 5000)
+        target_token_holders_list1 = self.token_holders_list(token, web3.eth.blockNumber)        
+        session.add(target_token_holders_list1)
+        session.commit()
+        bond_position_indexer.sync_new_logs()
+        processor.collect()
+        
+        user1_record: TokenHolder = (
+            session.query(TokenHolder)
+            .filter(TokenHolder.holder_list == target_token_holders_list1.id)
+            .filter(TokenHolder.account_address == self.user1["account_address"])
+            .first()
+        )
+        trader_record: TokenHolder = (
+            session.query(TokenHolder)
+            .filter(TokenHolder.holder_list == target_token_holders_list1.id)
+            .filter(TokenHolder.account_address == self.trader["account_address"])
+            .first()
+        )
+
+        _user1_record_validator: IDXPosition = (
+            session.query(IDXPosition)
+            .filter(IDXPosition.account_address == user1_record.account_address)
+            .order_by(IDXPosition.created)
+            .first()
+        )
+        _trader_record_validator: IDXPosition = (
+            session.query(IDXPosition)
+            .filter(IDXPosition.account_address == trader_record.account_address)
+            .order_by(IDXPosition.created)
+            .first()
+        )
+
+        assert user1_record.balance == _user1_record_validator.balance
+        assert user1_record.pending_transfer == _user1_record_validator.pending_transfer
+        assert user1_record.exchange_balance == _user1_record_validator.exchange_balance
+        assert user1_record.exchange_commitment == _user1_record_validator.exchange_commitment
+
+        assert trader_record.balance == _trader_record_validator.balance
+        assert trader_record.pending_transfer == _trader_record_validator.pending_transfer
+        assert trader_record.exchange_balance == _trader_record_validator.exchange_balance
+        assert trader_record.exchange_commitment == _trader_record_validator.exchange_commitment
+
+        bond_transfer_to_exchange(self.user1, {"address": exchange_contract["address"]}, token, 10000)
+        make_sell(self.user1, exchange_contract, token, 10000, 100)
+        cancel_order(self.user1, exchange_contract, get_latest_orderid(exchange_contract))
+        bond_transfer_to_exchange(self.user1, exchange_contract, token, 10000)
+        make_sell(self.user1, exchange_contract, token, 10000, 100)
+        force_cancel_order(self.agent, exchange_contract, get_latest_orderid(exchange_contract))
+
+        bond_transfer_to_exchange(self.user1, exchange_contract, token, 10000)
+        make_sell(self.user1, exchange_contract, token, 10000, 100)
+        _latest_order_id = get_latest_orderid(exchange_contract)
+        take_buy(self.trader, exchange_contract, _latest_order_id, 10000)
+        confirm_agreement(
+            self.agent, exchange_contract, _latest_order_id, get_latest_agreementid(exchange_contract, _latest_order_id)
+        )
+        target_token_holders_list2 = self.token_holders_list(token, web3.eth.blockNumber)
+
+        session.add(target_token_holders_list2)
+        session.commit()
+        bond_position_indexer.sync_new_logs()
+        processor.collect()
+        
+        user1_record: TokenHolder = (
+            session.query(TokenHolder)
+            .filter(TokenHolder.holder_list == target_token_holders_list2.id)
+            .filter(TokenHolder.account_address == self.user1["account_address"])
+            .first()
+        )
+        trader_record: TokenHolder = (
+            session.query(TokenHolder)
+            .filter(TokenHolder.holder_list == target_token_holders_list2.id)
+            .filter(TokenHolder.account_address == self.trader["account_address"])
+            .first()
+        )
+
+        _user1_record_validator: IDXPosition = (
+            session.query(IDXPosition)
+            .filter(IDXPosition.account_address == user1_record.account_address)
+            .order_by(IDXPosition.created)
+            .first()
+        )
+        _trader_record_validator: IDXPosition = (
+            session.query(IDXPosition)
+            .filter(IDXPosition.account_address == trader_record.account_address)
+            .order_by(IDXPosition.created)
+            .first()
+        )
+
+        assert user1_record.balance == _user1_record_validator.balance
+        assert user1_record.pending_transfer == _user1_record_validator.pending_transfer
+        assert user1_record.exchange_balance == _user1_record_validator.exchange_balance
+        assert user1_record.exchange_commitment == _user1_record_validator.exchange_commitment
+
+        assert trader_record.balance == _trader_record_validator.balance
+        assert trader_record.pending_transfer == _trader_record_validator.pending_transfer
+        assert trader_record.exchange_balance == _trader_record_validator.exchange_balance
+        assert trader_record.exchange_commitment == _trader_record_validator.exchange_commitment
+        
+        bond_transfer_to_exchange(self.user1, exchange_contract, token, 4000)
+        make_buy(self.trader, exchange_contract, token, 4000, 100)
+        _latest_order_id = get_latest_orderid(exchange_contract)
+        take_sell(self.user1, exchange_contract, _latest_order_id, 4000)
+        cancel_agreement(self.agent, exchange_contract, _latest_order_id, get_latest_agreementid(exchange_contract, _latest_order_id))
+
+        bond_transfer_to_exchange(self.user1, exchange_contract, token, 4000)
+        make_buy(self.trader, exchange_contract, token, 4000, 100)
+        _latest_order_id = get_latest_orderid(exchange_contract)
+        take_sell(self.user1, exchange_contract, _latest_order_id, 4000)
+        confirm_agreement(
+            self.agent, exchange_contract, _latest_order_id, get_latest_agreementid(exchange_contract, _latest_order_id)
+        )
+
+        bond_issue_from(self.issuer, token, self.issuer["account_address"], 40000)
+        bond_redeem_from(self.issuer, token, self.trader["account_address"], 10000)
+
+        bond_issue_from(self.issuer, token, self.trader["account_address"], 30000)
+        bond_redeem_from(self.issuer, token, self.issuer["account_address"], 10000)
+        target_token_holders_list3 = self.token_holders_list(token, web3.eth.blockNumber)
+        session.add(target_token_holders_list3)
+        session.commit()
+        bond_position_indexer.sync_new_logs()
+        processor.collect()
+        
+        user1_record: TokenHolder = (
+            session.query(TokenHolder)
+            .filter(TokenHolder.holder_list == target_token_holders_list3.id)
+            .filter(TokenHolder.account_address == self.user1["account_address"])
+            .first()
+        )
+        trader_record: TokenHolder = (
+            session.query(TokenHolder)
+            .filter(TokenHolder.holder_list == target_token_holders_list3.id)
+            .filter(TokenHolder.account_address == self.trader["account_address"])
+            .first()
+        )
+
+        _user1_record_validator: IDXPosition = (
+            session.query(IDXPosition)
+            .filter(IDXPosition.account_address == user1_record.account_address)
+            .order_by(IDXPosition.created)
+            .first()
+        )
+        _trader_record_validator: IDXPosition = (
+            session.query(IDXPosition)
+            .filter(IDXPosition.account_address == trader_record.account_address)
+            .order_by(IDXPosition.created)
+            .first()
+        )
+
+        assert user1_record.balance == _user1_record_validator.balance
+        assert user1_record.pending_transfer == _user1_record_validator.pending_transfer
+        assert user1_record.exchange_balance == _user1_record_validator.exchange_balance
+        assert user1_record.exchange_commitment == _user1_record_validator.exchange_commitment
+
+        assert trader_record.balance == _trader_record_validator.balance
+        assert trader_record.pending_transfer == _trader_record_validator.pending_transfer
+        assert trader_record.exchange_balance == _trader_record_validator.exchange_balance
+        assert trader_record.exchange_commitment == _trader_record_validator.exchange_commitment        
+
+    # <Normal_14>
+    # StraightBond
+    # Pending jobs are to be processed one by one.
+    def test_normal_14(
+        self, processor: Processor, shared_contract, session: Session, caplog, block_number: None
+    ):
+        token_list_contract = shared_contract["TokenList"]
+        personal_info_contract = shared_contract["PersonalInfo"]
+        exchange_contract = shared_contract["IbetStraightBondExchange"]
+
+        # Issuer issues bond token.
+        token = self.issue_token_bond(
+            self.issuer, exchange_contract["address"], personal_info_contract["address"], token_list_contract
+        )
+        self.listing_token(token["address"], session)
+        config.TOKEN_LIST_CONTRACT_ADDRESS = token_list_contract["address"]
+        token_contract = Contract.get_contract("IbetStraightBond", token["address"])
+
+        # User1 and trader must register personal information before they receive token.
+        register_personalinfo(self.user1, personal_info_contract)
+        register_personalinfo(self.trader, personal_info_contract)
+
+        target_token_holders_list1 = self.token_holders_list(token, web3.eth.blockNumber)
+        session.add(target_token_holders_list1)
+        session.commit()
+        transfer_token(token_contract, self.issuer["account_address"], self.user1["account_address"], 20000)
+        transfer_token(token_contract, self.issuer["account_address"], self.trader["account_address"], 10000)
+        target_token_holders_list2 = self.token_holders_list(token, web3.eth.blockNumber)
+        session.add(target_token_holders_list2)
+        session.commit()
+
+        processor.collect()
+        LOG.addHandler(caplog.handler)
+        with caplog.at_level(logging.INFO):
+            processor.collect()
+        assert f"Token holder list({target_token_holders_list2.list_id}) status changes to be done." in caplog.text
+        assert f"Collect job has been completed" in caplog.text
+
+    ###########################################################################
+    # Error Case
+    ###########################################################################
+
+    # <Error_1>
+    # There is no target token holders list id with batch_status PENDING.
+    def test_error_1(
+        self, processor: Processor, shared_contract, session: Session, caplog, block_number: None
+    ):
+        LOG.addHandler(caplog.handler)
+        with caplog.at_level(logging.DEBUG):
+            processor.collect()
+        assert "There are no pending collect batch" in caplog.text
+        assert "Collect job has been completed" in caplog.text
+
+    # <Error_2>
+    # There is target token holders list id with batch_status PENDING.
+    # And target token is not contained in "TokenList" contract.
+    def test_error_2(
+        self, processor: Processor, shared_contract, session: Session, caplog, block_number: None
+    ):
+        token_list_contract = shared_contract["TokenList"]
+        config.TOKEN_LIST_CONTRACT_ADDRESS = token_list_contract["address"]
+
+        # Insert collection definition with token address Zero
+        target_token_holders_list = TokenHoldersList()
+        target_token_holders_list.token_address = ZERO_ADDRESS
+        target_token_holders_list.list_id = str(uuid.uuid4())
+        target_token_holders_list.batch_status = BatchStatus.PENDING.value
+        target_token_holders_list.block_number = 1000
+        session.add(target_token_holders_list)
+        session.commit()
+
+        # Debug message should be shown that points out token contract must be listed.
+        LOG.addHandler(caplog.handler)
+        with caplog.at_level(logging.DEBUG):
+            processor.collect()
+        assert "Token contract must be listed to TokenList contract." in caplog.text
+        assert f"Collect job has been completed" in caplog.text
+
+        # Batch status of token holders list expects to be "ERROR"
+        error_record_num = len(
+            list(
+                session.query(TokenHoldersList).filter(
+                    TokenHoldersList.batch_status == BatchStatus.FAILED.value
+                )
+            )
+        )
+        assert error_record_num == 1
+
+    # <Error_3>
+    # Failed to get Logs from blockchain.
+    @mock.patch("web3.contract.ContractEvent.getLogs", MagicMock(side_effect=Exception()))
+    def test_error_3(
+        self, processor: Processor, shared_contract, session: Session, caplog, block_number: None
+    ):
+        token_list_contract = shared_contract["TokenList"]
+        personal_info_contract = shared_contract["PersonalInfo"]
+        escrow_contract = shared_contract["IbetSecurityTokenEscrow"]
+
+        # Issuer issues bond token.
+        token = self.issue_token_bond(
+            self.issuer, escrow_contract.address, personal_info_contract["address"], token_list_contract
+        )
+        self.listing_token(token["address"], session)
+
+        config.TOKEN_LIST_CONTRACT_ADDRESS = token_list_contract["address"]
+        token_contract = Contract.get_contract("IbetStraightBond", token["address"])
+
+        # User1 and trader must register personal information before they receive token.
+        register_personalinfo(self.user1, personal_info_contract)
+        register_personalinfo(self.trader, personal_info_contract)
+
+        transfer_token(token_contract, self.issuer["account_address"], self.user1["account_address"], 20000)
+        bond_transfer_to_exchange(self.user1, {"address": escrow_contract.address}, token, 10000)
+
+        block_number = web3.eth.blockNumber
+        # Insert collection record with above token and current block number
+        target_token_holders_list = self.token_holders_list(token, block_number)
+        session.add(target_token_holders_list)
+        session.commit()
+
+        mock_lib = MagicMock()
+        with mock.patch.object(Processor, "_Processor__sync_all", return_value=mock_lib) as __sync_initial_issue_mock:
+            # Then execute processor.
+            __sync_initial_issue_mock.return_value = None
+            processor.collect()
+            _records: List[TokenHolder] = (
+                session.query(TokenHolder).filter(TokenHolder.holder_list == target_token_holders_list.id).all()
+            )
+            assert len(_records) == 0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,9 @@ import pytest
 from falcon import testing
 from web3 import Web3
 from web3.middleware import geth_poa_middleware
+from web3.types import (
+    RPCEndpoint,
+)
 
 from app.main import App
 from app.middleware import (
@@ -227,6 +230,16 @@ def db(request):
     request.addfinalizer(teardown)
     return db_session
 
+
+# ブロックナンバーの保存・復元
+@pytest.fixture(scope='function')
+def block_number(request):
+    evm_snapshot = web3.provider.make_request(RPCEndpoint("evm_snapshot"), [])
+
+    def teardown():
+        web3.provider.make_request(RPCEndpoint("evm_revert"), [int(evm_snapshot['result'], 16), ])
+
+    request.addfinalizer(teardown)
 
 # セッションの作成・自動ロールバック
 @pytest.fixture(scope='function')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -241,6 +241,7 @@ def block_number(request):
 
     request.addfinalizer(teardown)
 
+
 # セッションの作成・自動ロールバック
 @pytest.fixture(scope='function')
 def session(request, db):

--- a/tests/contract_modules.py
+++ b/tests/contract_modules.py
@@ -217,6 +217,107 @@ def bond_untransferable(invoker, token):
     web3.eth.waitForTransactionReceipt(tx_hash)
 
 
+# 移転承諾要否フラグの更新
+def bond_set_transfer_approval_required(invoker, token, required: bool):
+    web3.eth.defaultAccount = invoker['account_address']
+
+    TokenContract = Contract.get_contract('IbetStraightBond', token['address'])
+    tx_hash = TokenContract.functions.setTransferApprovalRequired(required).transact({
+        'from': invoker['account_address']
+    })
+    web3.eth.waitForTransactionReceipt(tx_hash)
+
+
+# トークン移転申請
+def bond_apply_for_transfer(invoker, token, recipient, amount, application_data):
+    web3.eth.defaultAccount = invoker['account_address']
+
+    TokenContract = Contract.get_contract('IbetStraightBond', token['address'])
+    tx_hash = TokenContract.functions.applyForTransfer(recipient["account_address"], amount, application_data). \
+        transact({'from': invoker['account_address'], 'gas': 4000000})
+    web3.eth.waitForTransactionReceipt(tx_hash)
+
+
+# トークン移転申請取消
+def bond_cancel_transfer(invoker, token, application_id, application_data):
+    web3.eth.defaultAccount = invoker['account_address']
+
+    TokenContract = Contract.get_contract('IbetStraightBond', token['address'])
+    tx_hash = TokenContract.functions.cancelTransfer(application_id, application_data). \
+        transact({'from': invoker['account_address'], 'gas': 4000000})
+    web3.eth.waitForTransactionReceipt(tx_hash)
+
+
+# トークン移転申請承認
+def bond_approve_transfer(invoker, token, application_id, application_data):
+    web3.eth.defaultAccount = invoker['account_address']
+
+    TokenContract = Contract.get_contract('IbetStraightBond', token['address'])
+    tx_hash = TokenContract.functions.approveTransfer(application_id, application_data). \
+        transact({'from': invoker['account_address'], 'gas': 4000000})
+    web3.eth.waitForTransactionReceipt(tx_hash)
+
+
+# 資産ロックアドレスの認可
+def bond_authorize_lock_address(invoker, token, lock_address: str, auth: bool):
+    web3.eth.defaultAccount = invoker['account_address']
+
+    TokenContract = Contract.get_contract('IbetStraightBond', token['address'])
+    tx_hash = TokenContract.functions.authorizeLockAddress(lock_address, auth). \
+        transact({'from': invoker['account_address'], 'gas': 4000000})
+    web3.eth.waitForTransactionReceipt(tx_hash)
+
+
+# トークン資産ロック
+def bond_lock(invoker, token, lock_address: str, amount: int):
+    web3.eth.defaultAccount = invoker['account_address']
+
+    TokenContract = Contract.get_contract('IbetStraightBond', token['address'])
+    tx_hash = TokenContract.functions.lock(lock_address, amount). \
+        transact({'from': invoker['account_address'], 'gas': 4000000})
+    web3.eth.waitForTransactionReceipt(tx_hash)
+
+
+# トークン資産アンロック
+def bond_unlock(invoker, token, target: str, recipient: str, amount: int):
+    web3.eth.defaultAccount = invoker['account_address']
+
+    TokenContract = Contract.get_contract('IbetStraightBond', token['address'])
+    tx_hash = TokenContract.functions.unlock(target, recipient, amount). \
+        transact({'from': invoker['account_address'], 'gas': 4000000})
+    web3.eth.waitForTransactionReceipt(tx_hash)
+
+
+# トークン追加発行
+def bond_issue_from(invoker, token, target: str, amount: int, lock_address: str = config.ZERO_ADDRESS):
+    web3.eth.defaultAccount = invoker['account_address']
+
+    TokenContract = Contract.get_contract('IbetStraightBond', token['address'])
+    tx_hash = TokenContract.functions.issueFrom(target, lock_address, amount). \
+        transact({'from': invoker['account_address'], 'gas': 4000000})
+    web3.eth.waitForTransactionReceipt(tx_hash)
+
+
+# トークン発行数量の削減
+def bond_redeem_from(invoker, token, target_address: str, amount: int, lock_address: str = config.ZERO_ADDRESS):
+    web3.eth.defaultAccount = invoker['account_address']
+
+    TokenContract = Contract.get_contract('IbetStraightBond', token['address'])
+    tx_hash = TokenContract.functions.redeemFrom(target_address, lock_address, amount). \
+        transact({'from': invoker['account_address'], 'gas': 4000000})
+    web3.eth.waitForTransactionReceipt(tx_hash)
+
+
+# 取引コントラクトの更新
+def bond_set_tradable_exchange(invoker, token, exchange_address: str):
+    web3.eth.defaultAccount = invoker['account_address']
+
+    TokenContract = Contract.get_contract('IbetStraightBond', token['address'])
+    tx_hash = TokenContract.functions.setTradableExchange(exchange_address). \
+        transact({'from': invoker['account_address'], 'gas': 4000000})
+    web3.eth.waitForTransactionReceipt(tx_hash)
+
+
 '''
 Share Token （株式）
 '''
@@ -312,6 +413,107 @@ def untransferable_share_token(invoker, token):
     web3.eth.defaultAccount = invoker['account_address']
     ShareTokenContract = Contract.get_contract('IbetShare', token['address'])
     tx_hash = ShareTokenContract.functions.setTransferable(False). \
+        transact({'from': invoker['account_address'], 'gas': 4000000})
+    web3.eth.waitForTransactionReceipt(tx_hash)
+
+
+# 移転承諾要否フラグの更新
+def share_set_transfer_approval_required(invoker, token, required: bool):
+    web3.eth.defaultAccount = invoker['account_address']
+
+    TokenContract = Contract.get_contract('IbetShare', token['address'])
+    tx_hash = TokenContract.functions.setTransferApprovalRequired(required).transact({
+        'from': invoker['account_address']
+    })
+    web3.eth.waitForTransactionReceipt(tx_hash)
+
+
+# トークン移転申請
+def share_apply_for_transfer(invoker, token, recipient, amount, application_data):
+    web3.eth.defaultAccount = invoker['account_address']
+
+    TokenContract = Contract.get_contract('IbetShare', token['address'])
+    tx_hash = TokenContract.functions.applyForTransfer(recipient["account_address"], amount, application_data). \
+        transact({'from': invoker['account_address'], 'gas': 4000000})
+    web3.eth.waitForTransactionReceipt(tx_hash)
+
+
+# トークン移転申請取消
+def share_cancel_transfer(invoker, token, application_id, application_data):
+    web3.eth.defaultAccount = invoker['account_address']
+
+    TokenContract = Contract.get_contract('IbetShare', token['address'])
+    tx_hash = TokenContract.functions.cancelTransfer(application_id, application_data). \
+        transact({'from': invoker['account_address'], 'gas': 4000000})
+    web3.eth.waitForTransactionReceipt(tx_hash)
+
+
+# トークン移転申請承認
+def share_approve_transfer(invoker, token, application_id, application_data):
+    web3.eth.defaultAccount = invoker['account_address']
+
+    TokenContract = Contract.get_contract('IbetShare', token['address'])
+    tx_hash = TokenContract.functions.approveTransfer(application_id, application_data). \
+        transact({'from': invoker['account_address'], 'gas': 4000000})
+    web3.eth.waitForTransactionReceipt(tx_hash)
+
+
+# 資産ロックアドレスの認可
+def share_authorize_lock_address(invoker, token, lock_address: str, auth: bool):
+    web3.eth.defaultAccount = invoker['account_address']
+
+    TokenContract = Contract.get_contract('IbetShare', token['address'])
+    tx_hash = TokenContract.functions.authorizeLockAddress(lock_address, auth). \
+        transact({'from': invoker['account_address'], 'gas': 4000000})
+    web3.eth.waitForTransactionReceipt(tx_hash)
+
+
+# トークン資産ロック
+def share_lock(invoker, token, lock_address: str, amount: int):
+    web3.eth.defaultAccount = invoker['account_address']
+
+    TokenContract = Contract.get_contract('IbetShare', token['address'])
+    tx_hash = TokenContract.functions.lock(lock_address, amount). \
+        transact({'from': invoker['account_address'], 'gas': 4000000})
+    web3.eth.waitForTransactionReceipt(tx_hash)
+
+
+# トークン資産アンロック
+def share_unlock(invoker, token, target: str, recipient: str, amount: int):
+    web3.eth.defaultAccount = invoker['account_address']
+
+    TokenContract = Contract.get_contract('IbetShare', token['address'])
+    tx_hash = TokenContract.functions.unlock(target, recipient, amount). \
+        transact({'from': invoker['account_address'], 'gas': 4000000})
+    web3.eth.waitForTransactionReceipt(tx_hash)
+
+
+# トークン追加発行
+def share_issue_from(invoker, token, target: str, amount: int, lock_address: str = config.ZERO_ADDRESS):
+    web3.eth.defaultAccount = invoker['account_address']
+
+    TokenContract = Contract.get_contract('IbetShare', token['address'])
+    tx_hash = TokenContract.functions.issueFrom(target, lock_address, amount). \
+        transact({'from': invoker['account_address'], 'gas': 4000000})
+    web3.eth.waitForTransactionReceipt(tx_hash)
+
+
+# トークン発行数量の削減
+def share_redeem_from(invoker, token, target_address: str, amount: int, lock_address: str = config.ZERO_ADDRESS):
+    web3.eth.defaultAccount = invoker['account_address']
+
+    TokenContract = Contract.get_contract('IbetShare', token['address'])
+    tx_hash = TokenContract.functions.redeemFrom(target_address, lock_address, amount). \
+        transact({'from': invoker['account_address'], 'gas': 4000000})
+    web3.eth.waitForTransactionReceipt(tx_hash)
+
+
+# 取引コントラクトの更新
+def share_set_tradable_exchange(invoker, token, exchange_address: str):
+    web3.eth.defaultAccount = invoker['account_address']
+
+    TokenContract = Contract.get_contract('IbetShare', token['address'])
+    tx_hash = TokenContract.functions.setTradableExchange(exchange_address). \
         transact({'from': invoker['account_address'], 'gas': 4000000})
     web3.eth.waitForTransactionReceipt(tx_hash)
 
@@ -432,6 +634,16 @@ def coupon_withdraw_from_exchange(invoker, exchange, token, amount):
     })
 
 
+# 取引コントラクトの更新
+def coupon_set_tradable_exchange(invoker, token, exchange_address: str):
+    web3.eth.defaultAccount = invoker['account_address']
+
+    TokenContract = Contract.get_contract('IbetCoupon', token['address'])
+    tx_hash = TokenContract.functions.setTradableExchange(exchange_address). \
+        transact({'from': invoker['account_address'], 'gas': 4000000})
+    web3.eth.waitForTransactionReceipt(tx_hash)
+
+
 '''
 Membership Token （会員権）
 '''
@@ -502,6 +714,16 @@ def membership_transfer_to_exchange(invoker, exchange, token, amount):
         get_contract('IbetMembership', token['address'])
     tx_hash = TokenContract.functions. \
         transfer(exchange['address'], amount). \
+        transact({'from': invoker['account_address'], 'gas': 4000000})
+    web3.eth.waitForTransactionReceipt(tx_hash)
+
+
+# 取引コントラクトの更新
+def membership_set_tradable_exchange(invoker, token, exchange_address: str):
+    web3.eth.defaultAccount = invoker['account_address']
+
+    TokenContract = Contract.get_contract('IbetMembership', token['address'])
+    tx_hash = TokenContract.functions.setTradableExchange(exchange_address). \
         transact({'from': invoker['account_address'], 'gas': 4000000})
     web3.eth.waitForTransactionReceipt(tx_hash)
 
@@ -633,6 +855,25 @@ def get_latest_security_escrow_id(exchange):
     latest_escrow_id = \
         IbetSecurityTokenEscrowContract.functions.latestEscrowId().call()
     return latest_escrow_id
+
+# エスクローのキャンセル
+def cancel_security_token_escrow(invoker, exchange, escrow_id):
+    web3.eth.defaultAccount = invoker['account_address']
+    IbetSecurityTokenEscrowContract = Contract. \
+        get_contract('IbetSecurityTokenEscrow', exchange['address'])
+    tx_hash = IbetSecurityTokenEscrowContract.functions. \
+        cancelEscrow(escrow_id).transact({'from': invoker['account_address'], 'gas': 4000000})
+    web3.eth.waitForTransactionReceipt(tx_hash)
+
+# 移転の承認
+def approve_transfer_security_token_escrow(invoker, exchange, escrow_id, transfer_approval_data: str):
+    web3.eth.defaultAccount = invoker['account_address']
+    IbetSecurityTokenEscrowContract = Contract. \
+        get_contract('IbetSecurityTokenEscrow', exchange['address'])
+    tx_hash = IbetSecurityTokenEscrowContract.functions. \
+        approveTransfer(escrow_id, transfer_approval_data).transact(
+            {'from': invoker['account_address'], 'gas': 4000000})
+    web3.eth.waitForTransactionReceipt(tx_hash)
 
 # エスクローの完了
 def finish_security_token_escrow(invoker, exchange, escrow_id):


### PR DESCRIPTION
Close #1134 

## 1. Online API feature

### POST
https://github.com/BoostryJP/ibet-Wallet-API/blob/b0ba9c92653a0b1f8525f3d58c7fbc0e90c710e7/docs/ibet_wallet_api_v2.yaml#L1996

* Added POST endpoint.
* This api expect “contract_address” in path, “list_id” and “block_number” in body.
* ”list_id” is assumed to be UUID.
* If existing combinations of block_number and contract_address is given, this api will return existing list_id.

### GET
https://github.com/BoostryJP/ibet-Wallet-API/blob/b0ba9c92653a0b1f8525f3d58c7fbc0e90c710e7/docs/ibet_wallet_api_v2.yaml#L2064 

* This api expect “contract_address” and “list_id “ in path.

## 2. Batch feature

* It syncs all events from 0 to given block number.
* If it has already collected events from 0 to some block number and stored data in DB, it can reuse the data.
* Token holders address is excluding issuer address as we cannot get totalSupply at specific block_number(If all events we may fetch, it could).

## 3. others
https://github.com/BoostryJP/ibet-Wallet-API/blob/b0ba9c92653a0b1f8525f3d58c7fbc0e90c710e7/docs/ibet_wallet_api_v3.yaml#L1272-L1279
- In swagger v2 format, “example” phrase in request parameter is not permitted.
 In the past PR(#1127 ) I added this mistakenly, then now fixed.