### PR TITLE
fix: add rollback before second query in unit test

### DIFF
--- a/tests/batch/indexer_Consume_Coupon_test.py
+++ b/tests/batch/indexer_Consume_Coupon_test.py
@@ -320,6 +320,7 @@ class TestProcessor:
         processor.sync_new_logs()
 
         # Assertion
+        session.rollback()
         _consume_coupon_list = session.query(IDXConsumeCoupon).order_by(IDXConsumeCoupon.created).all()
         assert len(_consume_coupon_list) == 0
         # Latest_block is incremented in "sync_new_logs" process.
@@ -354,6 +355,7 @@ class TestProcessor:
             processor.sync_new_logs()
 
         # Assertion
+        session.rollback()
         _consume_coupon_list = session.query(IDXConsumeCoupon).order_by(IDXConsumeCoupon.created).all()
         assert len(_consume_coupon_list) == 0
         # Latest_block is NOT incremented in "sync_new_logs" process.
@@ -389,6 +391,7 @@ class TestProcessor:
             processor.sync_new_logs()
 
         # Assertion
+        session.rollback()
         _consume_coupon_list = session.query(IDXConsumeCoupon).order_by(IDXConsumeCoupon.created).all()
         assert len(_consume_coupon_list) == 0
         # Latest_block is NOT incremented in "sync_new_logs" process.
@@ -425,6 +428,7 @@ class TestProcessor:
             processor.sync_new_logs()
 
         # Assertion
+        session.rollback()
         _consume_coupon_list = session.query(IDXConsumeCoupon).order_by(IDXConsumeCoupon.created).all()
         assert len(_consume_coupon_list) == 0
         # Latest_block is NOT incremented in "sync_new_logs" process.

--- a/tests/batch/indexer_DEX_test.py
+++ b/tests/batch/indexer_DEX_test.py
@@ -851,6 +851,7 @@ class TestProcessor:
         # Run target process
         processor.sync_new_logs()
         # Assertion
+        session.rollback()
         _order_list = session.query(IDXOrder).order_by(IDXOrder.created).all()
         assert len(_order_list) == 0
         _agreement_list = session.query(IDXAgreement).order_by(IDXAgreement.created).all()
@@ -896,6 +897,7 @@ class TestProcessor:
             processor.sync_new_logs()
 
         # Assertion
+        session.rollback()
         _order_list = session.query(IDXOrder).order_by(IDXOrder.created).all()
         assert len(_order_list) == 0
         _agreement_list = session.query(IDXAgreement).order_by(IDXAgreement.created).all()
@@ -942,6 +944,7 @@ class TestProcessor:
             processor.sync_new_logs()
 
         # Assertion
+        session.rollback()
         _order_list = session.query(IDXOrder).order_by(IDXOrder.created).all()
         assert len(_order_list) == 0
         _agreement_list = session.query(IDXAgreement).order_by(IDXAgreement.created).all()
@@ -989,6 +992,7 @@ class TestProcessor:
             processor.sync_new_logs()
 
         # Assertion
+        session.rollback()
         _order_list = session.query(IDXOrder).order_by(IDXOrder.created).all()
         assert len(_order_list) == 0
         _agreement_list = session.query(IDXAgreement).order_by(IDXAgreement.created).all()

--- a/tests/batch/indexer_Token_Holders_test.py
+++ b/tests/batch/indexer_Token_Holders_test.py
@@ -1675,6 +1675,7 @@ class TestProcessor:
                 pytest.raises(ServiceUnavailable):
             processor.collect()
 
+        session.rollback()
         _records: List[TokenHolder] = (
             session.query(TokenHolder).filter(TokenHolder.holder_list_id == target_token_holders_list.id).all()
         )

--- a/tests/batch/indexer_TransferApproval_test.py
+++ b/tests/batch/indexer_TransferApproval_test.py
@@ -1147,6 +1147,7 @@ class TestProcessor:
         processor.sync_new_logs()
 
         # Assertion
+        session.rollback()
         _transfer_approval_list = session.query(IDXTransferApproval). \
             order_by(IDXTransferApproval.created). \
             all()
@@ -1232,6 +1233,7 @@ class TestProcessor:
             processor.sync_new_logs()
 
         # Assertion
+        session.rollback()
         _transfer_approval_list = session.query(IDXTransferApproval). \
             order_by(IDXTransferApproval.created). \
             all()
@@ -1317,6 +1319,7 @@ class TestProcessor:
             processor.sync_new_logs()
 
         # Assertion
+        session.rollback()
         _transfer_approval_list = session.query(IDXTransferApproval). \
             order_by(IDXTransferApproval.created). \
             all()
@@ -1403,6 +1406,7 @@ class TestProcessor:
             processor.sync_new_logs()
 
         # Assertion
+        session.rollback()
         _transfer_approval_list = session.query(IDXTransferApproval). \
             order_by(IDXTransferApproval.created). \
             all()

--- a/tests/batch/indexer_Transfer_test.py
+++ b/tests/batch/indexer_Transfer_test.py
@@ -419,6 +419,7 @@ class TestProcessor:
         processor.sync_new_logs()
 
         # Assertion
+        session.rollback()
         _transfer_list = session.query(IDXTransfer).order_by(IDXTransfer.created).all()
         assert len(_transfer_list) == 1  # prepare same
 
@@ -492,6 +493,7 @@ class TestProcessor:
         processor.sync_new_logs()
 
         # Assertion
+        session.rollback()
         _transfer_list = session.query(IDXTransfer).order_by(IDXTransfer.created).all()
         assert len(_transfer_list) == 0
         # Latest_block is incremented in "initial_sync" process.
@@ -533,6 +535,7 @@ class TestProcessor:
             processor.sync_new_logs()
 
         # Assertion
+        session.rollback()
         _transfer_list = session.query(IDXTransfer).order_by(IDXTransfer.created).all()
         assert len(_transfer_list) == 0
         # Latest_block is NOT incremented in "sync_new_logs" process.
@@ -575,6 +578,7 @@ class TestProcessor:
             processor.sync_new_logs()
 
         # Assertion
+        session.rollback()
         _transfer_list = session.query(IDXTransfer).order_by(IDXTransfer.created).all()
         assert len(_transfer_list) == 0
         # Latest_block is NOT incremented in "sync_new_logs" process.
@@ -618,6 +622,7 @@ class TestProcessor:
             processor.sync_new_logs()
 
         # Assertion
+        session.rollback()
         _transfer_list = session.query(IDXTransfer).order_by(IDXTransfer.created).all()
         assert len(_transfer_list) == 0
         # Latest_block is NOT incremented in "sync_new_logs" process.


### PR DESCRIPTION
close #1144 
**Fixed only Unit test.**
