### PR TITLE
feat: Add indexer batch for token details

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -112,22 +112,28 @@ CONTRACT_REGISTRY_ADDRESS = os.environ.get('CONTRACT_REGISTRY_ADDRESS')
 
 # トークン情報キャッシュの設定
 TOKEN_CACHE = False if os.environ.get("TOKEN_CACHE") == "0" else True
+
 # トークン情報キャッシュの有効期限 (秒)
 TOKEN_CACHE_TTL = int(os.environ.get("TOKEN_CACHE_TTL")) if os.environ.get("TOKEN_CACHE_TTL") else 43200
 # トークン情報キャッシュの更新間隔 (秒)
+# NOTE: デフォルト値はTTLの80%
 TOKEN_CACHE_REFRESH_INTERVAL = int(os.environ.get("TOKEN_CACHE_REFRESH_INTERVAL"))\
     if os.environ.get("TOKEN_CACHE_REFRESH_INTERVAL") else 34560
+
 # トークン情報短時間キャッシュの有効期限 (秒)
 TOKEN_SHORT_TERM_CACHE_TTL = int(os.environ.get("TOKEN_SHORT_TERM_CACHE_TTL"))\
     if os.environ.get("TOKEN_SHORT_TERM_CACHE_TTL") else 40
 # トークン情報短時間キャッシュの更新間隔 (秒)
+# NOTE: デフォルト値はTTLの80%
 TOKEN_SHORT_TERM_CACHE_REFRESH_INTERVAL = int(os.environ.get("TOKEN_SHORT_TERM_CACHE_REFRESH_INTERVAL"))\
-    if os.environ.get("TOKEN_SHORT_TERM_CACHE_REFRESH_INTERVAL") else 30
+    if os.environ.get("TOKEN_SHORT_TERM_CACHE_REFRESH_INTERVAL") else 32
 
 # トークン情報キャッシュの取得間隔 (秒)
+# NOTE: トークン情報1件あたりに割り当てる間隔
 TOKEN_FETCH_INTERVAL = int(os.environ.get("TOKEN_FETCH_INTERVAL")) \
     if os.environ.get("TOKEN_FETCH_INTERVAL") else 3
 # トークン情報短時間キャッシュの取得間隔 (ミリ秒)
+# NOTE: トークン情報1件あたりに割り当てる間隔
 TOKEN_SHORT_TERM_FETCH_INTERVAL_MSEC = int(os.environ.get("TOKEN_SHORT_TERM_FETCH_INTERVAL_MSEC")) \
     if os.environ.get("TOKEN_SHORT_TERM_FETCH_INTERVAL_MSEC") else 100
 

--- a/app/config.py
+++ b/app/config.py
@@ -110,9 +110,27 @@ IBET_SECURITY_TOKEN_ESCROW_CONTRACT_ADDRESS = os.environ.get('IBET_SECURITY_TOKE
 E2E_MESSAGING_CONTRACT_ADDRESS = os.environ.get('E2E_MESSAGING_CONTRACT_ADDRESS')
 CONTRACT_REGISTRY_ADDRESS = os.environ.get('CONTRACT_REGISTRY_ADDRESS')
 
-# トークン情報のキャッシュ
+# トークン情報キャッシュの設定
 TOKEN_CACHE = False if os.environ.get("TOKEN_CACHE") == "0" else True
+# トークン情報キャッシュの有効期限 (秒)
 TOKEN_CACHE_TTL = int(os.environ.get("TOKEN_CACHE_TTL")) if os.environ.get("TOKEN_CACHE_TTL") else 43200
+# トークン情報キャッシュの更新間隔 (秒)
+TOKEN_CACHE_REFRESH_INTERVAL = int(os.environ.get("TOKEN_CACHE_REFRESH_INTERVAL"))\
+    if os.environ.get("TOKEN_CACHE_REFRESH_INTERVAL") else 34560
+# トークン情報短時間キャッシュの有効期限 (秒)
+TOKEN_SHORT_TERM_CACHE_TTL = int(os.environ.get("TOKEN_SHORT_TERM_CACHE_TTL"))\
+    if os.environ.get("TOKEN_SHORT_TERM_CACHE_TTL") else 40
+# トークン情報短時間キャッシュの更新間隔 (秒)
+TOKEN_SHORT_TERM_CACHE_REFRESH_INTERVAL = int(os.environ.get("TOKEN_SHORT_TERM_CACHE_REFRESH_INTERVAL"))\
+    if os.environ.get("TOKEN_SHORT_TERM_CACHE_REFRESH_INTERVAL") else 30
+
+# トークン情報キャッシュの取得間隔 (秒)
+TOKEN_FETCH_INTERVAL = int(os.environ.get("TOKEN_FETCH_INTERVAL")) \
+    if os.environ.get("TOKEN_FETCH_INTERVAL") else 3
+# トークン情報短時間キャッシュの取得間隔 (ミリ秒)
+TOKEN_SHORT_TERM_FETCH_INTERVAL_MSEC = int(os.environ.get("TOKEN_SHORT_TERM_FETCH_INTERVAL_MSEC")) \
+    if os.environ.get("TOKEN_SHORT_TERM_FETCH_INTERVAL_MSEC") else 100
+
 
 # テスト用設定：Locust
 BASIC_AUTH_USER = os.environ.get('BASIC_AUTH_USER')

--- a/app/errors.py
+++ b/app/errors.py
@@ -66,6 +66,12 @@ ERR_DATA_NOT_EXISTS = {
     'title': 'Data Not Exists'
 }
 
+ERR_DATA_CONFLICT = {
+    "status": falcon.HTTP_409,
+    "code": 40,
+    "title": "Data Conflict"
+}
+
 ERR_SERVICE_UNAVAILABLE = {
     'status': falcon.HTTP_503,
     'code': 503,
@@ -153,6 +159,15 @@ class SuspendedTokenError(AppError):
     def __init__(self, description=None):
         super().__init__(ERR_SUSPENDED_TOKEN)
         self.error['description'] = description
+
+
+class DataConflictError(AppError):
+    """
+    409 ERROR: データが重複
+    """
+    def __init__(self, description=None):
+        super().__init__(ERR_DATA_CONFLICT)
+        self.error["description"] = description
 
 
 class ServiceUnavailable(AppError):

--- a/app/model/blockchain/__init__.py
+++ b/app/model/blockchain/__init__.py
@@ -20,5 +20,7 @@ from .token import (
     BondToken,
     ShareToken,
     MembershipToken,
-    CouponToken
+    CouponToken,
+    TokenClassTypes,
+    TokenInstanceTypes
 )

--- a/app/model/db/__init__.py
+++ b/app/model/db/__init__.py
@@ -43,6 +43,18 @@ from .idx_position import (
     IDXPositionMembershipBlockNumber,
     IDXPositionCouponBlockNumber
 )
+from .idx_token import (
+    IDXBondToken,
+    IDXShareToken,
+    IDXMembershipToken,
+    IDXCouponToken,
+    TokenModelClassTypes,
+    TokenModelInstanceTypes
+)
+from .idx_token_list import (
+    IDXTokenListItem,
+    IDXTokenListBlockNumber
+)
 from .tokenholders import (
     TokenHoldersList,
     TokenHolderBatchStatus,

--- a/app/model/db/idx_token.py
+++ b/app/model/db/idx_token.py
@@ -1,0 +1,352 @@
+"""
+Copyright BOOSTRY Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+from typing import Union, Type
+from sqlalchemy import (
+    Column,
+    String,
+    BigInteger,
+    Boolean,
+    Float,
+    Text,
+    JSON,
+    DateTime
+)
+from app.model.db import Base
+
+
+class TokenBase(Base):
+    """Token Base Attribute"""
+    __abstract__ = True
+
+    # Token Address
+    token_address = Column(String(42), primary_key=True)
+    # Token Template
+    token_template = Column(String(40))
+    # Owner Address
+    owner_address = Column(String(42), index=True)
+    # Company Name(Corporate)
+    # NOTE: Short-term cache required
+    company_name = Column(Text)
+    # RSA Public Key(Corporate)
+    # NOTE: Short-term cache required
+    rsa_publickey = Column(String(2000))
+    # Name
+    name = Column(String(200))
+    # Symbol
+    symbol = Column(String(200))
+    # Total Supply
+    # NOTE: Short-term cache required
+    total_supply = Column(BigInteger)
+    # Tradable Exchange
+    tradable_exchange = Column(String(42), index=True)
+    # Contact Information
+    contact_information = Column(String(2000))
+    # Privacy Policy
+    privacy_policy = Column(String(5000))
+    # Status
+    # NOTE: Short-term cache required
+    status = Column(Boolean)
+    # Max Holding Quantity
+    max_holding_quantity = Column(BigInteger)
+    # Max Sell Amount
+    max_sell_amount = Column(BigInteger)
+    # Cached time of short-term cache
+    short_term_cache_created = Column(DateTime)
+
+    FIELDS = {
+        "id": int,
+        "token_address": str,
+        "token_template": str,
+        "owner_address": str,
+        "company_name": str,
+        "rsa_publickey": str,
+        "name": str,
+        "symbol": str,
+        "total_supply": int,
+        "tradable_exchange": str,
+        "contact_information": str,
+        "privacy_policy": str,
+        "status": bool,
+        "max_holding_quantity": int,
+        "max_sell_amount": int,
+    }
+
+    FIELDS.update(Base.FIELDS)
+
+    def json(self):
+        return {
+            "token_address": self.token_address,
+            "token_template": self.token_template,
+            "owner_address": self.owner_address,
+            "company_name": self.company_name,
+            "rsa_publickey": self.rsa_publickey,
+            "name": self.name,
+            "symbol": self.symbol,
+            "total_supply": self.total_supply,
+            "tradable_exchange": self.tradable_exchange,
+            "contact_information": self.contact_information,
+            "privacy_policy": self.privacy_policy,
+            "status": self.status,
+            "max_holding_quantity": self.max_holding_quantity,
+            "max_sell_amount": self.max_sell_amount,
+        }
+
+
+class IDXBondToken(TokenBase):
+    """BondToken (INDEX)"""
+    __tablename__ = "bond_token"
+
+    # Personal Info Address
+    personal_info_address = Column(String(42), index=True)
+    # Transferable
+    # NOTE: Short-term cache required
+    transferable = Column(Boolean)
+    # Is Offering
+    # NOTE: Short-term cache required
+    is_offering = Column(Boolean)
+    # Transfer Approval Required
+    # NOTE: Short-term cache required
+    transfer_approval_required = Column(Boolean)
+    # Face Value
+    face_value = Column(BigInteger)
+    # Interest Rate
+    interest_rate = Column(Float)
+    # Interest Payment Date(JSON)
+    interest_payment_date = Column(JSON)
+    # Redemption Date
+    redemption_date = Column(String(8))
+    # Redemption Value
+    redemption_value = Column(BigInteger)
+    # Return Date
+    return_date = Column(String(8))
+    # Return Amount
+    return_amount = Column(String(2000))
+    # Purpose
+    purpose = Column(String(2000))
+    # Memo
+    memo = Column(String(2000))
+    # Is Redeemed
+    # NOTE: Short-term cache required
+    is_redeemed = Column(Boolean)
+
+    FIELDS = {
+        "personal_info_address": str,
+        "transferable": bool,
+        "is_offering": bool,
+        "transfer_approval_required": bool,
+        "face_value": int,
+        "interest_rate": float,
+        "interest_payment_date": list,
+        "redemption_date": str,
+        "redemption_value": int,
+        "return_date": str,
+        "return_amount": str,
+        "purpose": str,
+        "memo": str,
+        "is_redeemed": bool
+    }
+
+    FIELDS.update(TokenBase.FIELDS)
+
+    def json(self):
+        return {
+            **super().json(),
+            "personal_info_address": self.personal_info_address,
+            "transferable": self.transferable,
+            "is_offering": self.is_offering,
+            "transfer_approval_required": self.transfer_approval_required,
+            "face_value": self.face_value,
+            "interest_rate": self.interest_rate,
+            "interest_payment_date": self.interest_payment_date,
+            "redemption_date": self.redemption_date,
+            "redemption_value": self.redemption_value,
+            "return_date": self.return_date,
+            "return_amount": self.return_amount,
+            "purpose": self.purpose,
+            "memo": self.memo,
+            "is_redeemed": self.is_redeemed
+        }
+
+
+class IDXShareToken(TokenBase):
+    """ShareToken (INDEX)"""
+    __tablename__ = "share_token"
+
+    # Personal Info Address
+    personal_info_address = Column(String(42), index=True)
+    # Transferable
+    # NOTE: Short-term cache required
+    transferable = Column(Boolean)
+    # Is Offering
+    # NOTE: Short-term cache required
+    is_offering = Column(Boolean)
+    # Transfer Approval Required
+    # NOTE: Short-term cache required
+    transfer_approval_required = Column(Boolean)
+    # Issue Price
+    issue_price = Column(BigInteger)
+    # Cancellation Date
+    cancellation_date = Column(String(8))
+    # Memo
+    memo = Column(String(2000))
+    # Principal Value
+    # NOTE: Short-term cache required
+    principal_value = Column(BigInteger)
+    # Is Canceled
+    # NOTE: Short-term cache required
+    is_canceled = Column(Boolean)
+    # Dividend Information(JSON)
+    # NOTE: Short-term cache required
+    dividend_information = Column(JSON)
+
+    FIELDS = {
+        "personal_info_address": str,
+        "transferable": bool,
+        "is_offering": bool,
+        "transfer_approval_required": bool,
+        "issue_price": int,
+        "cancellation_date": str,
+        "memo": str,
+        "principal_value": int,
+        "is_canceled": bool,
+        "dividend_information": slice
+    }
+
+    FIELDS.update(TokenBase.FIELDS)
+
+    def json(self):
+        return {
+            **super().json(),
+            "personal_info_address": self.personal_info_address,
+            "transferable": self.transferable,
+            "is_offering": self.is_offering,
+            "transfer_approval_required": self.transfer_approval_required,
+            "issue_price": self.issue_price,
+            "cancellation_date": self.cancellation_date,
+            "memo": self.memo,
+            "principal_value": self.principal_value,
+            "is_canceled": self.is_canceled,
+            "dividend_information": self.dividend_information
+        }
+
+
+class IDXMembershipToken(TokenBase):
+    """MembershipToken (INDEX)"""
+    __tablename__ = "membership_token"
+
+    # Details
+    details = Column(String(2000))
+    # Return Details
+    return_details = Column(String(2000))
+    # Expiration Date
+    expiration_date = Column(String(8))
+    # Memo
+    memo = Column(String(2000))
+    # Transferable
+    # NOTE: Short-term cache required
+    transferable = Column(Boolean)
+    # Initial Offering Status
+    # NOTE: Short-term cache required
+    initial_offering_status = Column(Boolean)
+    # Image URL(JSON)
+    image_url = Column(JSON)
+
+    FIELDS = {
+        "details": str,
+        "return_details": str,
+        "expiration_date": str,
+        "memo": str,
+        "transferable": bool,
+        "initial_offering_status": bool,
+        "image_url": list,
+    }
+
+    FIELDS.update(TokenBase.FIELDS)
+
+    def json(self):
+        return {
+            **super().json(),
+            "details": self.details,
+            "return_details": self.return_details,
+            "expiration_date": self.expiration_date,
+            "memo": self.memo,
+            "transferable": self.transferable,
+            "initial_offering_status": self.initial_offering_status,
+            "image_url": self.image_url
+        }
+
+
+class IDXCouponToken(TokenBase):
+    """CouponToken (INDEX)"""
+    __tablename__ = "coupon_token"
+
+    # Details
+    details = Column(String(2000))
+    # Return Details
+    return_details = Column(String(2000))
+    # Expiration Date
+    expiration_date = Column(String(8))
+    # Memo
+    memo = Column(String(2000))
+    # Transferable
+    # NOTE: Short-term cache required
+    transferable = Column(Boolean)
+    # Initial Offering Status
+    # NOTE: Short-term cache required
+    initial_offering_status = Column(Boolean)
+    # Image URL(JSON)
+    image_url = Column(JSON)
+
+    FIELDS = {
+        "details": str,
+        "return_details": str,
+        "expiration_date": str,
+        "memo": str,
+        "transferable": bool,
+        "initial_offering_status": bool,
+        "image_url": list,
+    }
+
+    FIELDS.update(TokenBase.FIELDS)
+
+    def json(self):
+        return {
+            **super().json(),
+            "details": self.details,
+            "return_details": self.return_details,
+            "expiration_date": self.expiration_date,
+            "memo": self.memo,
+            "transferable": self.transferable,
+            "initial_offering_status": self.initial_offering_status,
+            "image_url": self.image_url
+        }
+
+
+TokenModelClassTypes = Union[
+    Type[IDXShareToken],
+    Type[IDXBondToken],
+    Type[IDXMembershipToken],
+    Type[IDXCouponToken]
+]
+TokenModelInstanceTypes = Union[
+    IDXBondToken,
+    IDXShareToken,
+    IDXMembershipToken,
+    IDXCouponToken
+]

--- a/app/model/db/idx_token_list.py
+++ b/app/model/db/idx_token_list.py
@@ -1,0 +1,63 @@
+"""
+Copyright BOOSTRY Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+from sqlalchemy import (
+    Column,
+    String,
+    BigInteger
+)
+
+from app.model.db import Base
+
+
+class IDXTokenListItem(Base):
+    """Token List Items (INDEX)"""
+    __tablename__ = "token_list"
+
+    # Token Address
+    token_address = Column(String(42), primary_key=True)
+    # Token Template
+    token_template = Column(String(40), nullable=False)
+    # Owner Address
+    owner_address = Column(String(42), index=True)
+
+    FIELDS = {
+        "token_address": str,
+        "token_template": str,
+        "owner_address": str,
+    }
+
+    FIELDS.update(Base.FIELDS)
+
+
+class IDXTokenListBlockNumber(Base):
+    """Synchronized blockNumber of IDXTokenList"""
+    __tablename__ = "idx_token_list_block_number"
+
+    # target address
+    contract_address = Column(String(42), primary_key=True)
+    # latest blockNumber
+    latest_block_number = Column(BigInteger)
+
+    FIELDS = {
+        'id': int,
+        'target_address': str,
+        'latest_block_number': int,
+    }
+
+    FIELDS.update(Base.FIELDS)

--- a/batch/indexer_Token_Detail.py
+++ b/batch/indexer_Token_Detail.py
@@ -1,0 +1,156 @@
+"""
+Copyright BOOSTRY Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+import os
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime
+from eth_utils import to_checksum_address
+from sqlalchemy import create_engine
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
+from typing import List, Type
+
+path = os.path.join(os.path.dirname(__file__), "../")
+sys.path.append(path)
+
+from app.config import (
+    DATABASE_URL,
+    TOKEN_FETCH_INTERVAL,
+    TOKEN_CACHE_REFRESH_INTERVAL,
+    BOND_TOKEN_ENABLED,
+    SHARE_TOKEN_ENABLED,
+    MEMBERSHIP_TOKEN_ENABLED,
+    COUPON_TOKEN_ENABLED
+)
+from app.errors import ServiceUnavailable
+from app.model.blockchain.token import TokenClassTypes
+from app.model.db import (
+    Listing,
+    IDXTokenListItem,
+)
+from app.model.blockchain import (
+    CouponToken,
+    MembershipToken,
+    BondToken,
+    ShareToken
+)
+import log
+
+process_name = "INDEXER-TOKEN-DETAIL"
+LOG = log.get_logger(process_name=process_name)
+
+db_engine = create_engine(DATABASE_URL, echo=False, pool_pre_ping=True)
+
+
+class Processor:
+    """Processor for indexing token detail"""
+
+    @dataclass
+    class TargetTokenType:
+        template: str
+        token_class: Type[TokenClassTypes]
+
+    target_token_types: List[TargetTokenType]
+    SEC_PER_RECORD: int = TOKEN_FETCH_INTERVAL
+
+    def __init__(self):
+        self.target_token_types = []
+        if BOND_TOKEN_ENABLED:
+            self.target_token_types.append(
+                self.TargetTokenType(template="IbetStraightBond", token_class=BondToken)
+            )
+        if SHARE_TOKEN_ENABLED:
+            self.target_token_types.append(
+                self.TargetTokenType(template="IbetShare", token_class=ShareToken)
+            )
+        if MEMBERSHIP_TOKEN_ENABLED:
+            self.target_token_types.append(
+                self.TargetTokenType(template="IbetMembership", token_class=MembershipToken)
+            )
+        if COUPON_TOKEN_ENABLED:
+            self.target_token_types.append(
+                self.TargetTokenType(template="IbetCoupon", token_class=CouponToken)
+            )
+
+    @staticmethod
+    def __get_db_session() -> Session:
+        return Session(autocommit=False, autoflush=True, bind=db_engine)
+
+    def process(self):
+        start_time = time.time()
+        local_session = self.__get_db_session()
+        try:
+            self.__sync(local_session)
+        except Exception:
+            local_session.rollback()
+            local_session.close()
+            raise
+        finally:
+            local_session.close()
+        elapsed_time = time.time() - start_time
+        LOG.info(f"<{process_name}> Sync job has been completed in {elapsed_time:.3f} sec")
+
+    def __sync(self, local_session: Session):
+        for token_type in self.target_token_types:
+            available_tokens: List[Listing] = local_session.query(Listing).\
+                join(IDXTokenListItem, IDXTokenListItem.token_address == Listing.token_address).\
+                filter(Listing.is_public == True).\
+                filter(IDXTokenListItem.token_template == token_type.template).\
+                order_by(Listing.id).all()
+
+            for available_token in available_tokens:
+                start_time = time.time()
+                token_address = to_checksum_address(available_token.token_address)
+                token_detail_obj = token_type.token_class.fetch(local_session, token_address)
+                token_detail = token_detail_obj.to_model()
+                token_detail.created = datetime.utcnow()
+                local_session.merge(token_detail)
+                local_session.commit()
+
+                # Keep request interval constant to avoid throwing many request to JSON-RPC
+                elapsed_time = time.time() - start_time
+                time.sleep(max(self.SEC_PER_RECORD - elapsed_time, 0))
+
+
+def main():
+    LOG.info("Service started successfully")
+    processor = Processor()
+    while True:
+        start_time = time.time()
+
+        try:
+            processor.process()
+            LOG.debug("Processed")
+        except ServiceUnavailable:
+            LOG.warning("An external service was unavailable")
+        except SQLAlchemyError as sa_err:
+            LOG.error(f"A database error has occurred: code={sa_err.code}\n{sa_err}")
+        except Exception:  # Unexpected errors
+            LOG.exception("An exception occurred during event synchronization")
+
+        elapsed_time = time.time() - start_time
+        time_to_sleep = max(TOKEN_CACHE_REFRESH_INTERVAL - elapsed_time, 0)
+        if time_to_sleep == 0:
+            LOG.debug("Processing is delayed")
+        time.sleep(time_to_sleep)
+
+
+if __name__ == "__main__":
+    main()

--- a/batch/indexer_Token_Detail_ShortTerm.py
+++ b/batch/indexer_Token_Detail_ShortTerm.py
@@ -1,0 +1,160 @@
+"""
+Copyright BOOSTRY Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+import os
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime
+from sqlalchemy import create_engine
+from sqlalchemy.exc import (
+    SQLAlchemyError
+)
+from sqlalchemy.orm import Session
+from typing import List, Type
+
+path = os.path.join(os.path.dirname(__file__), "../")
+sys.path.append(path)
+
+from app.config import (
+    DATABASE_URL,
+    BOND_TOKEN_ENABLED,
+    SHARE_TOKEN_ENABLED,
+    MEMBERSHIP_TOKEN_ENABLED,
+    COUPON_TOKEN_ENABLED,
+    TOKEN_SHORT_TERM_CACHE_REFRESH_INTERVAL,
+    TOKEN_SHORT_TERM_FETCH_INTERVAL_MSEC
+)
+from app.errors import ServiceUnavailable
+from app.model.db import (
+    Listing,
+    IDXBondToken as BondTokenModel,
+    IDXShareToken as ShareTokenModel,
+    IDXMembershipToken as MembershipTokenModel,
+    IDXCouponToken as CouponTokenModel,
+    TokenModelInstanceTypes
+)
+from app.model.blockchain import (
+    CouponToken,
+    MembershipToken,
+    BondToken,
+    ShareToken,
+    TokenClassTypes
+)
+import log
+
+process_name = "INDEXER-TOKEN-DETAIL-SHORT-TERM"
+LOG = log.get_logger(process_name=process_name)
+
+db_engine = create_engine(DATABASE_URL, echo=False, pool_pre_ping=True)
+
+
+class Processor:
+    """Processor for indexing token detail attributes for short term"""
+    @dataclass
+    class TargetTokenType:
+        template: str
+        token_class: Type[TokenClassTypes]
+        token_model: Type[TokenModelInstanceTypes]
+
+    target_token_types: List[TargetTokenType]
+    SEC_PER_RECORD: float = TOKEN_SHORT_TERM_FETCH_INTERVAL_MSEC/1000
+
+    def __init__(self):
+        self.target_token_types = []
+        if BOND_TOKEN_ENABLED:
+            self.target_token_types.append(
+                self.TargetTokenType(template="IbetStraightBond", token_class=BondToken, token_model=BondTokenModel)
+            )
+        if SHARE_TOKEN_ENABLED:
+            self.target_token_types.append(
+                self.TargetTokenType(template="IbetShare", token_class=ShareToken, token_model=ShareTokenModel)
+            )
+        if MEMBERSHIP_TOKEN_ENABLED:
+            self.target_token_types.append(
+                self.TargetTokenType(template="IbetMembership", token_class=MembershipToken, token_model=MembershipTokenModel)
+            )
+        if COUPON_TOKEN_ENABLED:
+            self.target_token_types.append(
+                self.TargetTokenType(template="IbetCoupon", token_class=CouponToken, token_model=CouponTokenModel)
+            )
+
+    @staticmethod
+    def __get_db_session() -> Session:
+        return Session(autocommit=False, autoflush=True, bind=db_engine)
+
+    def process(self):
+        start_time = time.time()
+        local_session = self.__get_db_session()
+        try:
+            self.__sync(local_session)
+        except Exception:
+            local_session.rollback()
+            local_session.close()
+            raise
+        finally:
+            local_session.close()
+        elapsed_time = time.time() - start_time
+        LOG.info(f"<{process_name}> Sync job has been completed in {elapsed_time:.3f} sec")
+
+    def __sync(self, local_session: Session):
+        for token_type in self.target_token_types:
+            available_tokens = local_session.query(token_type.token_model).\
+                join(Listing, token_type.token_model.token_address == Listing.token_address).\
+                filter(Listing.is_public == True).all()
+
+            for available_token in available_tokens:
+                start_time = time.time()
+                token = token_type.token_class.from_model(available_token)
+                token.fetch_expiry_short()
+                token_model = token.to_model()
+                token_model.created = datetime.utcnow()
+                local_session.merge(token_model)
+
+                # Keep request interval constant to avoid throwing many request to JSON-RPC
+                elapsed_time = time.time() - start_time
+                time.sleep(max(self.SEC_PER_RECORD - elapsed_time, 0))
+
+            local_session.commit()
+
+
+def main():
+    LOG.info("Service started successfully")
+    processor = Processor()
+    while True:
+        start_time = time.time()
+
+        try:
+            processor.process()
+            LOG.debug("Processed")
+        except ServiceUnavailable:
+            LOG.warning("An external service was unavailable")
+        except SQLAlchemyError as sa_err:
+            LOG.error(f"A database error has occurred: code={sa_err.code}\n{sa_err}")
+        except Exception:  # Unexpected errors
+            LOG.exception("An exception occurred during event synchronization")
+
+        elapsed_time = time.time() - start_time
+        time_to_sleep = max(TOKEN_SHORT_TERM_CACHE_REFRESH_INTERVAL - elapsed_time, 0)
+        if time_to_sleep == 0:
+            LOG.debug("Processing is delayed")
+        time.sleep(time_to_sleep)
+
+
+if __name__ == "__main__":
+    main()

--- a/batch/indexer_Token_List.py
+++ b/batch/indexer_Token_List.py
@@ -1,0 +1,225 @@
+"""
+Copyright BOOSTRY Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+import os
+import sys
+import time
+from typing import Optional
+
+from sqlalchemy import create_engine
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
+from web3.exceptions import ABIEventFunctionNotFound
+
+path = os.path.join(os.path.dirname(__file__), "../")
+sys.path.append(path)
+
+from app.config import (
+    DATABASE_URL,
+    COUPON_TOKEN_ENABLED,
+    MEMBERSHIP_TOKEN_ENABLED,
+    SHARE_TOKEN_ENABLED,
+    BOND_TOKEN_ENABLED,
+    TOKEN_LIST_CONTRACT_ADDRESS
+)
+from app.contracts import Contract
+from app.errors import ServiceUnavailable
+from app.model.db import (
+    IDXTokenListBlockNumber,
+    IDXTokenListItem
+)
+from app.utils.web3_utils import Web3Wrapper
+import log
+
+process_name = "INDEXER-TOKEN-LIST"
+LOG = log.get_logger(process_name=process_name)
+
+web3 = Web3Wrapper()
+db_engine = create_engine(DATABASE_URL, echo=False, pool_pre_ping=True)
+
+
+class Processor:
+    """Processor for indexing TokenList events"""
+
+    def __init__(self):
+        self.token_list_contract = Contract.get_contract(
+            contract_name="TokenList",
+            address=TOKEN_LIST_CONTRACT_ADDRESS
+        )
+
+    @staticmethod
+    def __get_db_session():
+        return Session(autocommit=False, autoflush=True, bind=db_engine)
+
+    def process(self):
+        local_session = self.__get_db_session()
+        try:
+            latest_block = web3.eth.block_number
+            _from_block = self.__get_idx_token_list_block_number(
+                db_session=local_session,
+                contract_address=TOKEN_LIST_CONTRACT_ADDRESS
+            ) + 1
+            _to_block = 999999 + _from_block
+            if latest_block > _to_block:
+                while _to_block < latest_block:
+                    self.__sync_all(
+                        db_session=local_session,
+                        block_from=_from_block,
+                        block_to=_to_block
+                    )
+                    _to_block += 1000000
+                self.__sync_all(
+                    db_session=local_session,
+                    block_from=_from_block,
+                    block_to=latest_block
+                )
+            else:
+                if _from_block > latest_block:
+                    return
+                self.__sync_all(
+                    db_session=local_session,
+                    block_from=_from_block,
+                    block_to=latest_block
+                )
+            self.__set_idx_token_list_block_number(
+                db_session=local_session,
+                contract_address=TOKEN_LIST_CONTRACT_ADDRESS,
+                block_number=latest_block,
+            )
+            local_session.commit()
+        except Exception as e:
+            local_session.rollback()
+            raise
+        finally:
+            local_session.close()
+        LOG.info(f"<{process_name}> Sync job has been completed")
+
+    def __sync_all(self, db_session: Session, block_from: int, block_to: int):
+        LOG.info("syncing from={}, to={}".format(block_from, block_to))
+        self.__sync_register(db_session, block_from, block_to)
+
+    def __sync_register(self, db_session: Session, block_from: int, block_to: int):
+        """Sync Register Events
+
+        :param db_session: ORM session
+        :param block_from: From block
+        :param block_to: To block
+        :return: None
+        """
+        try:
+            events = self.token_list_contract.events.Register.getLogs(
+                fromBlock=block_from,
+                toBlock=block_to
+            )
+        except ABIEventFunctionNotFound:
+            events = []
+        try:
+            for _event in events:
+                token_address = _event["args"].get("token_address")
+                token_template = _event["args"].get("token_template")
+                owner_address = _event["args"].get("owner_address")
+                self.__sink_on_token_info(
+                    db_session=db_session,
+                    token_address=token_address,
+                    token_template=token_template,
+                    owner_address=owner_address
+                )
+        except Exception as e:
+            raise e
+
+    def __sink_on_token_info(self, db_session: Session, token_address: str, token_template: str, owner_address: str):
+        """Update Token Info item in DB
+
+        :param db_session: ORM session
+        :param token_address: token address
+        :param token_template: token template
+        :param owner_address: owner address
+        :return: None
+        """
+        if token_template not in self.available_token_template():
+            return
+
+        idx_token_list: Optional[IDXTokenListItem] = db_session.query(IDXTokenListItem).\
+            filter(IDXTokenListItem.token_address == token_address).first()
+        if idx_token_list is not None:
+            idx_token_list.token_template = token_template
+            idx_token_list.owner_address = owner_address
+            db_session.merge(idx_token_list)
+        else:
+            idx_token_list = IDXTokenListItem()
+            idx_token_list.token_address = token_address
+            idx_token_list.token_template = token_template
+            idx_token_list.owner_address = owner_address
+            db_session.add(idx_token_list)
+
+    @staticmethod
+    def available_token_template():
+        """Get available token template"""
+        available_token_template_list = []
+        if BOND_TOKEN_ENABLED:
+            available_token_template_list.append("IbetStraightBond")
+        if SHARE_TOKEN_ENABLED:
+            available_token_template_list.append("IbetShare")
+        if MEMBERSHIP_TOKEN_ENABLED:
+            available_token_template_list.append("IbetMembership")
+        if COUPON_TOKEN_ENABLED:
+            available_token_template_list.append("IbetCoupon")
+        return available_token_template_list
+
+    @staticmethod
+    def __get_idx_token_list_block_number(db_session: Session, contract_address: str):
+        """Get token list index for Share """
+        _idx_token_list_block_number = db_session.query(IDXTokenListBlockNumber).\
+            filter(IDXTokenListBlockNumber.contract_address == contract_address).first()
+        if _idx_token_list_block_number is None:
+            return -1
+        else:
+            return _idx_token_list_block_number.latest_block_number
+
+    @staticmethod
+    def __set_idx_token_list_block_number(db_session: Session, contract_address: str, block_number: int):
+        """Get token list index for Share """
+        _idx_token_list_block_number = db_session.query(IDXTokenListBlockNumber). \
+            filter(IDXTokenListBlockNumber.contract_address == contract_address).first()
+        if _idx_token_list_block_number is None:
+            _idx_token_list_block_number = IDXTokenListBlockNumber()
+        _idx_token_list_block_number.latest_block_number = block_number
+        _idx_token_list_block_number.contract_address = contract_address
+        db_session.merge(_idx_token_list_block_number)
+
+
+def main():
+    LOG.info("Service started successfully")
+    processor = Processor()
+
+    while True:
+        try:
+            processor.process()
+            LOG.debug("Processed")
+        except ServiceUnavailable:
+            LOG.warning("An external service was unavailable")
+        except SQLAlchemyError as sa_err:
+            LOG.error(f"A database error has occurred: code={sa_err.code}\n{sa_err}")
+        except Exception:
+            LOG.exception("An exception occurred during event synchronization")
+
+        time.sleep(5)
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/healthcheck_indexer.sh
+++ b/bin/healthcheck_indexer.sh
@@ -49,6 +49,11 @@ if [ -n "$IBET_SHARE_EXCHANGE_CONTRACT_ADDRESS" -o \
   PROC_LIST="${PROC_LIST} batch/indexer_DEX.py"
 fi
 
+if [ "$TOKEN_CACHE" -ne 0 ]; then
+  PROC_LIST="${PROC_LIST} batch/indexer_Token_Detail.py"
+  PROC_LIST="${PROC_LIST} batch/indexer_Token_Detail_ShortTerm.py"
+fi
+
 for i in ${PROC_LIST}; do
   # shellcheck disable=SC2009
   ps -ef | grep -v grep | grep "$i"

--- a/bin/run_indexer.sh
+++ b/bin/run_indexer.sh
@@ -40,6 +40,7 @@ fi
 
 python batch/indexer_Transfer.py &
 python batch/indexer_Token_Holders.py &
+python batch/indexer_Token_List.py &
 
 if [ $SHARE_TOKEN_ENABLED = 1 ]; then
   python batch/indexer_Position_Share.py &
@@ -64,6 +65,11 @@ if [ -n "$IBET_SHARE_EXCHANGE_CONTRACT_ADDRESS" -o \
   -n "$IBET_MEMBERSHIP_EXCHANGE_CONTRACT_ADDRESS" -o \
   -n "$IBET_CP_EXCHANGE_CONTRACT_ADDRESS" ]; then
   python batch/indexer_DEX.py &
+fi
+
+if [ "$TOKEN_CACHE" -ne 0 ]; then
+  python batch/indexer_Token_Detail.py &
+  python batch/indexer_Token_Detail_ShortTerm.py &
 fi
 
 tail -f /dev/null

--- a/docs/ibet_wallet_api_v2.yaml
+++ b/docs/ibet_wallet_api_v2.yaml
@@ -120,6 +120,13 @@ paths:
             properties:
               meta:
                 $ref: "#/definitions/400InvalidParameterError"
+        409:
+          description: Data Conflict Error
+          schema:
+            type: object
+            properties:
+              meta:
+                $ref: "#/definitions/409DataConflictError"
   /Admin/Tokens/Type:
     get:
       tags:
@@ -5170,6 +5177,21 @@ definitions:
         type: string
         description: Error Reason
         example: Not Supported
+      description:
+        type: string
+        description: Error Reason
+        example: ""
+  409DataConflictError:
+    type: object
+    properties:
+      code:
+        type: integer
+        description: Error Code
+        example: 40
+      message:
+        type: string
+        description: Error Reason
+        example: Data Conflict
       description:
         type: string
         description: Error Reason

--- a/migrations/versions/035_create_bond_token.py
+++ b/migrations/versions/035_create_bond_token.py
@@ -1,0 +1,77 @@
+"""
+Copyright BOOSTRY Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+import logging
+from datetime import datetime
+
+from sqlalchemy import *
+from sqlalchemy.exc import ProgrammingError
+from migrate import *
+
+
+meta = MetaData()
+
+table = Table(
+    "bond_token", meta,
+    Column("token_address", String(42), primary_key=True),
+    Column("token_template", String(40)),
+    Column("owner_address", String(42), index=True),
+    Column("company_name", Text),
+    Column("rsa_publickey", String(2000)),
+    Column("name", String(200)),
+    Column("symbol", String(200)),
+    Column("total_supply", BigInteger),
+    Column("tradable_exchange", String(42), index=True),
+    Column("contact_information", String(2000)),
+    Column("privacy_policy", String(5000)),
+    Column("status", Boolean),
+    Column("max_holding_quantity", BigInteger),
+    Column("max_sell_amount", BigInteger),
+
+    Column("personal_info_address", String(42), index=True),
+    Column("transferable", Boolean),
+    Column("is_offering", Boolean),
+    Column("transfer_approval_required", Boolean),
+    Column("face_value", BigInteger),
+    Column("interest_rate", Float),
+    Column("interest_payment_date", JSON),
+    Column("redemption_date", String(8)),
+    Column("redemption_value", BigInteger),
+    Column("return_date", String(8)),
+    Column("return_amount", String(2000)),
+    Column("purpose", String(2000)),
+    Column("memo", String(2000)),
+    Column("is_redeemed", Boolean),
+
+    Column("short_term_cache_created", DateTime),
+    Column("created", DateTime, default=datetime.utcnow),
+    Column("modified", DateTime, default=datetime.utcnow, onupdate=datetime.utcnow),
+)
+
+
+def upgrade(migrate_engine):
+    meta.bind = migrate_engine
+    try:
+        table.create()
+    except sqlalchemy.exc.ProgrammingError as err:
+        logging.warning(err)
+
+
+def downgrade(migrate_engine):
+    meta.bind = migrate_engine
+    table.drop()

--- a/migrations/versions/036_create_share_token.py
+++ b/migrations/versions/036_create_share_token.py
@@ -1,0 +1,73 @@
+"""
+Copyright BOOSTRY Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+import logging
+from datetime import datetime
+
+from sqlalchemy import *
+from sqlalchemy.exc import ProgrammingError
+from migrate import *
+
+
+meta = MetaData()
+
+table = Table(
+    "share_token", meta,
+    Column("token_address", String(42), primary_key=True),
+    Column("token_template", String(40)),
+    Column("owner_address", String(42), index=True),
+    Column("company_name", Text),
+    Column("rsa_publickey", String(2000)),
+    Column("name", String(200)),
+    Column("symbol", String(200)),
+    Column("total_supply", BigInteger),
+    Column("tradable_exchange", String(42), index=True),
+    Column("contact_information", String(2000)),
+    Column("privacy_policy", String(5000)),
+    Column("status", Boolean),
+    Column("max_holding_quantity", BigInteger),
+    Column("max_sell_amount", BigInteger),
+
+    Column("personal_info_address", String(42), index=True),
+    Column("transferable", Boolean),
+    Column("is_offering", Boolean),
+    Column("transfer_approval_required", Boolean),
+    Column("issue_price", BigInteger),
+    Column("cancellation_date", String(8)),
+    Column("memo", String(2000)),
+    Column("principal_value", BigInteger),
+    Column("is_canceled", Boolean),
+    Column("dividend_information", JSON),
+
+    Column("short_term_cache_created", DateTime),
+    Column("created", DateTime, default=datetime.utcnow),
+    Column("modified", DateTime, default=datetime.utcnow, onupdate=datetime.utcnow),
+)
+
+
+def upgrade(migrate_engine):
+    meta.bind = migrate_engine
+    try:
+        table.create()
+    except sqlalchemy.exc.ProgrammingError as err:
+        logging.warning(err)
+
+
+def downgrade(migrate_engine):
+    meta.bind = migrate_engine
+    table.drop()

--- a/migrations/versions/037_create_membership_token.py
+++ b/migrations/versions/037_create_membership_token.py
@@ -1,0 +1,70 @@
+"""
+Copyright BOOSTRY Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+import logging
+from datetime import datetime
+
+from sqlalchemy import *
+from sqlalchemy.exc import ProgrammingError
+from migrate import *
+
+
+meta = MetaData()
+
+table = Table(
+    "membership_token", meta,
+    Column("token_address", String(42), primary_key=True),
+    Column("token_template", String(40)),
+    Column("owner_address", String(42), index=True),
+    Column("company_name", Text),
+    Column("rsa_publickey", String(2000)),
+    Column("name", String(200)),
+    Column("symbol", String(200)),
+    Column("total_supply", BigInteger),
+    Column("tradable_exchange", String(42), index=True),
+    Column("contact_information", String(2000)),
+    Column("privacy_policy", String(5000)),
+    Column("status", Boolean),
+    Column("max_holding_quantity", BigInteger),
+    Column("max_sell_amount", BigInteger),
+
+    Column("details", String(2000)),
+    Column("return_details", String(2000)),
+    Column("expiration_date", String(8)),
+    Column("memo", String(2000)),
+    Column("transferable", Boolean),
+    Column("initial_offering_status", Boolean),
+    Column("image_url", JSON),
+
+    Column("short_term_cache_created", DateTime),
+    Column("created", DateTime, default=datetime.utcnow),
+    Column("modified", DateTime, default=datetime.utcnow, onupdate=datetime.utcnow),
+)
+
+
+def upgrade(migrate_engine):
+    meta.bind = migrate_engine
+    try:
+        table.create()
+    except sqlalchemy.exc.ProgrammingError as err:
+        logging.warning(err)
+
+
+def downgrade(migrate_engine):
+    meta.bind = migrate_engine
+    table.drop()

--- a/migrations/versions/038_create_coupon_token.py
+++ b/migrations/versions/038_create_coupon_token.py
@@ -1,0 +1,70 @@
+"""
+Copyright BOOSTRY Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+import logging
+from datetime import datetime
+
+from sqlalchemy import *
+from sqlalchemy.exc import ProgrammingError
+from migrate import *
+
+
+meta = MetaData()
+
+table = Table(
+    "coupon_token", meta,
+    Column("token_address", String(42), primary_key=True),
+    Column("token_template", String(40)),
+    Column("owner_address", String(42), index=True),
+    Column("company_name", Text),
+    Column("rsa_publickey", String(2000)),
+    Column("name", String(200)),
+    Column("symbol", String(200)),
+    Column("total_supply", BigInteger),
+    Column("tradable_exchange", String(42), index=True),
+    Column("contact_information", String(2000)),
+    Column("privacy_policy", String(5000)),
+    Column("status", Boolean),
+    Column("max_holding_quantity", BigInteger),
+    Column("max_sell_amount", BigInteger),
+
+    Column("details", String(2000)),
+    Column("return_details", String(2000)),
+    Column("expiration_date", String(8)),
+    Column("memo", String(2000)),
+    Column("transferable", Boolean),
+    Column("initial_offering_status", Boolean),
+    Column("image_url", JSON),
+
+    Column("short_term_cache_created", DateTime),
+    Column("created", DateTime, default=datetime.utcnow),
+    Column("modified", DateTime, default=datetime.utcnow, onupdate=datetime.utcnow),
+)
+
+
+def upgrade(migrate_engine):
+    meta.bind = migrate_engine
+    try:
+        table.create()
+    except sqlalchemy.exc.ProgrammingError as err:
+        logging.warning(err)
+
+
+def downgrade(migrate_engine):
+    meta.bind = migrate_engine
+    table.drop()

--- a/migrations/versions/039_create_token_list.py
+++ b/migrations/versions/039_create_token_list.py
@@ -1,0 +1,49 @@
+"""
+Copyright BOOSTRY Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+import logging
+from datetime import datetime
+
+from sqlalchemy import *
+from sqlalchemy.exc import ProgrammingError
+from migrate import *
+
+
+meta = MetaData()
+
+table = Table(
+    "token_list", meta,
+    Column("token_address", String(42), primary_key=True),
+    Column("token_template", String(40)),
+    Column("owner_address", String(42), index=True),
+    Column("created", DateTime, default=datetime.utcnow),
+    Column("modified", DateTime, default=datetime.utcnow, onupdate=datetime.utcnow),
+)
+
+
+def upgrade(migrate_engine):
+    meta.bind = migrate_engine
+    try:
+        table.create()
+    except sqlalchemy.exc.ProgrammingError as err:
+        logging.warning(err)
+
+
+def downgrade(migrate_engine):
+    meta.bind = migrate_engine
+    table.drop()

--- a/migrations/versions/040_create_idx_token_list_block_number.py
+++ b/migrations/versions/040_create_idx_token_list_block_number.py
@@ -1,0 +1,48 @@
+"""
+Copyright BOOSTRY Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+import logging
+from datetime import datetime
+
+from sqlalchemy import *
+from sqlalchemy.exc import ProgrammingError
+from migrate import *
+
+
+meta = MetaData()
+
+table = Table(
+    "idx_token_list_block_number", meta,
+    Column("contract_address", String(42), primary_key=True),
+    Column("latest_block_number", BigInteger),
+    Column("created", DateTime, default=datetime.utcnow),
+    Column("modified", DateTime, default=datetime.utcnow, onupdate=datetime.utcnow),
+)
+
+
+def upgrade(migrate_engine):
+    meta.bind = migrate_engine
+    try:
+        table.create()
+    except sqlalchemy.exc.ProgrammingError as err:
+        logging.warning(err)
+
+
+def downgrade(migrate_engine):
+    meta.bind = migrate_engine
+    table.drop()

--- a/tests/app/v2_admin_Tokens_POST_test.py
+++ b/tests/app/v2_admin_Tokens_POST_test.py
@@ -339,10 +339,10 @@ class TestAdminTokensPOST:
         request_body = json.dumps(request_params)
         resp = client.simulate_post(self.apiurl, headers=headers, body=request_body)
 
-        assert resp.status_code == 400
+        assert resp.status_code == 409
         assert resp.json['meta'] == {
-            'code': 88,
-            'message': 'Invalid Parameter',
+            'code': 40,
+            'message': 'Data Conflict',
             'description': 'contract_address already exist'
         }
 
@@ -378,10 +378,10 @@ class TestAdminTokensPOST:
         resp = client.simulate_post(
             self.apiurl, headers=headers, body=request_body)
 
-        assert resp.status_code == 400
+        assert resp.status_code == 409
         assert resp.json['meta'] == {
-            'code': 88,
-            'message': 'Invalid Parameter',
+            'code': 40,
+            'message': 'Data Conflict',
             'description': 'contract_address already exist'
         }
 

--- a/tests/app/v2_token_coupontokens_test.py
+++ b/tests/app/v2_token_coupontokens_test.py
@@ -23,7 +23,7 @@ from eth_utils import to_checksum_address
 from web3 import Web3
 from web3.middleware import geth_poa_middleware
 
-from app.model.db import Listing
+from app.model.db import Listing, IDXTokenListItem
 from app import config
 from app.contracts import Contract
 
@@ -78,6 +78,11 @@ class TestV2TokenCouponTokens:
         listed_token.max_holding_quantity = 1
         listed_token.max_sell_amount = 1000
         session.add(listed_token)
+        token_list_item = IDXTokenListItem()
+        token_list_item.token_address = token["address"]
+        token_list_item.token_template = "IbetCoupon"
+        token_list_item.owner_address = ""
+        session.add(token_list_item)
 
     # ＜正常系1＞
     # 発行済クーポンあり（1件）
@@ -135,6 +140,12 @@ class TestV2TokenCouponTokens:
             }
         ]
 
+        assert resp.status_code == 200
+        assert resp.json['meta'] == {'code': 200, 'message': 'OK'}
+        assert resp.json['data'] == assumed_body
+
+        # Test Cache
+        resp = client.simulate_get(self.apiurl, query_string=query_string)
         assert resp.status_code == 200
         assert resp.json['meta'] == {'code': 200, 'message': 'OK'}
         assert resp.json['data'] == assumed_body
@@ -223,6 +234,13 @@ class TestV2TokenCouponTokens:
                 'tradable_exchange': exchange_address,
             }
         ]
+
+        assert resp.status_code == 200
+        assert resp.json['meta'] == {'code': 200, 'message': 'OK'}
+        assert resp.json['data'] == assumed_body
+
+        # Test Cache
+        resp = client.simulate_get(self.apiurl, query_string=query_string)
 
         assert resp.status_code == 200
         assert resp.json['meta'] == {'code': 200, 'message': 'OK'}
@@ -318,6 +336,13 @@ class TestV2TokenCouponTokens:
         assert resp.json['meta'] == {'code': 200, 'message': 'OK'}
         assert resp.json['data'] == assumed_body
 
+        # Test Cache
+        resp = client.simulate_get(self.apiurl, query_string=query_string)
+
+        assert resp.status_code == 200
+        assert resp.json['meta'] == {'code': 200, 'message': 'OK'}
+        assert resp.json['data'] == assumed_body
+
     # ＜正常系4＞
     # 発行済クーポンあり（2件）
     # cursor=1、 limit=1
@@ -373,6 +398,13 @@ class TestV2TokenCouponTokens:
             'privacy_policy': 'プライバシーポリシー',
             'tradable_exchange': exchange_address,
         }]
+
+        assert resp.status_code == 200
+        assert resp.json['meta'] == {'code': 200, 'message': 'OK'}
+        assert resp.json['data'] == assumed_body
+
+        # Test Cache
+        resp = client.simulate_get(self.apiurl, query_string=query_string)
 
         assert resp.status_code == 200
         assert resp.json['meta'] == {'code': 200, 'message': 'OK'}
@@ -438,6 +470,13 @@ class TestV2TokenCouponTokens:
         assert resp.json['meta'] == {'code': 200, 'message': 'OK'}
         assert resp.json['data'] == assumed_body
 
+        # Test Cache
+        resp = client.simulate_get(self.apiurl, query_string=query_string)
+
+        assert resp.status_code == 200
+        assert resp.json['meta'] == {'code': 200, 'message': 'OK'}
+        assert resp.json['data'] == assumed_body
+
     # ＜正常系6＞
     # クーポン発行（1件）　→　無効化
     # cursor=設定なし、 limit=設定なし
@@ -467,6 +506,13 @@ class TestV2TokenCouponTokens:
         resp = client.simulate_get(self.apiurl, query_string=query_string)
 
         assumed_body = []
+
+        assert resp.status_code == 200
+        assert resp.json['meta'] == {'code': 200, 'message': 'OK'}
+        assert resp.json['data'] == assumed_body
+
+        # Test Cache
+        resp = client.simulate_get(self.apiurl, query_string=query_string)
 
         assert resp.status_code == 200
         assert resp.json['meta'] == {'code': 200, 'message': 'OK'}
@@ -528,6 +574,15 @@ class TestV2TokenCouponTokens:
             }
             assumed_body = [assumed_body_element] + assumed_body
 
+        resp = client.simulate_get(self.apiurl, params={
+            'include_inactive_tokens': 'true'
+        })
+
+        assert resp.status_code == 200
+        assert resp.json['meta'] == {'code': 200, 'message': 'OK'}
+        assert resp.json['data'] == assumed_body
+
+        # Test Cache
         resp = client.simulate_get(self.apiurl, params={
             'include_inactive_tokens': 'true'
         })

--- a/tests/app/v2_token_membershiptokens_test.py
+++ b/tests/app/v2_token_membershiptokens_test.py
@@ -23,7 +23,7 @@ from eth_utils import to_checksum_address
 from web3 import Web3
 from web3.middleware import geth_poa_middleware
 
-from app.model.db import Listing
+from app.model.db import Listing, IDXTokenListItem
 from app import config
 from app.contracts import Contract
 
@@ -78,6 +78,11 @@ class TestV2TokenMembershipTokens:
         listed_token.max_holding_quantity = 1
         listed_token.max_sell_amount = 1000
         session.add(listed_token)
+        token_list_item = IDXTokenListItem()
+        token_list_item.token_address = token["address"]
+        token_list_item.token_template = "IbetMembership"
+        token_list_item.owner_address = ""
+        session.add(token_list_item)
 
     # ＜正常系1＞
     # 発行済会員権あり（1件）
@@ -136,6 +141,13 @@ class TestV2TokenMembershipTokens:
                 'tradable_exchange': exchange_address,
             }
         ]
+
+        assert resp.status_code == 200
+        assert resp.json['meta'] == {'code': 200, 'message': 'OK'}
+        assert resp.json['data'] == assumed_body
+
+        # Cache Test
+        resp = client.simulate_get(self.apiurl, query_string=query_string)
 
         assert resp.status_code == 200
         assert resp.json['meta'] == {'code': 200, 'message': 'OK'}
@@ -233,6 +245,13 @@ class TestV2TokenMembershipTokens:
         assert resp.json['meta'] == {'code': 200, 'message': 'OK'}
         assert resp.json['data'] == assumed_body
 
+        # Cache Test
+        resp = client.simulate_get(self.apiurl, query_string=query_string)
+
+        assert resp.status_code == 200
+        assert resp.json['meta'] == {'code': 200, 'message': 'OK'}
+        assert resp.json['data'] == assumed_body
+
     # ＜正常系3＞
     # 発行済会員権あり（2件）
     # cursor=2、 limit=2
@@ -325,6 +344,13 @@ class TestV2TokenMembershipTokens:
         assert resp.json['meta'] == {'code': 200, 'message': 'OK'}
         assert resp.json['data'] == assumed_body
 
+        # Cache Test
+        resp = client.simulate_get(self.apiurl, query_string=query_string)
+
+        assert resp.status_code == 200
+        assert resp.json['meta'] == {'code': 200, 'message': 'OK'}
+        assert resp.json['data'] == assumed_body
+
     # ＜正常系4＞
     # 発行済会員権あり（2件）
     # cursor=1、 limit=1
@@ -383,6 +409,13 @@ class TestV2TokenMembershipTokens:
             'privacy_policy': 'プライバシーポリシー',
             'tradable_exchange': exchange_address,
         }]
+
+        assert resp.status_code == 200
+        assert resp.json['meta'] == {'code': 200, 'message': 'OK'}
+        assert resp.json['data'] == assumed_body
+
+        # Cache Test
+        resp = client.simulate_get(self.apiurl, query_string=query_string)
 
         assert resp.status_code == 200
         assert resp.json['meta'] == {'code': 200, 'message': 'OK'}
@@ -451,6 +484,13 @@ class TestV2TokenMembershipTokens:
         assert resp.json['meta'] == {'code': 200, 'message': 'OK'}
         assert resp.json['data'] == assumed_body
 
+        # Cache Test
+        resp = client.simulate_get(self.apiurl, query_string=query_string)
+
+        assert resp.status_code == 200
+        assert resp.json['meta'] == {'code': 200, 'message': 'OK'}
+        assert resp.json['data'] == assumed_body
+
     # ＜正常系6＞
     # 会員権発行（1件）　→　無効化
     # cursor=設定なし、 limit=設定なし
@@ -482,6 +522,13 @@ class TestV2TokenMembershipTokens:
         resp = client.simulate_get(self.apiurl, query_string=query_string)
 
         assumed_body = []
+
+        assert resp.status_code == 200
+        assert resp.json['meta'] == {'code': 200, 'message': 'OK'}
+        assert resp.json['data'] == assumed_body
+
+        # Cache Test
+        resp = client.simulate_get(self.apiurl, query_string=query_string)
 
         assert resp.status_code == 200
         assert resp.json['meta'] == {'code': 200, 'message': 'OK'}
@@ -545,6 +592,15 @@ class TestV2TokenMembershipTokens:
             }
             assumed_body = [assumed_body_element] + assumed_body
 
+        resp = client.simulate_get(self.apiurl, params={
+            'include_inactive_tokens': 'true'
+        })
+
+        assert resp.status_code == 200
+        assert resp.json['meta'] == {'code': 200, 'message': 'OK'}
+        assert resp.json['data'] == assumed_body
+
+        # Cache Test
         resp = client.simulate_get(self.apiurl, params={
             'include_inactive_tokens': 'true'
         })

--- a/tests/app/v2_token_sharetokens_test.py
+++ b/tests/app/v2_token_sharetokens_test.py
@@ -23,7 +23,7 @@ from eth_utils import to_checksum_address
 from web3 import Web3
 from web3.middleware import geth_poa_middleware
 
-from app.model.db import Listing
+from app.model.db import Listing, IDXTokenListItem
 from app import config
 from app.contracts import Contract
 
@@ -82,6 +82,11 @@ class TestV2TokenShareTokens:
         listed_token.max_holding_quantity = 1
         listed_token.max_sell_amount = 1000
         session.add(listed_token)
+        token_list_item = IDXTokenListItem()
+        token_list_item.token_address = token["address"]
+        token_list_item.token_template = "IbetShare"
+        token_list_item.owner_address = ""
+        session.add(token_list_item)
 
     # ＜正常系1＞
     # 発行済株式あり（1件）
@@ -141,6 +146,12 @@ class TestV2TokenShareTokens:
             'personal_info_address': personal_info,
         }]
 
+        assert resp.status_code == 200
+        assert resp.json['meta'] == {'code': 200, 'message': 'OK'}
+        assert resp.json['data'] == assumed_body
+
+        # Test Cache
+        resp = client.simulate_get(self.apiurl, query_string=query_string)
         assert resp.status_code == 200
         assert resp.json['meta'] == {'code': 200, 'message': 'OK'}
         assert resp.json['data'] == assumed_body
@@ -234,6 +245,12 @@ class TestV2TokenShareTokens:
             'personal_info_address': personal_info,
         }]
 
+        assert resp.status_code == 200
+        assert resp.json['meta'] == {'code': 200, 'message': 'OK'}
+        assert resp.json['data'] == assumed_body
+
+        # Test Cache
+        resp = client.simulate_get(self.apiurl, query_string=query_string)
         assert resp.status_code == 200
         assert resp.json['meta'] == {'code': 200, 'message': 'OK'}
         assert resp.json['data'] == assumed_body
@@ -332,6 +349,12 @@ class TestV2TokenShareTokens:
         assert resp.json['meta'] == {'code': 200, 'message': 'OK'}
         assert resp.json['data'] == assumed_body
 
+        # Test Cache
+        resp = client.simulate_get(self.apiurl, query_string=query_string)
+        assert resp.status_code == 200
+        assert resp.json['meta'] == {'code': 200, 'message': 'OK'}
+        assert resp.json['data'] == assumed_body
+
     # ＜正常系4＞
     # 発行済株式あり（2件）
     # cursor=1、 limit=1
@@ -392,6 +415,12 @@ class TestV2TokenShareTokens:
             'personal_info_address': personal_info,
         }]
 
+        assert resp.status_code == 200
+        assert resp.json['meta'] == {'code': 200, 'message': 'OK'}
+        assert resp.json['data'] == assumed_body
+
+        # Test Cache
+        resp = client.simulate_get(self.apiurl, query_string=query_string)
         assert resp.status_code == 200
         assert resp.json['meta'] == {'code': 200, 'message': 'OK'}
         assert resp.json['data'] == assumed_body
@@ -520,6 +549,15 @@ class TestV2TokenShareTokens:
             }
             assumed_body = [assumed_body_element] + assumed_body
 
+        resp = client.simulate_get(self.apiurl, params={
+            'include_inactive_tokens': 'true'
+        })
+
+        assert resp.status_code == 200
+        assert resp.json['meta'] == {'code': 200, 'message': 'OK'}
+        assert resp.json['data'] == assumed_body
+
+        # Test Cache
         resp = client.simulate_get(self.apiurl, params={
             'include_inactive_tokens': 'true'
         })

--- a/tests/app/v2_token_straightbondtokens_test.py
+++ b/tests/app/v2_token_straightbondtokens_test.py
@@ -23,7 +23,7 @@ from eth_utils import to_checksum_address
 from web3 import Web3
 from web3.middleware import geth_poa_middleware
 
-from app.model.db import Listing
+from app.model.db import Listing, IDXTokenListItem
 from app import config
 from app.contracts import Contract
 
@@ -95,6 +95,11 @@ class TestV2TokenStraightBondTokens:
         listed_token.max_holding_quantity = 1
         listed_token.max_sell_amount = 1000
         session.add(listed_token)
+        token_list_item = IDXTokenListItem()
+        token_list_item.token_address = token["address"]
+        token_list_item.token_template = "IbetStraightBond"
+        token_list_item.owner_address = ""
+        session.add(token_list_item)
 
     # ＜正常系1＞
     # 発行済債券あり（1件）
@@ -164,6 +169,15 @@ class TestV2TokenStraightBondTokens:
             'personal_info_address': personal_info,
             'transfer_approval_required': False,
         }]
+
+        assert resp.status_code == 200
+        assert resp.json['meta'] == {'code': 200, 'message': 'OK'}
+        assert resp.json['data'] == assumed_body
+
+        # Test Cache
+        resp = client.simulate_get(self.apiurl, params={
+            'include_inactive_tokens': 'true'
+        })
 
         assert resp.status_code == 200
         assert resp.json['meta'] == {'code': 200, 'message': 'OK'}
@@ -279,6 +293,15 @@ class TestV2TokenStraightBondTokens:
             'personal_info_address': personal_info,
             'transfer_approval_required': False,
         }]
+
+        assert resp.status_code == 200
+        assert resp.json['meta'] == {'code': 200, 'message': 'OK'}
+        assert resp.json['data'] == assumed_body
+
+        # Test Cache
+        resp = client.simulate_get(self.apiurl, params={
+            'include_inactive_tokens': 'true'
+        })
 
         assert resp.status_code == 200
         assert resp.json['meta'] == {'code': 200, 'message': 'OK'}
@@ -400,6 +423,15 @@ class TestV2TokenStraightBondTokens:
         assert resp.json['meta'] == {'code': 200, 'message': 'OK'}
         assert resp.json['data'] == assumed_body
 
+        # Test Cache
+        resp = client.simulate_get(self.apiurl, params={
+            'include_inactive_tokens': 'true'
+        })
+
+        assert resp.status_code == 200
+        assert resp.json['meta'] == {'code': 200, 'message': 'OK'}
+        assert resp.json['data'] == assumed_body
+
     # ＜正常系4＞
     # 発行済債券あり（2件）
     # cursor=1、 limit=1
@@ -475,6 +507,13 @@ class TestV2TokenStraightBondTokens:
         assert resp.json['meta'] == {'code': 200, 'message': 'OK'}
         assert resp.json['data'] == assumed_body
 
+        # Test Cache
+        resp = client.simulate_get(self.apiurl, query_string=query_string)
+
+        assert resp.status_code == 200
+        assert resp.json['meta'] == {'code': 200, 'message': 'OK'}
+        assert resp.json['data'] == assumed_body
+
     # ＜正常系5＞
     # 発行済債券あり（2件）
     # cursor=1、 limit=2
@@ -545,6 +584,13 @@ class TestV2TokenStraightBondTokens:
             'personal_info_address': personal_info,
             'transfer_approval_required': False,
         }]
+
+        assert resp.status_code == 200
+        assert resp.json['meta'] == {'code': 200, 'message': 'OK'}
+        assert resp.json['data'] == assumed_body
+
+        # Test Cache
+        resp = client.simulate_get(self.apiurl, query_string=query_string)
 
         assert resp.status_code == 200
         assert resp.json['meta'] == {'code': 200, 'message': 'OK'}
@@ -628,6 +674,13 @@ class TestV2TokenStraightBondTokens:
         assert resp.json['meta'] == {'code': 200, 'message': 'OK'}
         assert resp.json['data'] == assumed_body
 
+        # Test Cache
+        resp = client.simulate_get(self.apiurl, query_string=query_string)
+
+        assert resp.status_code == 200
+        assert resp.json['meta'] == {'code': 200, 'message': 'OK'}
+        assert resp.json['data'] == assumed_body
+
     # ＜正常系7＞
     # 発行済債券あり（5件）
     # cursor=設定なし、 limit=設定なし、include_inactive_tokens=True
@@ -699,6 +752,15 @@ class TestV2TokenStraightBondTokens:
             }
             assumed_body = [assumed_body_element] + assumed_body
 
+        resp = client.simulate_get(self.apiurl, params={
+            'include_inactive_tokens': 'true'
+        })
+
+        assert resp.status_code == 200
+        assert resp.json['meta'] == {'code': 200, 'message': 'OK'}
+        assert resp.json['data'] == assumed_body
+
+        # Test Cache
         resp = client.simulate_get(self.apiurl, params={
             'include_inactive_tokens': 'true'
         })

--- a/tests/batch/indexer_Token_Detail_ShortTerm_test.py
+++ b/tests/batch/indexer_Token_Detail_ShortTerm_test.py
@@ -268,8 +268,8 @@ class TestProcessor:
             _coupon_token_expected_list.append({"token_address": token["address"]})
 
         session.commit()
-        time.sleep(1)
         current = datetime.utcnow()
+        time.sleep(1)
 
         # Run target process
         processor.SEC_PER_RECORD = 0

--- a/tests/batch/indexer_Token_Detail_ShortTerm_test.py
+++ b/tests/batch/indexer_Token_Detail_ShortTerm_test.py
@@ -1,0 +1,767 @@
+"""
+Copyright BOOSTRY Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+import logging
+import time
+from datetime import datetime
+from decimal import Decimal
+import pytest
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
+from unittest import mock
+from unittest.mock import MagicMock
+from web3 import Web3
+from web3.middleware import geth_poa_middleware
+
+from app import config
+from app.contracts import Contract
+from app.errors import ServiceUnavailable
+from app.model.blockchain import BondToken, ShareToken, MembershipToken, CouponToken
+from app.model.db import (
+    Listing,
+    IDXBondToken as BondTokenModel,
+    IDXShareToken as ShareTokenModel,
+    IDXMembershipToken as MembershipTokenModel,
+    IDXCouponToken as CouponTokenModel,
+    IDXTokenListItem
+)
+from batch import indexer_Token_Detail_ShortTerm
+from batch.indexer_Token_Detail_ShortTerm import Processor, LOG, main
+from tests.account_config import eth_account
+from tests.contract_modules import (
+    issue_bond_token,
+    register_bond_list,
+    issue_share_token,
+    register_share_list,
+    issue_coupon_token,
+    coupon_register_list,
+    membership_issue,
+    membership_register_list
+)
+
+web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
+web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+
+
+@pytest.fixture(scope="session")
+def test_module(shared_contract):
+    return indexer_Token_Detail_ShortTerm
+
+
+@pytest.fixture(scope="function")
+def processor(test_module, session):
+    processor = test_module.Processor()
+    return processor
+
+
+@pytest.fixture(scope="function")
+def main_func(test_module):
+    LOG = logging.getLogger("Processor")
+    default_log_level = LOG.level
+    LOG.setLevel(logging.DEBUG)
+    LOG.propagate = True
+    yield main
+    LOG.propagate = False
+    LOG.setLevel(default_log_level)
+
+
+class TestProcessor:
+    issuer = eth_account["issuer"]
+    user1 = eth_account["user1"]
+    user2 = eth_account["user2"]
+    trader = eth_account["trader"]
+    agent = eth_account["agent"]
+
+    @staticmethod
+    def listing_token(token_address, token_template, session):
+        _listing = Listing()
+        _listing.token_address = token_address
+        _listing.is_public = True
+        _listing.max_holding_quantity = 1000000
+        _listing.max_sell_amount = 1000000
+        _listing.owner_address = TestProcessor.issuer["account_address"]
+        session.add(_listing)
+
+        _idx_token_list_item = IDXTokenListItem()
+        _idx_token_list_item.token_address = token_address
+        _idx_token_list_item.token_template = token_template
+        _idx_token_list_item.owner_address = TestProcessor.issuer["account_address"]
+        session.add(_idx_token_list_item)
+        session.commit()
+
+    @staticmethod
+    def issue_token_bond_with_args(issuer, token_list, args):
+        # Issue token
+        token = issue_bond_token(issuer, args)
+        register_bond_list(issuer, token, token_list)
+
+        return token
+
+    @staticmethod
+    def issue_token_share_with_args(issuer, token_list, args):
+        # Issue token
+        token = issue_share_token(issuer, args)
+        register_share_list(issuer, token, token_list)
+
+        return token
+
+    @staticmethod
+    def issue_token_coupon_with_args(issuer, token_list, args):
+        # Issue token
+        token = issue_coupon_token(issuer, args)
+        coupon_register_list(issuer, token, token_list)
+
+        return token
+
+    @staticmethod
+    def issue_token_membership_with_args(issuer, token_list, args):
+        # Issue token
+        token = membership_issue(issuer, args)
+        membership_register_list(issuer, token, token_list)
+
+        return token
+
+    ###########################################################################
+    # Normal Case
+    ###########################################################################
+
+    # <Normal_1>
+    # Multiple listed tokens and no events
+    def test_normal_1(self, processor: Processor, shared_contract, session: Session, block_number: None):
+        token_list_contract = shared_contract["TokenList"]
+        personal_info_contract = shared_contract["PersonalInfo"]
+        exchange_contract = shared_contract["IbetStraightBondExchange"]
+
+        config.TOKEN_LIST_CONTRACT_ADDRESS = token_list_contract['address']
+        _bond_token_expected_list = []
+        # Issue bond token
+        for i in range(10):
+            args = {
+                "name": f"テスト債券{str(i+1)}",
+                "symbol": f"BOND{str(i+1)}",
+                "totalSupply": 1000000+1,
+                "tradableExchange": exchange_contract["address"],
+                "faceValue": int((i+1)*10000),
+                "interestRate": 602+1,
+                "interestPaymentDate1": "0101",
+                "interestPaymentDate2": "0201",
+                "interestPaymentDate3": "0301",
+                "interestPaymentDate4": "0401",
+                "interestPaymentDate5": "0501",
+                "interestPaymentDate6": "0601",
+                "interestPaymentDate7": "0701",
+                "interestPaymentDate8": "0801",
+                "interestPaymentDate9": "0901",
+                "interestPaymentDate10": "1001",
+                "interestPaymentDate11": "1101",
+                "interestPaymentDate12": "1201",
+                "redemptionDate": "20191231",
+                "redemptionValue": 10000+1,
+                "returnDate": "20191231",
+                "returnAmount": f"商品券をプレゼント{str(i+1)}",
+                "purpose": f"新商品の開発資金として利用。{str(i+1)}",
+                "memo": f"メモ{str(i+1)}",
+                "contactInformation": f"問い合わせ先{str(i+1)}",
+                "privacyPolicy": f"プライバシーポリシー{str(i+1)}",
+                "personalInfoAddress": personal_info_contract["address"],
+                "transferable": True,
+                "isRedeemed": False,
+            }
+            token = self.issue_token_bond_with_args(
+                self.issuer, token_list_contract, args
+            )
+            self.listing_token(token["address"], "IbetStraightBond", session)
+            # Fetch data for cache
+            session.add(BondToken.get(session, token["address"]).to_model())
+            _bond_token_expected_list.append({"token_address": token["address"]})
+
+        _share_token_expected_list = []
+        # Issue share token
+        for i in range(10):
+            args = {
+                "name": f"テスト株式{str(i+1)}",
+                "symbol": f"SHARE{str(i+1)}",
+                "tradableExchange": exchange_contract["address"],
+                "personalInfoAddress": personal_info_contract["address"],
+                "issuePrice": int((i+1)*1000),
+                "principalValue": 1000+i,
+                "totalSupply": 1000000+i,
+                "dividends": 101+i,
+                "dividendRecordDate": "20200401",
+                "dividendPaymentDate": "20200502",
+                "cancellationDate": "20200603",
+                "contactInformation": f"問い合わせ先{str(i+1)}",
+                "privacyPolicy": f"プライバシーポリシー{str(i+1)}",
+                "memo": "メモ",
+                "transferable": True,
+            }
+            token = self.issue_token_share_with_args(
+                self.issuer, token_list_contract, args
+            )
+            self.listing_token(token["address"], "IbetShare", session)
+            # Fetch data for cache
+            session.add(ShareToken.get(session, token["address"]).to_model())
+            _share_token_expected_list.append({"token_address": token["address"]})
+
+        _membership_token_expected_list = []
+        # Issue membership token
+        for i in range(10):
+            args = {
+                "name": f"テスト会員権{str(i+1)}",
+                "symbol": f"MEMBERSHIP{str(i+1)}",
+                "initialSupply": int((i+1)*1000000),
+                "tradableExchange": exchange_contract["address"],
+                "details": f"詳細{str(i+1)}",
+                "returnDetails": f"リターン詳細{str(i+1)}",
+                "expirationDate": "20191231",
+                "memo": f"メモ{str(i+1)}",
+                "transferable": True,
+                "contactInformation": f"問い合わせ先{str(i+1)}",
+                "privacyPolicy": f"プライバシーポリシー{str(i+1)}",
+            }
+            token = self.issue_token_membership_with_args(
+                self.issuer, token_list_contract, args
+            )
+            self.listing_token(token["address"], "IbetMembership", session)
+            # Fetch data for cache
+            session.add(MembershipToken.get(session, token["address"]).to_model())
+            _membership_token_expected_list.append({"token_address": token["address"]})
+
+        _coupon_token_expected_list = []
+        # issue coupon token
+        for i in range(10):
+            args = {
+                "name": f"テストクーポン{str(i+1)}",
+                "symbol": f"COUPON{str(i+1)}",
+                "totalSupply":  int((i+1)*1000000),
+                "tradableExchange": exchange_contract["address"],
+                "details": f"クーポン詳細{str(i+1)}",
+                "returnDetails": f"リターン詳細{str(i+1)}",
+                "memo": f"クーポンメモ欄{str(i+1)}",
+                "expirationDate": "20191231",
+                "transferable": True,
+                "contactInformation": f"問い合わせ先{str(i+1)}",
+                "privacyPolicy": f"プライバシーポリシー{str(i+1)}",
+            }
+
+            token = self.issue_token_coupon_with_args(
+                self.issuer, token_list_contract, args
+            )
+            self.listing_token(token["address"], "IbetCoupon", session)
+            # Fetch data for cache
+            session.add(CouponToken.get(session, token["address"]).to_model())
+            _coupon_token_expected_list.append({"token_address": token["address"]})
+
+        session.commit()
+        time.sleep(1)
+        current = datetime.utcnow()
+
+        # Run target process
+        processor.SEC_PER_RECORD = 0
+        with mock.patch("app.config.TOKEN_SHORT_TERM_FETCH_INTERVAL_MSEC", 0):
+            processor.process()
+
+        session.rollback()
+        # assertion
+        for _expect_dict in _bond_token_expected_list:
+            _bond_token: BondTokenModel = session.query(BondTokenModel).\
+                filter(BondTokenModel.token_address == _expect_dict["token_address"]).one()
+            assert _bond_token.short_term_cache_created > current
+
+        for _expect_dict in _share_token_expected_list:
+            _share_token: ShareTokenModel = session.query(ShareTokenModel).\
+                filter(ShareTokenModel.token_address == _expect_dict["token_address"]).one()
+            assert _share_token.short_term_cache_created > current
+
+        for _expect_dict in _membership_token_expected_list:
+            _membership_token: MembershipTokenModel = session.query(MembershipTokenModel).\
+                filter(MembershipTokenModel.token_address == _expect_dict["token_address"]).one()
+            assert _membership_token.short_term_cache_created > current
+
+        for _expect_dict in _coupon_token_expected_list:
+            _coupon_token: CouponTokenModel = session.query(CouponTokenModel).\
+                filter(CouponTokenModel.token_address == _expect_dict["token_address"]).one()
+            assert _coupon_token.short_term_cache_created > current
+
+    # <Normal_2>
+    # Multiple listed tokens and multiple events
+    # - Bond
+    #   - ChangeStatus
+    #   - ChangeFaceValue
+    #   - ChangeRedemptionValue
+    #   - ChangeTransferApprovalRequired
+    #   - ChangeOfferingStatus
+    #   - ChangeToRedeemed
+    def test_normal_2(self, processor: Processor, shared_contract, session: Session, block_number: None):
+        token_list_contract = shared_contract["TokenList"]
+        personal_info_contract = shared_contract["PersonalInfo"]
+        exchange_contract = shared_contract["IbetStraightBondExchange"]
+
+        config.TOKEN_LIST_CONTRACT_ADDRESS = token_list_contract['address']
+
+        _bond_token_expected_list = []
+        # Issue bond token
+        for i in range(5):
+            args = {
+                "name": f"テスト債券{str(i+1)}",
+                "symbol": f"BOND{str(i+1)}",
+                "totalSupply": 1000000+1,
+                "tradableExchange": exchange_contract["address"],
+                "faceValue": int((i+1)*10000),
+                "interestRate": 602+1,
+                "interestPaymentDate1": "0101",
+                "interestPaymentDate2": "0201",
+                "interestPaymentDate3": "0301",
+                "interestPaymentDate4": "0401",
+                "interestPaymentDate5": "0501",
+                "interestPaymentDate6": "0601",
+                "interestPaymentDate7": "0701",
+                "interestPaymentDate8": "0801",
+                "interestPaymentDate9": "0901",
+                "interestPaymentDate10": "1001",
+                "interestPaymentDate11": "1101",
+                "interestPaymentDate12": "1201",
+                "redemptionDate": "20191231",
+                "redemptionValue": 10000+1,
+                "returnDate": "20191231",
+                "returnAmount": f"商品券をプレゼント{str(i+1)}",
+                "purpose": f"新商品の開発資金として利用。{str(i+1)}",
+                "memo": f"メモ{str(i+1)}",
+                "contactInformation": f"問い合わせ先{str(i+1)}",
+                "privacyPolicy": f"プライバシーポリシー{str(i+1)}",
+                "personalInfoAddress": personal_info_contract["address"],
+                "transferable": True,
+                "isRedeemed": False,
+            }
+            token = self.issue_token_bond_with_args(
+                self.issuer, token_list_contract, args
+            )
+            self.listing_token(token["address"], "IbetStraightBond", session)
+
+            # Change attributes to occur events
+            token_contract = Contract.get_contract(
+                contract_name="IbetStraightBond",
+                address=token["address"]
+            )
+            token_contract.functions.setRedemptionValue(
+                99999
+            ).transact({
+                "from": self.issuer["account_address"]
+            })
+            token_contract.functions.changeToRedeemed(
+            ).transact({
+                "from": self.issuer["account_address"]
+            })
+            token_contract.functions.changeOfferingStatus(
+                False
+            ).transact({
+                "from": self.issuer["account_address"]
+            })
+            token_contract.functions.setTransferApprovalRequired(
+                True
+            ).transact({
+                "from": self.issuer["account_address"]
+            })
+            token_contract.functions.setFaceValue(
+                1
+            ).transact({
+                "from": self.issuer["account_address"]
+            })
+            token_contract.functions.setStatus(
+                False
+            ).transact({
+                "from": self.issuer["account_address"]
+            })
+
+            # Fetch data for cache
+            bond_token = BondToken.get(session, token["address"])
+            session.add(bond_token.to_model())
+            _bond_token_expected_list.append({"token_address": token["address"]})
+
+        session.commit()
+        # Then
+        processor.process()
+
+        # assertion
+        for _expect_dict in _bond_token_expected_list:
+            _bond_token: BondTokenModel = session.query(BondTokenModel).\
+                filter(BondTokenModel.token_address == _expect_dict["token_address"]).one()
+            assert _bond_token.redemption_value == 99999
+            assert _bond_token.is_redeemed == True
+            assert _bond_token.is_offering == False
+            assert _bond_token.transfer_approval_required == True
+            assert _bond_token.redemption_value == 99999
+            assert _bond_token.face_value == 1
+            assert _bond_token.status == False
+
+    # <Normal_3>
+    # Multiple listed tokens and multiple events
+    # - Share
+    #   - ChangeStatus
+    #   - ChangeTransferApprovalRequired
+    #   - ChangeOfferingStatus
+    #   - ChangeDividendInformation
+    #   - ChangeToCanceled
+    def test_normal_3(self, processor: Processor, shared_contract, session: Session, block_number: None):
+        token_list_contract = shared_contract["TokenList"]
+        personal_info_contract = shared_contract["PersonalInfo"]
+        exchange_contract = shared_contract["IbetStraightBondExchange"]
+
+        config.TOKEN_LIST_CONTRACT_ADDRESS = token_list_contract['address']
+
+        _share_token_expected_list = []
+        # Issue bond token
+        for i in range(5):
+            args = {
+                "name": f"テスト株式{str(i+1)}",
+                "symbol": f"SHARE{str(i+1)}",
+                "tradableExchange": exchange_contract["address"],
+                "personalInfoAddress": personal_info_contract["address"],
+                "issuePrice": int((i+1)*1000),
+                "principalValue": 1000+i,
+                "totalSupply": 1000000+i,
+                "dividends": 101+i,
+                "dividendRecordDate": "20200401",
+                "dividendPaymentDate": "20200502",
+                "cancellationDate": "20200603",
+                "contactInformation": f"問い合わせ先{str(i+1)}",
+                "privacyPolicy": f"プライバシーポリシー{str(i+1)}",
+                "memo": "メモ",
+                "transferable": True,
+            }
+            token = self.issue_token_share_with_args(
+                self.issuer, token_list_contract, args
+            )
+            self.listing_token(token["address"], "IbetStraightBond", session)
+
+            # Change attributes to occur events
+            token_contract = Contract.get_contract(
+                contract_name="IbetShare",
+                address=token["address"]
+            )
+
+            token_contract.functions.setStatus(
+                False
+            ).transact({
+                "from": self.issuer["account_address"]
+            })
+            token_contract.functions.setTransferApprovalRequired(
+                True
+            ).transact({
+                "from": self.issuer["account_address"]
+            })
+            token_contract.functions.changeOfferingStatus(
+                False
+            ).transact({
+                "from": self.issuer["account_address"]
+            })
+            token_contract.functions.changeToCanceled(
+            ).transact({
+                "from": self.issuer["account_address"]
+            })
+            token_contract.functions.setDividendInformation(
+                50, "20200401", "20200401"
+            ).transact({
+                "from": self.issuer["account_address"]
+            })
+
+            # Fetch data for cache
+            share_token = ShareToken.get(session, token["address"])
+            session.add(share_token.to_model())
+            _share_token_expected_list.append({"token_address": token["address"]})
+
+        session.commit()
+        # Then
+        processor.process()
+
+        # assertion
+        for _expect_dict in _share_token_expected_list:
+            _share_token: ShareTokenModel = session.query(ShareTokenModel).\
+                filter(ShareTokenModel.token_address == _expect_dict["token_address"]).one()
+            assert _share_token.status == False
+            assert _share_token.transfer_approval_required == True
+            assert _share_token.is_offering == False
+            assert _share_token.is_canceled == True
+            assert _share_token.dividend_information == {
+                'dividends': float(Decimal(str(50)) * Decimal("0.01")),
+                'dividend_record_date': "20200401",
+                'dividend_payment_date': "20200401",
+            }
+
+    # <Normal_4>
+    # Multiple listed tokens and multiple events
+    # - Membership/Coupon
+    #   - ChangeStatus
+    def test_normal_4(self, processor: Processor, shared_contract, session: Session, block_number: None):
+        token_list_contract = shared_contract["TokenList"]
+        exchange_contract = shared_contract["IbetStraightBondExchange"]
+
+        config.TOKEN_LIST_CONTRACT_ADDRESS = token_list_contract['address']
+
+        _membership_token_expected_list = []
+        # Issue bond token
+        for i in range(5):
+            args = {
+                "name": f"テスト会員権{str(i+1)}",
+                "symbol": f"MEMBERSHIP{str(i+1)}",
+                "initialSupply": int((i+1)*1000000),
+                "tradableExchange": exchange_contract["address"],
+                "details": f"詳細{str(i+1)}",
+                "returnDetails": f"リターン詳細{str(i+1)}",
+                "expirationDate": "20191231",
+                "memo": f"メモ{str(i+1)}",
+                "transferable": True,
+                "contactInformation": f"問い合わせ先{str(i+1)}",
+                "privacyPolicy": f"プライバシーポリシー{str(i+1)}",
+            }
+            token = self.issue_token_membership_with_args(
+                self.issuer, token_list_contract, args
+            )
+            self.listing_token(token["address"], "IbetMembership", session)
+            session.add(MembershipToken.get(session, token["address"]).to_model())
+
+            # Change attributes to occur events
+            token_contract = Contract.get_contract(
+                contract_name="IbetMembership",
+                address=token["address"]
+            )
+
+            token_contract.functions.setStatus(
+                False
+            ).transact({
+                "from": self.issuer["account_address"]
+            })
+
+            # Fetch data for cache
+            _membership_token_expected_list.append({"token_address": token["address"]})
+
+        _coupon_token_expected_list = []
+        # issue coupon token
+        for i in range(5):
+            args = {
+                "name": f"テストクーポン{str(i+1)}",
+                "symbol": f"COUPON{str(i+1)}",
+                "totalSupply":  int((i+1)*1000000),
+                "tradableExchange": exchange_contract["address"],
+                "details": f"クーポン詳細{str(i+1)}",
+                "returnDetails": f"リターン詳細{str(i+1)}",
+                "memo": f"クーポンメモ欄{str(i+1)}",
+                "expirationDate": "20191231",
+                "transferable": True,
+                "contactInformation": f"問い合わせ先{str(i+1)}",
+                "privacyPolicy": f"プライバシーポリシー{str(i+1)}",
+            }
+
+            token = self.issue_token_coupon_with_args(
+                self.issuer, token_list_contract, args
+            )
+            self.listing_token(token["address"], "IbetCoupon", session)
+            session.add(CouponToken.get(session, token["address"]).to_model())
+
+            # Change attributes to occur events
+            token_contract = Contract.get_contract(
+                contract_name="IbetCoupon",
+                address=token["address"]
+            )
+
+            token_contract.functions.setStatus(
+                False
+            ).transact({
+                "from": self.issuer["account_address"]
+            })
+
+            # Fetch data for cache
+            _coupon_token_expected_list.append({"token_address": token["address"]})
+
+        session.commit()
+        # Then
+        processor.process()
+
+        session.rollback()
+        # assertion
+        for _expect_dict in _membership_token_expected_list:
+            _membership_token: MembershipTokenModel = session.query(MembershipTokenModel).\
+                filter(MembershipTokenModel.token_address == _expect_dict["token_address"]).one()
+            assert _membership_token.status == False
+
+        # assertion
+        for _expect_dict in _coupon_token_expected_list:
+            _coupon_token: CouponTokenModel = session.query(CouponTokenModel).\
+                filter(CouponTokenModel.token_address == _expect_dict["token_address"]).one()
+            assert _coupon_token.status == False
+
+    ###########################################################################
+    # Error Case
+    ###########################################################################
+    # <Error_1_1>: ServiceUnavailable occurs in __sync_xx method.
+    # <Error_1_2>: SQLAlchemyError occurs in "process"
+    # <Error_2>: ServiceUnavailable occurs and is handled in mainloop.
+
+    # <Error_1_1>: ServiceUnavailable occurs in __sync_xx method.
+    def test_error_1_1(self, processor: Processor, shared_contract, session):
+        # Issue Token
+        token_list_contract = shared_contract["TokenList"]
+        exchange_contract = shared_contract["IbetStraightBondExchange"]
+        args = {
+            "name": "テストクーポン",
+            "symbol": "COUPON",
+            "totalSupply":  1000000,
+            "tradableExchange": exchange_contract["address"],
+            "details": "クーポン詳細",
+            "returnDetails": "リターン詳細",
+            "memo": "クーポンメモ欄",
+            "expirationDate": "20191231",
+            "transferable": True,
+            "contactInformation": "問い合わせ先",
+            "privacyPolicy": "プライバシーポリシー",
+        }
+        token = self.issue_token_coupon_with_args(self.issuer, token_list_contract, args)
+        self.listing_token(token["address"], "IbetCoupon", session)
+        coupon_data = CouponToken.get(session, token["address"])
+        session.add(coupon_data.to_model())
+
+        session.commit()
+        time.sleep(1)
+        current = datetime.utcnow()
+
+        # Expect that process() raises ServiceUnavailable.
+        with mock.patch("web3.providers.rpc.HTTPProvider.make_request", MagicMock(side_effect=ServiceUnavailable())), \
+                pytest.raises(ServiceUnavailable):
+            processor.process()
+
+        # Assertion
+        _coupon_token: CouponTokenModel = session.query(CouponTokenModel).\
+            filter(CouponTokenModel.token_address == token["address"]).one()
+        assert _coupon_token.short_term_cache_created < current
+
+        token = self.issue_token_coupon_with_args(self.issuer, token_list_contract, args)
+        self.listing_token(token["address"], "IbetCoupon", session)
+        coupon_data = CouponToken.get(session, token["address"])
+        session.add(coupon_data.to_model())
+
+        session.commit()
+        time.sleep(1)
+        current = datetime.utcnow()
+
+        # Expect that process() raises ServiceUnavailable.
+        with mock.patch("web3.providers.rpc.HTTPProvider.make_request", MagicMock(side_effect=ServiceUnavailable())), \
+                pytest.raises(ServiceUnavailable):
+            processor.process()
+
+        # Assertion
+        session.rollback()
+        _coupon_token: CouponTokenModel = session.query(CouponTokenModel).\
+            filter(CouponTokenModel.token_address == token["address"]).one()
+        assert _coupon_token.short_term_cache_created < current
+
+    # <Error_1_2>: SQLAlchemyError occurs in "process".
+    def test_error_1_2(self, processor: Processor, shared_contract, session):
+        # Issue Token
+        token_list_contract = shared_contract["TokenList"]
+        exchange_contract = shared_contract["IbetStraightBondExchange"]
+        args = {
+            "name": "テストクーポン",
+            "symbol": "COUPON",
+            "totalSupply":  1000000,
+            "tradableExchange": exchange_contract["address"],
+            "details": "クーポン詳細",
+            "returnDetails": "リターン詳細",
+            "memo": "クーポンメモ欄",
+            "expirationDate": "20191231",
+            "transferable": True,
+            "contactInformation": "問い合わせ先",
+            "privacyPolicy": "プライバシーポリシー",
+        }
+        token = self.issue_token_coupon_with_args(self.issuer, token_list_contract, args)
+        self.listing_token(token["address"], "IbetCoupon", session)
+        coupon_data = CouponToken.get(session, token["address"])
+        session.add(coupon_data.to_model())
+
+        session.commit()
+        time.sleep(1)
+        current = datetime.utcnow()
+
+        # Expect that process() raises SQLAlchemyError.
+        with mock.patch.object(Session, "commit", side_effect=SQLAlchemyError()), \
+                pytest.raises(SQLAlchemyError):
+            processor.process()
+
+        # Assertion
+        _coupon_token: CouponTokenModel = session.query(CouponTokenModel).\
+            filter(CouponTokenModel.token_address == token["address"]).one()
+        assert _coupon_token.short_term_cache_created < current
+
+        token = self.issue_token_coupon_with_args(self.issuer, token_list_contract, args)
+        self.listing_token(token["address"], "IbetCoupon", session)
+        coupon_data = CouponToken.get(session, token["address"])
+        session.add(coupon_data.to_model())
+
+        session.commit()
+        time.sleep(1)
+        current = datetime.utcnow()
+
+        # Expect that process() raises SQLAlchemyError.
+        with mock.patch.object(Session, "commit", side_effect=SQLAlchemyError()), \
+                pytest.raises(SQLAlchemyError):
+            processor.process()
+
+        # Assertion
+        session.rollback()
+        _coupon_token: CouponTokenModel = session.query(CouponTokenModel).\
+            filter(CouponTokenModel.token_address == token["address"]).one()
+        assert _coupon_token.short_term_cache_created < current
+
+    # <Error_2>: ServiceUnavailable occurs and is handled in mainloop.
+    def test_error_2(self, main_func, shared_contract, session, caplog):
+        # Issue Token
+        token_list_contract = shared_contract["TokenList"]
+        exchange_contract = shared_contract["IbetStraightBondExchange"]
+        args = {
+            "name": "テストクーポン",
+            "symbol": "COUPON",
+            "totalSupply":  1000000,
+            "tradableExchange": exchange_contract["address"],
+            "details": "クーポン詳細",
+            "returnDetails": "リターン詳細",
+            "memo": "クーポンメモ欄",
+            "expirationDate": "20191231",
+            "transferable": True,
+            "contactInformation": "問い合わせ先",
+            "privacyPolicy": "プライバシーポリシー",
+        }
+        token = self.issue_token_coupon_with_args(self.issuer, token_list_contract, args)
+        self.listing_token(token["address"], "IbetCoupon", session)
+        coupon_data = CouponToken.get(session, token["address"])
+        session.add(coupon_data.to_model())
+
+        session.commit()
+
+        # Mocking time.sleep to break mainloop
+        time_mock = MagicMock(wraps=time)
+        time_mock.sleep.side_effect = [TypeError()]
+
+        # Run mainloop once and fail with web3 utils error
+        with mock.patch("batch.indexer_Token_Detail_ShortTerm.time", time_mock),\
+            mock.patch("web3.providers.rpc.HTTPProvider.make_request", MagicMock(side_effect=ServiceUnavailable())), \
+                pytest.raises(TypeError):
+            # Expect that process() raises ServiceUnavailable and handled in mainloop.
+            main_func()
+
+        assert 1 == caplog.record_tuples.count((LOG.name, logging.INFO, "Service started successfully"))
+        assert 1 == caplog.record_tuples.count((LOG.name, logging.WARNING, "An external service was unavailable"))
+        caplog.clear()

--- a/tests/batch/indexer_Token_Detail_test.py
+++ b/tests/batch/indexer_Token_Detail_test.py
@@ -1,0 +1,441 @@
+"""
+Copyright BOOSTRY Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+import logging
+import re
+import time
+import pytest
+from decimal import Decimal
+from typing import List
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
+from unittest import mock
+from unittest.mock import MagicMock
+from web3 import Web3
+from web3.middleware import geth_poa_middleware
+
+from app import config
+from app.errors import ServiceUnavailable
+from app.model.blockchain import BondToken, ShareToken, MembershipToken, CouponToken
+from app.model.db import (
+    Listing,
+    IDXBondToken as BondTokenModel,
+    IDXShareToken as ShareTokenModel,
+    IDXMembershipToken as MembershipTokenModel,
+    IDXCouponToken as CouponTokenModel,
+    IDXTokenListItem
+)
+from batch import indexer_Token_Detail
+from batch.indexer_Token_Detail import Processor, LOG, main
+from tests.account_config import eth_account
+from tests.contract_modules import (
+    issue_bond_token,
+    register_bond_list,
+    issue_share_token,
+    register_share_list,
+    issue_coupon_token,
+    coupon_register_list,
+    membership_issue,
+    membership_register_list
+)
+
+web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
+web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+
+
+@pytest.fixture(scope="session")
+def test_module(shared_contract):
+    indexer_Token_Detail.TOKEN_LIST_CONTRACT_ADDRESS = shared_contract["TokenList"]["address"]
+    return indexer_Token_Detail
+
+
+@pytest.fixture(scope="function")
+def processor(test_module, session):
+    processor = test_module.Processor()
+    return processor
+
+
+@pytest.fixture(scope="function")
+def main_func(test_module):
+    LOG = logging.getLogger("Processor")
+    default_log_level = LOG.level
+    LOG.setLevel(logging.DEBUG)
+    LOG.propagate = True
+    yield main
+    LOG.propagate = False
+    LOG.setLevel(default_log_level)
+
+
+class TestProcessor:
+    issuer = eth_account["issuer"]
+    user1 = eth_account["user1"]
+    user2 = eth_account["user2"]
+    trader = eth_account["trader"]
+    agent = eth_account["agent"]
+
+    @staticmethod
+    def listing_token(token_address, token_template, session):
+        _listing = Listing()
+        _listing.token_address = token_address
+        _listing.is_public = True
+        _listing.max_holding_quantity = 1000000
+        _listing.max_sell_amount = 1000000
+        _listing.owner_address = TestProcessor.issuer["account_address"]
+        session.add(_listing)
+
+        _idx_token_list_item = IDXTokenListItem()
+        _idx_token_list_item.token_address = token_address
+        _idx_token_list_item.token_template = token_template
+        _idx_token_list_item.owner_address = TestProcessor.issuer["account_address"]
+        session.add(_idx_token_list_item)
+        session.commit()
+
+    @staticmethod
+    def issue_token_bond_with_args(issuer, token_list, args):
+        # Issue token
+        token = issue_bond_token(issuer, args)
+        register_bond_list(issuer, token, token_list)
+
+        return token
+
+    @staticmethod
+    def issue_token_share_with_args(issuer, token_list, args):
+        # Issue token
+        token = issue_share_token(issuer, args)
+        register_share_list(issuer, token, token_list)
+
+        return token
+
+    @staticmethod
+    def issue_token_coupon_with_args(issuer, token_list, args):
+        # Issue token
+        token = issue_coupon_token(issuer, args)
+        coupon_register_list(issuer, token, token_list)
+
+        return token
+
+    @staticmethod
+    def issue_token_membership_with_args(issuer, token_list, args):
+        # Issue token
+        token = membership_issue(issuer, args)
+        membership_register_list(issuer, token, token_list)
+
+        return token
+
+    ###########################################################################
+    # Normal Case
+    ###########################################################################
+
+    # <Normal_1>
+    def test_normal_1(self, processor: Processor, shared_contract, session: Session, block_number: None):
+        token_list_contract = shared_contract["TokenList"]
+        personal_info_contract = shared_contract["PersonalInfo"]
+        exchange_contract = shared_contract["IbetStraightBondExchange"]
+
+        config.TOKEN_LIST_CONTRACT_ADDRESS = token_list_contract['address']
+        _bond_token_expected_list = []
+        # Issue bond token
+        for i in range(10):
+            args = {
+                "name": f"テスト債券{str(i+1)}",
+                "symbol": f"BOND{str(i+1)}",
+                "totalSupply": 1000000+1,
+                "tradableExchange": exchange_contract["address"],
+                "faceValue": int((i+1)*10000),
+                "interestRate": 602+1,
+                "interestPaymentDate1": "0101",
+                "interestPaymentDate2": "0201",
+                "interestPaymentDate3": "0301",
+                "interestPaymentDate4": "0401",
+                "interestPaymentDate5": "0501",
+                "interestPaymentDate6": "0601",
+                "interestPaymentDate7": "0701",
+                "interestPaymentDate8": "0801",
+                "interestPaymentDate9": "0901",
+                "interestPaymentDate10": "1001",
+                "interestPaymentDate11": "1101",
+                "interestPaymentDate12": "1201",
+                "redemptionDate": "20191231",
+                "redemptionValue": 10000+1,
+                "returnDate": "20191231",
+                "returnAmount": f"商品券をプレゼント{str(i+1)}",
+                "purpose": f"新商品の開発資金として利用。{str(i+1)}",
+                "memo": f"メモ{str(i+1)}",
+                "contactInformation": f"問い合わせ先{str(i+1)}",
+                "privacyPolicy": f"プライバシーポリシー{str(i+1)}",
+                "personalInfoAddress": personal_info_contract["address"],
+                "transferable": True,
+                "isRedeemed": False,
+            }
+            token = self.issue_token_bond_with_args(
+                self.issuer, token_list_contract, args
+            )
+            self.listing_token(token["address"], "IbetStraightBond", session)
+            args = {
+                re.sub("([A-Z])", lambda x: "_" + x.group(1).lower(), k): v for k, v in args.items()
+            }
+            args["interest_rate"] = float(Decimal(str(args["interest_rate"])) * Decimal('0.0001'))
+            _bond_token_expected_list.append({**args, "token_address": token["address"]})
+
+        _share_token_expected_list = []
+        # Issue share token
+        for i in range(10):
+            args = {
+                "name": f"テスト株式{str(i+1)}",
+                "symbol": f"SHARE{str(i+1)}",
+                "tradableExchange": exchange_contract["address"],
+                "personalInfoAddress": personal_info_contract["address"],
+                "issuePrice": int((i+1)*1000),
+                "principalValue": 1000+i,
+                "totalSupply": 1000000+i,
+                "dividends": 101+i,
+                "dividendRecordDate": "20200401",
+                "dividendPaymentDate": "20200502",
+                "cancellationDate": "20200603",
+                "contactInformation": f"問い合わせ先{str(i+1)}",
+                "privacyPolicy": f"プライバシーポリシー{str(i+1)}",
+                "memo": "メモ",
+                "transferable": True,
+            }
+            token = self.issue_token_share_with_args(
+                self.issuer, token_list_contract, args
+            )
+            self.listing_token(token["address"], "IbetShare", session)
+            args = {
+                re.sub("([A-Z])", lambda x: "_" + x.group(1).lower(), k): v for k, v in args.items()
+            }
+            args["dividend_information"] = {
+                "dividends": float(Decimal(str(args["dividends"])) * Decimal("0.01")),
+                "dividend_record_date": args["dividend_record_date"],
+                "dividend_payment_date": args["dividend_payment_date"]
+            }
+            del args["dividends"]
+            del args["dividend_record_date"]
+            del args["dividend_payment_date"]
+            _share_token_expected_list.append({**args, "token_address": token["address"]})
+
+        _membership_token_expected_list = []
+        # Issue membership token
+        for i in range(10):
+            args = {
+                "name": f"テスト会員権{str(i+1)}",
+                "symbol": f"MEMBERSHIP{str(i+1)}",
+                "initialSupply": int((i+1)*1000000),
+                "tradableExchange": exchange_contract["address"],
+                "details": f"詳細{str(i+1)}",
+                "returnDetails": f"リターン詳細{str(i+1)}",
+                "expirationDate": "20191231",
+                "memo": f"メモ{str(i+1)}",
+                "transferable": True,
+                "contactInformation": f"問い合わせ先{str(i+1)}",
+                "privacyPolicy": f"プライバシーポリシー{str(i+1)}",
+            }
+            token = self.issue_token_membership_with_args(
+                self.issuer, token_list_contract, args
+            )
+            self.listing_token(token["address"], "IbetMembership", session)
+
+            args["totalSupply"] = args["initialSupply"]
+            del args["initialSupply"]
+            args = {
+                re.sub("([A-Z])", lambda x: "_" + x.group(1).lower(), k): v for k, v in args.items()
+            }
+            _membership_token_expected_list.append({**args, "token_address": token["address"]})
+
+        _coupon_token_expected_list = []
+        # issue coupon token
+        for i in range(10):
+            args = {
+                "name": f"テストクーポン{str(i+1)}",
+                "symbol": f"COUPON{str(i+1)}",
+                "totalSupply":  int((i+1)*1000000),
+                "tradableExchange": exchange_contract["address"],
+                "details": f"クーポン詳細{str(i+1)}",
+                "returnDetails": f"リターン詳細{str(i+1)}",
+                "memo": f"クーポンメモ欄{str(i+1)}",
+                "expirationDate": "20191231",
+                "transferable": True,
+                "contactInformation": f"問い合わせ先{str(i+1)}",
+                "privacyPolicy": f"プライバシーポリシー{str(i+1)}",
+            }
+
+            token = self.issue_token_coupon_with_args(
+                self.issuer, token_list_contract, args
+            )
+            self.listing_token(token["address"], "IbetCoupon", session)
+            args = {
+                re.sub("([A-Z])", lambda x: "_" + x.group(1).lower(), k): v for k, v in args.items()
+            }
+            _coupon_token_expected_list.append({**args, "token_address": token["address"]})
+
+        # Run target process
+        processor.SEC_PER_RECORD = 0
+        processor.process()
+
+        # assertion
+        for _expect_dict in _bond_token_expected_list:
+            _bond_token: BondTokenModel = session.query(BondTokenModel).filter(BondTokenModel.token_address == _expect_dict["token_address"]).one()
+            _bond_token_obj = BondToken.from_model(_bond_token)
+            for k, v in _expect_dict.items():
+                assert v == getattr(_bond_token_obj, k)
+
+        for _expect_dict in _share_token_expected_list:
+            _share_token: ShareTokenModel = session.query(ShareTokenModel).filter(ShareTokenModel.token_address == _expect_dict["token_address"]).one()
+            _share_token_obj = ShareToken.from_model(_share_token)
+            for k, v in _expect_dict.items():
+                assert v == getattr(_share_token_obj, k)
+
+        for _expect_dict in _membership_token_expected_list:
+            _membership_token: MembershipTokenModel = session.query(MembershipTokenModel).filter(MembershipTokenModel.token_address == _expect_dict["token_address"]).one()
+            _membership_token_obj = MembershipToken.from_model(_membership_token)
+            for k, v in _expect_dict.items():
+                assert v == getattr(_membership_token_obj, k)
+
+        for _expect_dict in _coupon_token_expected_list:
+            _coupon_token: CouponTokenModel = session.query(CouponTokenModel).filter(CouponTokenModel.token_address == _expect_dict["token_address"]).one()
+            _coupon_token_obj = CouponToken.from_model(_coupon_token)
+            for k, v in _expect_dict.items():
+                assert v == getattr(_coupon_token_obj, k)
+
+    ###########################################################################
+    # Error Case
+    ###########################################################################
+    # <Error_1_1>: ServiceUnavailable occurs in __sync_xx method.
+    # <Error_1_2>: SQLAlchemyError occurs in "process"
+    # <Error_2>: ServiceUnavailable occurs and is handled in mainloop.
+
+    # <Error_1_1>: ServiceUnavailable occurs in __sync_xx method.
+    def test_error_1_1(self, processor: Processor, shared_contract, session):
+        # Issue Token
+        token_list_contract = shared_contract["TokenList"]
+        exchange_contract = shared_contract["IbetStraightBondExchange"]
+        args = {
+            "name": "テストクーポン",
+            "symbol": "COUPON",
+            "totalSupply":  1000000,
+            "tradableExchange": exchange_contract["address"],
+            "details": "クーポン詳細",
+            "returnDetails": "リターン詳細",
+            "memo": "クーポンメモ欄",
+            "expirationDate": "20191231",
+            "transferable": True,
+            "contactInformation": "問い合わせ先",
+            "privacyPolicy": "プライバシーポリシー",
+        }
+        token = self.issue_token_coupon_with_args(self.issuer, token_list_contract, args)
+        self.listing_token(token["address"], "IbetCoupon", session)
+
+        # Expect that process() raises ServiceUnavailable.
+        with mock.patch("web3.providers.rpc.HTTPProvider.make_request", MagicMock(side_effect=ServiceUnavailable())), \
+                pytest.raises(ServiceUnavailable):
+            processor.process()
+
+        # Assertion
+        _coupon_token_list: List[CouponTokenModel] = session.query(CouponTokenModel).all()
+        assert len(_coupon_token_list) == 0
+
+        token = self.issue_token_coupon_with_args(self.issuer, token_list_contract, args)
+        self.listing_token(token["address"], "IbetCoupon", session)
+
+        # Expect that process() raises ServiceUnavailable.
+        with mock.patch("web3.providers.rpc.HTTPProvider.make_request", MagicMock(side_effect=ServiceUnavailable())), \
+                pytest.raises(ServiceUnavailable):
+            processor.process()
+
+        # Assertion
+        session.rollback()
+        _coupon_token_list: List[CouponTokenModel] = session.query(CouponTokenModel).all()
+        assert len(_coupon_token_list) == 0
+
+    # <Error_1_2>: SQLAlchemyError occurs in "process".
+    def test_error_1_2(self, processor: Processor, shared_contract, session):
+        # Issue Token
+        token_list_contract = shared_contract["TokenList"]
+        exchange_contract = shared_contract["IbetStraightBondExchange"]
+        args = {
+            "name": "テストクーポン",
+            "symbol": "COUPON",
+            "totalSupply":  1000000,
+            "tradableExchange": exchange_contract["address"],
+            "details": "クーポン詳細",
+            "returnDetails": "リターン詳細",
+            "memo": "クーポンメモ欄",
+            "expirationDate": "20191231",
+            "transferable": True,
+            "contactInformation": "問い合わせ先",
+            "privacyPolicy": "プライバシーポリシー",
+        }
+        token = self.issue_token_coupon_with_args(self.issuer, token_list_contract, args)
+        self.listing_token(token["address"], "IbetCoupon", session)
+
+        # Expect that process() raises SQLAlchemyError.
+        with mock.patch.object(Session, "commit", side_effect=SQLAlchemyError()), \
+                pytest.raises(SQLAlchemyError):
+            processor.process()
+
+        # Assertion
+        _coupon_token_list: List[CouponTokenModel] = session.query(CouponTokenModel).all()
+        assert len(_coupon_token_list) == 0
+
+        token = self.issue_token_coupon_with_args(self.issuer, token_list_contract, args)
+        self.listing_token(token["address"], "IbetCoupon", session)
+
+        # Expect that process() raises SQLAlchemyError.
+        with mock.patch.object(Session, "commit", side_effect=SQLAlchemyError()), \
+                pytest.raises(SQLAlchemyError):
+            processor.process()
+
+        # Assertion
+        session.rollback()
+        _coupon_token_list: List[CouponTokenModel] = session.query(CouponTokenModel).all()
+        assert len(_coupon_token_list) == 0
+
+    # <Error_2>: ServiceUnavailable occurs and is handled in mainloop.
+    def test_error_2(self, main_func, shared_contract, session, caplog):
+        # Issue Token
+        token_list_contract = shared_contract["TokenList"]
+        exchange_contract = shared_contract["IbetStraightBondExchange"]
+        args = {
+            "name": "テストクーポン",
+            "symbol": "COUPON",
+            "totalSupply":  1000000,
+            "tradableExchange": exchange_contract["address"],
+            "details": "クーポン詳細",
+            "returnDetails": "リターン詳細",
+            "memo": "クーポンメモ欄",
+            "expirationDate": "20191231",
+            "transferable": True,
+            "contactInformation": "問い合わせ先",
+            "privacyPolicy": "プライバシーポリシー",
+        }
+        token = self.issue_token_coupon_with_args(self.issuer, token_list_contract, args)
+        self.listing_token(token["address"], "IbetCoupon", session)
+        # Mocking time.sleep to break mainloop
+        time_mock = MagicMock(wraps=time)
+        time_mock.sleep.side_effect = [TypeError()]
+
+        # Run mainloop once and fail with web3 utils error
+        with mock.patch("batch.indexer_Token_Detail.time", time_mock),\
+            mock.patch("web3.providers.rpc.HTTPProvider.make_request", MagicMock(side_effect=ServiceUnavailable())), \
+                pytest.raises(TypeError):
+            # Expect that process() raises ServiceUnavailable and handled in mainloop.
+            main_func()
+
+        assert 1 == caplog.record_tuples.count((LOG.name, logging.INFO, "Service started successfully"))
+        assert 1 == caplog.record_tuples.count((LOG.name, logging.WARNING, "An external service was unavailable"))
+        caplog.clear()

--- a/tests/batch/indexer_Token_List_test.py
+++ b/tests/batch/indexer_Token_List_test.py
@@ -1,0 +1,516 @@
+"""
+Copyright BOOSTRY Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+import logging
+import time
+import pytest
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
+from typing import List, Optional
+from unittest import mock
+from unittest.mock import MagicMock
+from web3 import Web3
+from web3.middleware import geth_poa_middleware
+from web3.exceptions import ABIEventFunctionNotFound
+
+from app import config
+from app.errors import ServiceUnavailable
+from app.model.db import (
+    Listing,
+    IDXTokenListItem,
+    IDXTokenListBlockNumber
+)
+from batch import indexer_Token_List
+from batch.indexer_Token_List import Processor, LOG, main
+from tests.account_config import eth_account
+from tests.contract_modules import (
+    issue_bond_token,
+    register_bond_list,
+    issue_share_token,
+    register_share_list,
+    issue_coupon_token,
+    coupon_register_list,
+    membership_issue,
+    membership_register_list
+)
+
+web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
+web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+
+@pytest.fixture(scope="session")
+def test_module(shared_contract):
+    indexer_Token_List.TOKEN_LIST_CONTRACT_ADDRESS = shared_contract["TokenList"]["address"]
+    return indexer_Token_List
+
+
+@pytest.fixture(scope="function")
+def processor(test_module, session):
+    processor = test_module.Processor()
+    return processor
+
+
+@pytest.fixture(scope="function")
+def main_func(test_module):
+    LOG = logging.getLogger("Processor")
+    default_log_level = LOG.level
+    LOG.setLevel(logging.DEBUG)
+    LOG.propagate = True
+    yield main
+    LOG.propagate = False
+    LOG.setLevel(default_log_level)
+
+
+class TestProcessor:
+    issuer = eth_account["issuer"]
+    user1 = eth_account["user1"]
+    user2 = eth_account["user2"]
+    trader = eth_account["trader"]
+    agent = eth_account["agent"]
+
+    @staticmethod
+    def listing_token(token_address, session):
+        _listing = Listing()
+        _listing.token_address = token_address
+        _listing.is_public = True
+        _listing.max_holding_quantity = 1000000
+        _listing.max_sell_amount = 1000000
+        _listing.owner_address = TestProcessor.issuer["account_address"]
+        session.add(_listing)
+        session.commit()
+
+    @staticmethod
+    def issue_token_bond_with_args(issuer, token_list, args):
+        # Issue token
+        token = issue_bond_token(issuer, args)
+        register_bond_list(issuer, token, token_list)
+
+        return token
+
+    @staticmethod
+    def issue_token_share_with_args(issuer, token_list, args):
+        # Issue token
+        token = issue_share_token(issuer, args)
+        register_share_list(issuer, token, token_list)
+
+        return token
+
+    @staticmethod
+    def issue_token_coupon_with_args(issuer, token_list, args):
+        # Issue token
+        token = issue_coupon_token(issuer, args)
+        coupon_register_list(issuer, token, token_list)
+
+        return token
+
+    @staticmethod
+    def issue_token_membership_with_args(issuer, token_list, args):
+        # Issue token
+        token = membership_issue(issuer, args)
+        membership_register_list(issuer, token, token_list)
+
+        return token
+
+    ###########################################################################
+    # Normal Case
+    ###########################################################################
+
+    # <Normal_1>
+    # no token is listed
+    def test_normal_1(self, processor: Processor, shared_contract, session: Session, block_number: None):
+        token_list_contract = shared_contract["TokenList"]
+        _token_list_block_number = IDXTokenListBlockNumber()
+        _token_list_block_number.latest_block_number = web3.eth.block_number
+        _token_list_block_number.contract_address = token_list_contract['address']
+        session.add(_token_list_block_number)
+        session.commit()
+
+        # Run target process
+        processor.process()
+
+        # assertion
+        _token_list: List[IDXTokenListItem] = session.query(IDXTokenListItem).all()
+        assert len(_token_list) == 0
+
+    # <Normal_2>
+    # Multiple token is listed
+    def test_normal_2(self, processor: Processor, shared_contract, session: Session, block_number: None):
+        token_list_contract = shared_contract["TokenList"]
+        personal_info_contract = shared_contract["PersonalInfo"]
+        exchange_contract = shared_contract["IbetStraightBondExchange"]
+
+        config.TOKEN_LIST_CONTRACT_ADDRESS = token_list_contract['address']
+        _token_expected_list = []
+
+        _token_list_block_number = IDXTokenListBlockNumber()
+        _token_list_block_number.latest_block_number = web3.eth.block_number
+        _token_list_block_number.contract_address = token_list_contract['address']
+        session.add(_token_list_block_number)
+        session.commit()
+
+        # Issue bond token
+        for i in range(10):
+            args = {
+                "name": f"テスト債券{str(i+1)}",
+                "symbol": "BOND",
+                "totalSupply": 1000000,
+                "tradableExchange": exchange_contract["address"],
+                "faceValue": int((i+1)*10000),
+                "interestRate": 602,
+                "interestPaymentDate1": "0101",
+                "interestPaymentDate2": "0201",
+                "interestPaymentDate3": "0301",
+                "interestPaymentDate4": "0401",
+                "interestPaymentDate5": "0501",
+                "interestPaymentDate6": "0601",
+                "interestPaymentDate7": "0701",
+                "interestPaymentDate8": "0801",
+                "interestPaymentDate9": "0901",
+                "interestPaymentDate10": "1001",
+                "interestPaymentDate11": "1101",
+                "interestPaymentDate12": "1201",
+                "redemptionDate": "20191231",
+                "redemptionValue": 10000,
+                "returnDate": "20191231",
+                "returnAmount": "商品券をプレゼント",
+                "purpose": "新商品の開発資金として利用。",
+                "memo": "メモ",
+                "contactInformation": "問い合わせ先",
+                "privacyPolicy": "プライバシーポリシー",
+                "personalInfoAddress": personal_info_contract["address"],
+                "transferable": True,
+                "isRedeemed": False,
+            }
+            token = self.issue_token_bond_with_args(
+                self.issuer, token_list_contract, args
+            )
+            self.listing_token(token["address"], session)
+            _token_expected_list.append({
+                "token_address": token["address"],
+                "token_template": "IbetStraightBond",
+                "owner_address": self.issuer["account_address"]
+            })
+
+        # Issue share token
+        for i in range(10):
+            args = {
+                "name": "テスト株式",
+                "symbol": "SHARE",
+                "tradableExchange": exchange_contract["address"],
+                "personalInfoAddress": personal_info_contract["address"],
+                "issuePrice": int((i+1)*1000),
+                "principalValue": 1000,
+                "totalSupply": 1000000,
+                "dividends": 101,
+                "dividendRecordDate": "20200401",
+                "dividendPaymentDate": "20200502",
+                "cancellationDate": "20200603",
+                "contactInformation": "問い合わせ先",
+                "privacyPolicy": "プライバシーポリシー",
+                "memo": "メモ",
+                "transferable": True,
+            }
+            token = self.issue_token_share_with_args(
+                self.issuer, token_list_contract, args
+            )
+            self.listing_token(token["address"], session)
+            _token_expected_list.append({
+                "token_address": token["address"],
+                "token_template": "IbetShare",
+                "owner_address": self.issuer["account_address"]
+            })
+
+        # Issue membership token
+        for i in range(10):
+            args = {
+                "name": "テスト会員権",
+                "symbol": "MEMBERSHIP",
+                "initialSupply": int((i+1)*1000000),
+                "tradableExchange": exchange_contract["address"],
+                "details": "詳細",
+                "returnDetails": "リターン詳細",
+                "expirationDate": "20191231",
+                "memo": "メモ",
+                "transferable": True,
+                "contactInformation": "問い合わせ先",
+                "privacyPolicy": "プライバシーポリシー",
+            }
+            token = self.issue_token_membership_with_args(
+                self.issuer, token_list_contract, args
+            )
+            self.listing_token(token["address"], session)
+            _token_expected_list.append({
+                "token_address": token["address"],
+                "token_template": "IbetMembership",
+                "owner_address": self.issuer["account_address"]
+            })
+
+        # issue coupon token
+        for i in range(10):
+            args = {
+                "name": "テストクーポン",
+                "symbol": "COUPON",
+                "totalSupply":  int((i+1)*1000000),
+                "tradableExchange": exchange_contract["address"],
+                "details": "クーポン詳細",
+                "returnDetails": "リターン詳細",
+                "memo": "クーポンメモ欄",
+                "expirationDate": "20191231",
+                "transferable": True,
+                "contactInformation": "問い合わせ先",
+                "privacyPolicy": "プライバシーポリシー",
+            }
+
+            token = self.issue_token_coupon_with_args(
+                self.issuer, token_list_contract, args
+            )
+            self.listing_token(token["address"], session)
+            _token_expected_list.append({
+                "token_address": token["address"],
+                "token_template": "IbetCoupon",
+                "owner_address": self.issuer["account_address"]
+            })
+
+        # Run target process
+        processor.process()
+
+        # assertion
+        for _expect_dict in _token_expected_list:
+            token_list_item: IDXTokenListItem = session.query(IDXTokenListItem).\
+                filter(IDXTokenListItem.token_address == _expect_dict["token_address"]).one()
+
+            assert token_list_item.token_template == _expect_dict["token_template"]
+            assert token_list_item.owner_address == _expect_dict["owner_address"]
+
+    ###########################################################################
+    # Error Case
+    ###########################################################################
+    # <Error_1>: ABIEventFunctionNotFound occurs in __sync_xx method.
+    # <Error_2_1>: ServiceUnavailable occurs in __sync_xx method.
+    # <Error_2_2>: SQLAlchemyError occurs in "process".
+    # <Error_3>: ServiceUnavailable occurs and is handled in mainloop.
+
+    # <Error_1>: ABIEventFunctionNotFound occurs in __sync_xx method.
+    @mock.patch("web3.contract.ContractEvent.getLogs", MagicMock(side_effect=ABIEventFunctionNotFound()))
+    def test_error_1(self, processor: Processor, shared_contract, session):
+        # Issue Token
+        token_list_contract = shared_contract["TokenList"]
+        exchange_contract = shared_contract["IbetStraightBondExchange"]
+
+        _token_list_block_number = IDXTokenListBlockNumber()
+        _token_list_block_number.latest_block_number = web3.eth.block_number
+        _token_list_block_number.contract_address = token_list_contract["address"]
+        session.add(_token_list_block_number)
+        session.commit()
+
+        args = {
+            "name": "テストクーポン",
+            "symbol": "COUPON",
+            "totalSupply":  1000000,
+            "tradableExchange": exchange_contract["address"],
+            "details": "クーポン詳細",
+            "returnDetails": "リターン詳細",
+            "memo": "クーポンメモ欄",
+            "expirationDate": "20191231",
+            "transferable": True,
+            "contactInformation": "問い合わせ先",
+            "privacyPolicy": "プライバシーポリシー",
+        }
+        token = self.issue_token_coupon_with_args(self.issuer, token_list_contract, args)
+        self.listing_token(token["address"], session)
+
+        block_number_current = web3.eth.block_number
+        # Run initial sync
+        processor.process()
+
+        # Assertion
+        _token_list: List[IDXTokenListItem] = session.query(IDXTokenListItem).all()
+        _token_list_block_number: Optional[IDXTokenListBlockNumber] = session.query(IDXTokenListBlockNumber).first()
+        assert len(_token_list) == 0
+        # Latest_block is incremented in "process" process.
+        assert _token_list_block_number.latest_block_number == block_number_current
+
+        token = self.issue_token_coupon_with_args(self.issuer, token_list_contract, args)
+        self.listing_token(token["address"], session)
+
+        block_number_current = web3.eth.block_number
+        # Run target process
+        processor.process()
+
+        # Run target process
+        processor.process()
+
+        # Assertion
+        session.rollback()
+        # Assertion
+        _token_list: List[IDXTokenListItem] = session.query(IDXTokenListItem).all()
+        _token_list_block_number: Optional[IDXTokenListBlockNumber] = session.query(IDXTokenListBlockNumber).first()
+        assert len(_token_list) == 0
+        # Latest_block is incremented in "process" process.
+        assert _token_list_block_number.latest_block_number == block_number_current
+
+    # <Error_2_1>: ServiceUnavailable occurs in __sync_xx method.
+    def test_error_2_1(self, processor: Processor, shared_contract, session):
+        # Issue Token
+        token_list_contract = shared_contract["TokenList"]
+        exchange_contract = shared_contract["IbetStraightBondExchange"]
+
+        _token_list_block_number = IDXTokenListBlockNumber()
+        _token_list_block_number.latest_block_number = web3.eth.block_number
+        _token_list_block_number.contract_address = token_list_contract["address"]
+        session.add(_token_list_block_number)
+        session.commit()
+
+        args = {
+            "name": "テストクーポン",
+            "symbol": "COUPON",
+            "totalSupply":  1000000,
+            "tradableExchange": exchange_contract["address"],
+            "details": "クーポン詳細",
+            "returnDetails": "リターン詳細",
+            "memo": "クーポンメモ欄",
+            "expirationDate": "20191231",
+            "transferable": True,
+            "contactInformation": "問い合わせ先",
+            "privacyPolicy": "プライバシーポリシー",
+        }
+        token = self.issue_token_coupon_with_args(self.issuer, token_list_contract, args)
+        self.listing_token(token["address"], session)
+
+        _token_list_block_number_bf: Optional[IDXTokenListBlockNumber] = session.query(IDXTokenListBlockNumber).first()
+        # Expect that process() raises ServiceUnavailable.
+        with mock.patch("web3.providers.rpc.HTTPProvider.make_request", MagicMock(side_effect=ServiceUnavailable())), \
+                pytest.raises(ServiceUnavailable):
+            processor.process()
+
+        session.rollback()
+        # Assertion
+        _token_list: List[IDXTokenListItem] = session.query(IDXTokenListItem).all()
+        _token_list_block_number_af: Optional[IDXTokenListBlockNumber] = session.query(IDXTokenListBlockNumber).first()
+        assert len(_token_list) == 0
+        assert _token_list_block_number_bf.latest_block_number == _token_list_block_number_af.latest_block_number
+
+        token = self.issue_token_coupon_with_args(self.issuer, token_list_contract, args)
+        self.listing_token(token["address"], session)
+
+        session.rollback()
+        _token_list_block_number_bf: Optional[IDXTokenListBlockNumber] = session.query(IDXTokenListBlockNumber).first()
+
+        # Expect that process() raises ServiceUnavailable.
+        with mock.patch("web3.providers.rpc.HTTPProvider.make_request", MagicMock(side_effect=ServiceUnavailable())), \
+                pytest.raises(ServiceUnavailable):
+            processor.process()
+
+        # Assertion
+        session.rollback()
+        _token_list: List[IDXTokenListItem] = session.query(IDXTokenListItem).all()
+        _token_list_block_number_af: Optional[IDXTokenListBlockNumber] = session.query(IDXTokenListBlockNumber).first()
+        assert len(_token_list) == 0
+        assert _token_list_block_number_bf.latest_block_number == _token_list_block_number_af.latest_block_number
+
+    # <Error_2_2>: SQLAlchemyError occurs in "process".
+    def test_error_2_2(self, processor: Processor, shared_contract, session):
+        # Issue Token
+        token_list_contract = shared_contract["TokenList"]
+        exchange_contract = shared_contract["IbetStraightBondExchange"]
+
+        _token_list_block_number = IDXTokenListBlockNumber()
+        _token_list_block_number.latest_block_number = web3.eth.block_number
+        _token_list_block_number.contract_address = token_list_contract["address"]
+        session.add(_token_list_block_number)
+        session.commit()
+
+        args = {
+            "name": "テストクーポン",
+            "symbol": "COUPON",
+            "totalSupply":  1000000,
+            "tradableExchange": exchange_contract["address"],
+            "details": "クーポン詳細",
+            "returnDetails": "リターン詳細",
+            "memo": "クーポンメモ欄",
+            "expirationDate": "20191231",
+            "transferable": True,
+            "contactInformation": "問い合わせ先",
+            "privacyPolicy": "プライバシーポリシー",
+        }
+        token = self.issue_token_coupon_with_args(self.issuer, token_list_contract, args)
+        self.listing_token(token["address"], session)
+
+        # Expect that process() raises SQLAlchemyError.
+        with mock.patch.object(Session, "commit", side_effect=SQLAlchemyError()), \
+                pytest.raises(SQLAlchemyError):
+            processor.process()
+
+        # Assertion
+        _token_list: List[IDXTokenListItem] = session.query(IDXTokenListItem).all()
+        _token_list_block_number_af: Optional[IDXTokenListBlockNumber] = session.query(IDXTokenListBlockNumber).first()
+        assert len(_token_list) == 0
+        assert _token_list_block_number_af.latest_block_number == _token_list_block_number.latest_block_number
+
+        token = self.issue_token_coupon_with_args(self.issuer, token_list_contract, args)
+        self.listing_token(token["address"], session)
+
+        session.rollback()
+
+        # Expect that process() raises SQLAlchemyError.
+        with mock.patch.object(Session, "commit", side_effect=SQLAlchemyError()), \
+                pytest.raises(SQLAlchemyError):
+            processor.process()
+
+        # Assertion
+        session.rollback()
+        _token_list: List[IDXTokenListItem] = session.query(IDXTokenListItem).all()
+        _token_list_block_number_af: Optional[IDXTokenListBlockNumber] = session.query(IDXTokenListBlockNumber).first()
+        assert len(_token_list) == 0
+        assert _token_list_block_number_af.latest_block_number == _token_list_block_number.latest_block_number
+
+    # <Error_3>: ServiceUnavailable occurs and is handled in mainloop.
+    def test_error_3(self, main_func, shared_contract, session, caplog):
+        # Issue Token
+        token_list_contract = shared_contract["TokenList"]
+        exchange_contract = shared_contract["IbetStraightBondExchange"]
+
+        args = {
+            "name": "テストクーポン",
+            "symbol": "COUPON",
+            "totalSupply":  1000000,
+            "tradableExchange": exchange_contract["address"],
+            "details": "クーポン詳細",
+            "returnDetails": "リターン詳細",
+            "memo": "クーポンメモ欄",
+            "expirationDate": "20191231",
+            "transferable": True,
+            "contactInformation": "問い合わせ先",
+            "privacyPolicy": "プライバシーポリシー",
+        }
+        token = self.issue_token_coupon_with_args(self.issuer, token_list_contract, args)
+        self.listing_token(token["address"], session)
+
+        # Mocking time.sleep to break mainloop
+        time_mock = MagicMock(wraps=time)
+        time_mock.sleep.side_effect = [TypeError()]
+
+        # Run mainloop once and fail with web3 utils error
+        with mock.patch("batch.indexer_Token_List.time", time_mock),\
+            mock.patch("web3.providers.rpc.HTTPProvider.make_request", MagicMock(side_effect=ServiceUnavailable())), \
+                pytest.raises(TypeError):
+            # Expect that process() raises ServiceUnavailable and handled in mainloop.
+            main_func()
+
+        assert 1 == caplog.record_tuples.count((LOG.name, logging.INFO, "Service started successfully"))
+        assert 1 == caplog.record_tuples.count((LOG.name, logging.WARNING, "An external service was unavailable"))
+        caplog.clear()


### PR DESCRIPTION
## Issue ticket number and link
#1163 

## Describe your changes
1. Added 2 batches

which get token detail data from quorum at fixed interval.

2. Added cache functionality to following API endpoint

```
GET /Token/StraightBond
GET /Token/Share
GET /Token/Membership
GET /Token/Coupon
```

## Others

- **Environment variables added**
- **Migration files added**