### PR TITLE
feat: Change API access logging method

### DIFF
--- a/app/api/v2/admin.py
+++ b/app/api/v2/admin.py
@@ -49,8 +49,6 @@ class Tokens(BaseResource):
     # GET
     ########################################
     def on_get(self, req, res, **kwargs):
-        LOG.info("v2.admin.Tokens(GET)")
-
         session = req.context["session"]
 
         res_body = []
@@ -69,8 +67,6 @@ class Tokens(BaseResource):
     # POST
     ########################################
     def on_post(self, req, res, **kwargs):
-        LOG.info("v2.admin.Tokens(POST)")
-
         session = req.context["session"]
 
         # 入力値チェック
@@ -217,8 +213,6 @@ class TokenType(BaseResource):
     # GET
     ########################################
     def on_get(self, req, res, **kwargs):
-        LOG.info("v2.admin.TokenType")
-
         res_body = {
             "IbetStraightBond": config.BOND_TOKEN_ENABLED,
             "IbetShare": config.SHARE_TOKEN_ENABLED,
@@ -244,10 +238,7 @@ class Token(BaseResource):
     # GET
     ########################################
     def on_get(self, req, res, contract_address=None, **kwargs):
-        LOG.info("v2.admin.Token(GET)")
-
         session = req.context["session"]
-
         token = session.query(Listing).\
             filter(Listing.token_address == contract_address).\
             first()
@@ -263,8 +254,6 @@ class Token(BaseResource):
     # POST
     ########################################
     def on_post(self, req, res, contract_address=None, **kwargs):
-        LOG.info("v2.token.Token(POST)")
-
         session = req.context["session"]
 
         # 入力値チェック
@@ -340,10 +329,7 @@ class Token(BaseResource):
     # DELETE
     ########################################
     def on_delete(self, req, res, contract_address=None, **kwargs):
-        LOG.info("v2.admin.Token(DELETE)")
-
         session = req.context["session"]
-
         try:
             session.query(Listing).filter(Listing.token_address == contract_address).delete()
             session.query(ExecutableContract).filter(ExecutableContract.contract_address == contract_address).delete()

--- a/app/api/v2/company.py
+++ b/app/api/v2/company.py
@@ -50,8 +50,6 @@ class CompanyInfo(BaseResource):
     """
 
     def on_get(self, req, res, eth_address=None, **kwargs):
-        LOG.info('v2.company.CompanyInfo')
-
         if not Web3.isAddress(eth_address):
             description = 'invalid eth_address'
             raise InvalidParameterError(description=description)
@@ -72,8 +70,6 @@ class CompanyInfoList(BaseResource):
     """
 
     def on_get(self, req, res, **kwargs):
-        LOG.info('v2.company.CompanyInfoList')
-
         session = req.context["session"]
 
         # Validation
@@ -152,7 +148,6 @@ class CompanyTokenList(BaseResource):
     """
 
     def on_get(self, req, res, eth_address=None, **kwargs):
-        LOG.info('v2.company.CompanyTokenList')
         session = req.context['session']
 
         # Validation

--- a/app/api/v2/eth.py
+++ b/app/api/v2/eth.py
@@ -53,8 +53,6 @@ class GetTransactionCount(BaseResource):
     """
 
     def on_get(self, req, res, eth_address: ChecksumAddress = None, **kwargs):
-        LOG.info('v2.eth.GetTransactionCount')
-
         try:
             eth_address = to_checksum_address(eth_address)
         except ValueError:
@@ -103,8 +101,6 @@ class SendRawTransaction(BaseResource):
     """
 
     def on_post(self, req, res, **kwargs):
-        LOG.info("v2.eth.SendRawTransaction")
-
         session = req.context["session"]
 
         request_json = SendRawTransaction.validate(req)
@@ -123,7 +119,7 @@ class SendRawTransaction(BaseResource):
                 raw_tx = decode(HexBytes(raw_tx_hex))
                 to_contract_address = to_checksum_address("0x" + raw_tx[3].hex())
             except Exception as err:
-                LOG.info(f"RLP decoding failed: {err}")
+                LOG.warning(f"RLP decoding failed: {err}")
                 continue
 
             listed_token = session.query(Listing). \
@@ -156,7 +152,7 @@ class SendRawTransaction(BaseResource):
             try:
                 raw_tx = decode(HexBytes(raw_tx_hex))
                 to_contract_address = to_checksum_address("0x" + raw_tx[3].hex())
-                LOG.info(raw_tx)
+                LOG.debug(raw_tx)
             except Exception as err:
                 result.append({"id": i + 1, "status": 0})
                 LOG.error(f"RLP decoding failed: {err}")
@@ -306,8 +302,6 @@ class SendRawTransactionNoWait(BaseResource):
     """
 
     def on_post(self, req, res, **kwargs):
-        LOG.info("v2.eth.SendRawTransactionNoWait")
-
         session = req.context["session"]
 
         request_json = SendRawTransactionNoWait.validate(req)
@@ -326,7 +320,7 @@ class SendRawTransactionNoWait(BaseResource):
                 raw_tx = decode(HexBytes(raw_tx_hex))
                 to_contract_address = to_checksum_address("0x" + raw_tx[3].hex())
             except Exception as err:
-                LOG.info(f"RLP decoding failed: {err}")
+                LOG.warning(f"RLP decoding failed: {err}")
                 continue
 
             listed_token = session.query(Listing). \
@@ -334,7 +328,7 @@ class SendRawTransactionNoWait(BaseResource):
                 first()
 
             if listed_token is not None:
-                LOG.info(f"Token Address: {to_contract_address}")
+                LOG.debug(f"Token Address: {to_contract_address}")
                 token_attribute = Contract.call_function(
                     contract=list_contract,
                     function_name="getTokenByAddress",
@@ -360,7 +354,7 @@ class SendRawTransactionNoWait(BaseResource):
             try:
                 raw_tx = decode(HexBytes(raw_tx_hex))
                 to_contract_address = to_checksum_address("0x" + raw_tx[3].hex())
-                LOG.info(raw_tx)
+                LOG.debug(raw_tx)
             except Exception as err:
                 result.append({"id": i + 1, "status": 0})
                 LOG.error(f"RLP decoding failed: {err}")
@@ -439,8 +433,6 @@ class WaitForTransactionReceipt(BaseResource):
     """
 
     def on_post(self, req, res, **kwargs):
-        LOG.info('v2.eth.WaitForTransactionReceipt')
-
         request_json = self.validate(req)
         transaction_hash = request_json.get("transaction_hash")
         timeout = request_json.get("timeout", 5)
@@ -461,7 +453,7 @@ class WaitForTransactionReceipt(BaseResource):
                 result["error_msg"] = message
             else:
                 result["status"] = 1
-        except Exception as err:
+        except Exception:
             raise DataNotExistsError
 
         if tx is None:

--- a/app/api/v2/market_information.py
+++ b/app/api/v2/market_information.py
@@ -45,8 +45,6 @@ class GetAgreement(BaseResource):
     """約定情報参照"""
 
     def on_get(self, req, res, **kwargs):
-        LOG.info("v2.market_information.GetAgreement")
-
         if config.IBET_SB_EXCHANGE_CONTRACT_ADDRESS is None and \
                 config.IBET_MEMBERSHIP_EXCHANGE_CONTRACT_ADDRESS is None and \
                 config.IBET_CP_EXCHANGE_CONTRACT_ADDRESS is None and \
@@ -161,7 +159,6 @@ class StraightBondOrderBook(BaseResource):
     """[普通社債]板情報取得"""
 
     def on_post(self, req, res, **kwargs):
-        LOG.info("v2.market_information.StraightBondOrderBook")
         session = req.context["session"]
 
         if config.BOND_TOKEN_ENABLED is False or config.IBET_SB_EXCHANGE_CONTRACT_ADDRESS is None:
@@ -377,8 +374,6 @@ class StraightBondLastPrice(BaseResource):
     """[普通社債]現在値取得"""
 
     def on_post(self, req, res, **kwargs):
-        LOG.info("v2.market_information.StraightBondLastPrice")
-
         if config.BOND_TOKEN_ENABLED is False or config.IBET_SB_EXCHANGE_CONTRACT_ADDRESS is None:
             raise NotSupportedError(method="POST", url=req.path)
 
@@ -438,8 +433,6 @@ class StraightBondTick(BaseResource):
     """[普通社債]歩み値取得"""
 
     def on_post(self, req, res, **kwargs):
-        LOG.info("v2.market_information.StraightBondTick")
-
         if config.BOND_TOKEN_ENABLED is False or config.IBET_SB_EXCHANGE_CONTRACT_ADDRESS is None:
             raise NotSupportedError(method="POST", url=req.path)
 
@@ -514,7 +507,6 @@ class MembershipOrderBook(BaseResource):
     """[会員権]板情報取得"""
 
     def on_post(self, req, res, **kwargs):
-        LOG.info("v2.market_information.MembershipOrderBook")
         session = req.context["session"]
 
         if config.MEMBERSHIP_TOKEN_ENABLED is False or config.IBET_MEMBERSHIP_EXCHANGE_CONTRACT_ADDRESS is None:
@@ -737,8 +729,6 @@ class MembershipLastPrice(BaseResource):
     """[会員権]現在値取得"""
 
     def on_post(self, req, res, **kwargs):
-        LOG.info("v2.market_information.MembershipLastPrice")
-
         if config.MEMBERSHIP_TOKEN_ENABLED is False or config.IBET_MEMBERSHIP_EXCHANGE_CONTRACT_ADDRESS is None:
             raise NotSupportedError(method="POST", url=req.path)
 
@@ -799,8 +789,6 @@ class MembershipTick(BaseResource):
     """[会員権]歩み値取得"""
 
     def on_post(self, req, res, **kwargs):
-        LOG.info("v2.market_information.MembershipTick")
-
         if config.MEMBERSHIP_TOKEN_ENABLED is False or config.IBET_MEMBERSHIP_EXCHANGE_CONTRACT_ADDRESS is None:
             raise NotSupportedError(method="POST", url=req.path)
 
@@ -876,7 +864,6 @@ class CouponOrderBook(BaseResource):
     """[クーポン]板情報取得"""
 
     def on_post(self, req, res, **kwargs):
-        LOG.info("v2.market_information.CouponOrderBook")
         session = req.context["session"]
 
         if config.COUPON_TOKEN_ENABLED is False or config.IBET_CP_EXCHANGE_CONTRACT_ADDRESS is None:
@@ -1099,8 +1086,6 @@ class CouponLastPrice(BaseResource):
     """[クーポン]現在値取得"""
 
     def on_post(self, req, res, **kwargs):
-        LOG.info("v2.market_information.CouponLastPrice")
-
         if config.COUPON_TOKEN_ENABLED is False or config.IBET_CP_EXCHANGE_CONTRACT_ADDRESS is None:
             raise NotSupportedError(method="POST", url=req.path)
 
@@ -1160,8 +1145,6 @@ class CouponTick(BaseResource):
     """[クーポン]歩み値取得"""
 
     def on_post(self, req, res, **kwargs):
-        LOG.info("v2.market_information.CouponTick")
-
         if config.COUPON_TOKEN_ENABLED is False or config.IBET_CP_EXCHANGE_CONTRACT_ADDRESS is None:
             raise NotSupportedError(method="POST", url=req.path)
 

--- a/app/api/v2/nodeInfo.py
+++ b/app/api/v2/nodeInfo.py
@@ -38,9 +38,7 @@ class NodeInfo(BaseResource):
     Endpoint: /NodeInfo
     """
 
-    def on_get(self, req, res):
-        LOG.info('v2.nodeInfo.GetNodeInfo')
-
+    def on_get(self, req, res, **kwargs):
         payment_gateway_json = json.load(open("app/contracts/json/PaymentGateway.json", "r"))
         personal_info_json = json.load(open("app/contracts/json/PersonalInfo.json", "r"))
         ibet_exchange_json = json.load(open("app/contracts/json/IbetExchange.json", "r"))
@@ -81,9 +79,7 @@ class BlockSyncStatus(BaseResource):
     Endpoint: /NodeInfo/BlockSyncStatus
     """
 
-    def on_get(self, req, res):
-        LOG.info('v2.nodeInfo.GetBlockSyncStatus')
-
+    def on_get(self, req, res, **kwargs):
         session = req.context["session"]
 
         # Get block sync status

--- a/app/api/v2/notification.py
+++ b/app/api/v2/notification.py
@@ -39,9 +39,7 @@ class Notifications(BaseResource):
     Endpoint: /Notifications/
     """
 
-    def on_get(self, req, res):
-        LOG.info('v2.notification.Notifications(GET)')
-
+    def on_get(self, req, res, **kwargs):
         session = req.context["session"]
 
         # 入力値チェック
@@ -84,9 +82,7 @@ class Notifications(BaseResource):
 
         self.on_success(res, {"notifications": notification_list})
 
-    def on_post(self, req, res):
-        LOG.info('v2.notification.Notifications(POST)')
-
+    def on_post(self, req, res, **kwargs):
         session = req.context["session"]
 
         # 入力値チェック
@@ -225,9 +221,7 @@ class NotificationsRead(BaseResource):
     Endpoint: /Notifications/Read/
     """
 
-    def on_post(self, req, res):
-        LOG.info('v2.notification.NotificationsRead')
-
+    def on_post(self, req, res, **kwargs):
         session = req.context["session"]
 
         # 入力値チェック
@@ -279,9 +273,7 @@ class NotificationCount(BaseResource):
     Endpoint: /NotificationCount/
     """
 
-    def on_get(self, req, res):
-        LOG.info("v2.notification.NotificationCount")
-
+    def on_get(self, req, res, **kwargs):
         session = req.context["session"]
 
         # 入力値チェック

--- a/app/api/v2/order_list.py
+++ b/app/api/v2/order_list.py
@@ -447,7 +447,6 @@ class OrderList(BaseOrderList, BaseResource):
     """
 
     def on_post(self, req, res, token_address: str = None, **kwargs):
-        LOG.info("v2.order_list.OrderList")
         session = req.context["session"]
 
         # path validation
@@ -548,7 +547,6 @@ class StraightBondOrderList(BaseOrderList, BaseResource):
     """
 
     def on_post(self, req, res, **kwargs):
-        LOG.info("v2.order_list.StraightBondOrderList")
         session = req.context["session"]
 
         if config.BOND_TOKEN_ENABLED is False or config.IBET_SB_EXCHANGE_CONTRACT_ADDRESS is None:
@@ -645,7 +643,6 @@ class MembershipOrderList(BaseOrderList, BaseResource):
     """
 
     def on_post(self, req, res, **kwargs):
-        LOG.info("v2.order_list.MembershipOrderList")
         session = req.context["session"]
 
         if config.MEMBERSHIP_TOKEN_ENABLED is False or config.IBET_MEMBERSHIP_EXCHANGE_CONTRACT_ADDRESS is None:
@@ -743,7 +740,6 @@ class CouponOrderList(BaseOrderList, BaseResource):
     """
 
     def on_post(self, req, res, **kwargs):
-        LOG.info("v2.order_list.CouponOrderList")
         session = req.context["session"]
 
         if config.COUPON_TOKEN_ENABLED is False or config.IBET_CP_EXCHANGE_CONTRACT_ADDRESS is None:
@@ -841,7 +837,6 @@ class ShareOrderList(BaseOrderList, BaseResource):
     """
 
     def on_post(self, req, res, **kwargs):
-        LOG.info("v2.order_list.ShareOrderList")
         session = req.context["session"]
 
         if config.SHARE_TOKEN_ENABLED is False or config.IBET_SHARE_EXCHANGE_CONTRACT_ADDRESS is None:

--- a/app/api/v2/position.py
+++ b/app/api/v2/position.py
@@ -48,8 +48,7 @@ class ShareMyTokens(BaseResource):
     """保有一覧参照（Share）"""
 
     def on_post(self, req, res, **kwargs):
-        LOG.warning(DeprecationWarning("Deprecated API: v2.position.ShareMyTokens"))
-        LOG.info("v2.position.ShareMyTokens")
+        LOG.warning(DeprecationWarning("Deprecated API: /v2/Position/Share"))
 
         session = req.context["session"]
 
@@ -176,8 +175,7 @@ class StraightBondMyTokens(BaseResource):
     """保有一覧参照（StraightBond）"""
 
     def on_post(self, req, res, **kwargs):
-        LOG.warning(DeprecationWarning("Deprecated API: v2.position.StraightBondMyTokens"))
-        LOG.info("v2.position.StraightBondMyTokens")
+        LOG.warning(DeprecationWarning("Deprecated API: /v2/Position/StraightBond"))
 
         session = req.context["session"]
 
@@ -305,8 +303,7 @@ class MembershipMyTokens(BaseResource):
     """保有一覧参照（Membership）"""
 
     def on_post(self, req, res, **kwargs):
-        LOG.warning(DeprecationWarning("Deprecated API: v2.position.MembershipMyTokens"))
-        LOG.info("v2.position.MembershipMyTokens")
+        LOG.warning(DeprecationWarning("Deprecated API: /v2/Position/Membership"))
 
         session = req.context["session"]
 
@@ -424,8 +421,7 @@ class CouponMyTokens(BaseResource):
     """保有一覧参照（Coupon）"""
 
     def on_post(self, req, res, **kwargs):
-        LOG.warning(DeprecationWarning("Deprecated API: v2.position.CouponMyTokens"))
-        LOG.info("v2.position.CouponMyTokens")
+        LOG.warning(DeprecationWarning("Deprecated API: /v2/Position/Coupon"))
 
         session = req.context["session"]
 
@@ -561,8 +557,8 @@ class CouponConsumptions(BaseResource):
     """Coupon消費履歴参照"""
 
     def on_post(self, req, res, **kwargs):
-        LOG.warning(DeprecationWarning("Deprecated API: v2.position.CouponConsumptions"))
-        LOG.info("v2.position.CouponConsumptions")
+        LOG.warning(DeprecationWarning("Deprecated API: /v2/Position/Coupon/Consumptions"))
+
         session = req.context["session"]
 
         if config.COUPON_TOKEN_ENABLED is False:

--- a/app/api/v2/statistics.py
+++ b/app/api/v2/statistics.py
@@ -42,8 +42,6 @@ class Token(BaseResource):
     """トークン別統計値取得"""
 
     def on_get(self, req, res, contract_address=None, **kwargs):
-        LOG.info('v2.statistics.Token')
-
         session = req.context["session"]
 
         # Validation

--- a/app/api/v2/token.py
+++ b/app/api/v2/token.py
@@ -69,8 +69,6 @@ class TokenStatus(BaseResource):
         self.web3 = Web3Wrapper()
 
     def on_get(self, req, res, contract_address=None, **kwargs):
-        LOG.info('v2.token.TokenStatus')
-
         # 入力アドレスフォーマットチェック
         try:
             contract_address = to_checksum_address(contract_address)
@@ -132,8 +130,6 @@ class TokenHolders(BaseResource):
     """
 
     def on_get(self, req, res, contract_address=None, **kwargs):
-        LOG.info('v2.token.TokenHolders')
-
         session = req.context["session"]
 
         # Validation
@@ -190,8 +186,6 @@ class TokenHoldersCollection(BaseResource):
 
     def on_post(self, req: Request, res: Response, *args, **kwargs):
         """Token holders collection"""
-        LOG.info("v2.token.TokenHoldersCollection(POST)")
-
         session: Session = req.context["session"]
 
         # body部の入力値チェック
@@ -292,8 +286,6 @@ class TokenHoldersCollectionId(BaseResource):
 
     def on_get(self, req: Request, res: Response, *args, **kwargs):
         """Token holders collection Id"""
-        LOG.info("v2.token.TokenHoldersCollectionId(GET)")
-
         contract_address = kwargs.get("contract_address", "")
         list_id = kwargs.get("list_id", "")
 
@@ -332,9 +324,9 @@ class TokenHoldersCollectionId(BaseResource):
             first()
 
         if not _same_list_id_record:
-            raise DataNotExistsError("list_id: %s"%list_id)
+            raise DataNotExistsError("list_id: %s" % list_id)
         if _same_list_id_record.token_address != contract_address:
-            description = "list_id: %s is not collection for contract_address: %s"%(list_id, contract_address)
+            description = "list_id: %s is not collection for contract_address: %s" % (list_id, contract_address)
             raise InvalidParameterError(description=description)
 
         _token_holders: List[TokenHolder] = session.query(TokenHolder). \
@@ -355,8 +347,6 @@ class TransferHistory(BaseResource):
     """
 
     def on_get(self, req, res, contract_address=None, **kwargs):
-        LOG.info('v2.token.TransferHistory')
-
         session = req.context["session"]
 
         # 入力値チェック
@@ -442,7 +432,6 @@ class TransferApprovalHistory(BaseResource):
     """
 
     def on_get(self, req, res, contract_address=None, **kwargs):
-        LOG.info("v2.token.TransferApprovalHistory")
         db_session = req.context["session"]
 
         # Validation
@@ -532,8 +521,6 @@ class StraightBondTokens(BaseResource):
         self.web3 = Web3Wrapper()
 
     def on_get(self, req, res, **kwargs):
-        LOG.info('v2.token.StraightBondTokens')
-
         session = req.context["session"]
 
         if config.BOND_TOKEN_ENABLED is False:
@@ -634,8 +621,6 @@ class StraightBondTokenAddresses(BaseResource):
         self.web3 = Web3Wrapper()
 
     def on_get(self, req, res, **kwargs):
-        LOG.info('v2.token.StraightBondAddresses')
-
         session = req.context["session"]
 
         if config.BOND_TOKEN_ENABLED is False:
@@ -729,8 +714,6 @@ class StraightBondTokenDetails(BaseResource):
         self.web3 = Web3Wrapper()
 
     def on_get(self, req, res, contract_address=None, *args, **kwargs):
-        LOG.info('v2.token.StraightBondTokenDetails')
-
         if config.BOND_TOKEN_ENABLED is False:
             raise NotSupportedError(method='GET', url=req.path)
 
@@ -799,8 +782,6 @@ class ShareTokens(BaseResource):
         self.web3 = Web3Wrapper()
 
     def on_get(self, req, res, **kwargs):
-        LOG.info('v2.token.ShareTokens')
-
         session = req.context["session"]
 
         if config.SHARE_TOKEN_ENABLED is False:
@@ -904,8 +885,6 @@ class ShareTokenAddresses(BaseResource):
         self.web3 = Web3Wrapper()
 
     def on_get(self, req, res, **kwargs):
-        LOG.info('v2.token.ShareTokenAddresses')
-
         session = req.context["session"]
 
         if config.SHARE_TOKEN_ENABLED is False:
@@ -1000,8 +979,6 @@ class ShareTokenDetails(BaseResource):
         self.web3 = Web3Wrapper()
 
     def on_get(self, req, res, contract_address=None, **kwargs):
-        LOG.info('v2.token.ShareTokenDetails')
-
         if config.SHARE_TOKEN_ENABLED is False:
             raise NotSupportedError(method='GET', url=req.path)
 
@@ -1070,8 +1047,6 @@ class MembershipTokens(BaseResource):
         self.web3 = Web3Wrapper()
 
     def on_get(self, req, res, **kwargs):
-        LOG.info('v2.token.MembershipTokens')
-
         session = req.context["session"]
 
         if config.MEMBERSHIP_TOKEN_ENABLED is False:
@@ -1174,8 +1149,6 @@ class MembershipTokenAddresses(BaseResource):
         self.web3 = Web3Wrapper()
 
     def on_get(self, req, res, **kwargs):
-        LOG.info('v2.token.MembershipTokenAddresses')
-
         session = req.context["session"]
 
         if config.MEMBERSHIP_TOKEN_ENABLED is False:
@@ -1269,8 +1242,6 @@ class MembershipTokenDetails(BaseResource):
         self.web3 = Web3Wrapper()
 
     def on_get(self, req, res, contract_address=None, **kwargs):
-        LOG.info('v2.token.MembershipTokenDetails')
-
         if config.MEMBERSHIP_TOKEN_ENABLED is False:
             raise NotSupportedError(method='GET', url=req.path)
 
@@ -1339,8 +1310,6 @@ class CouponTokens(BaseResource):
         self.web3 = Web3Wrapper()
 
     def on_get(self, req, res, **kwargs):
-        LOG.info('v2.token.CouponTokens')
-
         session = req.context["session"]
 
         if config.COUPON_TOKEN_ENABLED is False:
@@ -1443,8 +1412,6 @@ class CouponTokenAddresses(BaseResource):
         self.web3 = Web3Wrapper()
 
     def on_get(self, req, res, **kwargs):
-        LOG.info('v2.token.CouponTokenAddresses')
-
         session = req.context["session"]
 
         if config.COUPON_TOKEN_ENABLED is False:
@@ -1539,8 +1506,6 @@ class CouponTokenDetails(BaseResource):
         self.web3 = Web3Wrapper()
 
     def on_get(self, req, res, contract_address=None, **kwargs):
-        LOG.info('v2.token.CouponTokenDetails')
-
         if config.COUPON_TOKEN_ENABLED is False:
             raise NotSupportedError(method='GET', url=req.path)
 

--- a/app/api/v2/token_abi.py
+++ b/app/api/v2/token_abi.py
@@ -34,9 +34,7 @@ class StraightBondABI(BaseResource):
     Endpoint: /v2/ABI/StraightBond
     """
 
-    def on_get(self, req, res):
-        LOG.info('v2.token_abi.StraightBondABI')
-
+    def on_get(self, req, res, **kwargs):
         if config.BOND_TOKEN_ENABLED is False:
             raise NotSupportedError(method='GET', url=req.path)
 
@@ -53,9 +51,7 @@ class ShareABI(BaseResource):
     Endpoint: /v2/ABI/Share
     """
 
-    def on_get(self, req, res):
-        LOG.info('v2.token_abi.ShareABI')
-
+    def on_get(self, req, res, **kwargs):
         if config.SHARE_TOKEN_ENABLED is False:
             raise NotSupportedError(method='GET', url=req.path)
 
@@ -72,9 +68,7 @@ class MembershipABI(BaseResource):
     Endpoint: /v2/ABI/Membership
     """
 
-    def on_get(self, req, res):
-        LOG.info('v2.token_abi.MembershipABI')
-
+    def on_get(self, req, res, **kwargs):
         if config.MEMBERSHIP_TOKEN_ENABLED is False:
             raise NotSupportedError(method='GET', url=req.path)
 
@@ -91,9 +85,7 @@ class CouponABI(BaseResource):
     Endpoint: /v2/ABI/Coupon
     """
 
-    def on_get(self, req, res):
-        LOG.info('v2.token_abi.CouponABI')
-
+    def on_get(self, req, res, **kwargs):
         if config.COUPON_TOKEN_ENABLED is False:
             raise NotSupportedError(method='GET', url=req.path)
 

--- a/app/api/v2/user.py
+++ b/app/api/v2/user.py
@@ -37,8 +37,6 @@ class PaymentAccount(BaseResource):
     Endpoint: /User/PaymentAccount
     """
     def on_get(self, req, res, **kwargs):
-        LOG.info("v2.user.PaymentAccount")
-
         request_json = PaymentAccount.validate(req)
 
         pg_contract = Contract.get_contract(
@@ -102,8 +100,6 @@ class PersonalInfo(BaseResource):
     Endpoint: /User/PersonalInfo
     """
     def on_get(self, req, res, **kwargs):
-        LOG.info("v2.user.PersonalInfo")
-
         # Validation
         request_json = PersonalInfo.validate(req)
 

--- a/app/api/v3/e2e_message.py
+++ b/app/api/v3/e2e_message.py
@@ -39,8 +39,6 @@ class EncryptionKey(BaseResource):
 
     def on_get(self, req, res, account_address=None, **kwargs):
         """Retrieve message encryption key"""
-        LOG.info("v3.e2e_message.EncryptionKey")
-
         # Validation
         try:
             account_address = to_checksum_address(account_address)

--- a/app/api/v3/events.py
+++ b/app/api/v3/events.py
@@ -35,10 +35,8 @@ web3 = Web3Wrapper()
 class E2EMessagingEvents(BaseResource):
     """E2EMessaging Event Logs"""
 
-    def on_get(self, req, res, account_address=None):
+    def on_get(self, req, res, account_address=None, **kwargs):
         """List all event logs"""
-        LOG.info("v3.events.E2EMassagingEvents")
-
         # Validate Request Data
         request_json = self.validate(req)
 
@@ -132,10 +130,8 @@ class E2EMessagingEvents(BaseResource):
 class IbetEscrowEvents(BaseResource):
     """IbetEscrow Event Logs"""
 
-    def on_get(self, req, res, account_address=None):
+    def on_get(self, req, res, account_address=None, **kwargs):
         """List all event logs"""
-        LOG.info("v3.events.IbetEscrowEvents")
-
         # Validate Request Data
         request_json = self.validate(req)
 
@@ -256,8 +252,6 @@ class IbetSecurityTokenEscrowEvents(BaseResource):
 
     def on_get(self, req, res, account_address=None, **kwargs):
         """List all event logs"""
-        LOG.info("v3.events.IbetSecurityTokenEscrowEvents")
-
         # Validate Request Data
         request_json = self.validate(req)
 

--- a/app/api/v3/notification.py
+++ b/app/api/v3/notification.py
@@ -40,9 +40,7 @@ class Notifications(BaseResource):
     Endpoint: /Notifications/
     """
 
-    def on_get(self, req, res):
-        LOG.info('v3.notification.Notifications(GET)')
-
+    def on_get(self, req, res, **kwargs):
         session = req.context["session"]
 
         # Validate Request Data
@@ -202,9 +200,7 @@ class NotificationsId(BaseResource):
     Endpoint: /Notifications/{id}
     """
 
-    def on_delete(self, req, res, id=None):
-        LOG.info('v3.notification.NotificationsId(DELETE)')
-
+    def on_delete(self, req, res, id=None, **kwargs):
         session = req.context["session"]
 
         # Get Notification

--- a/app/api/v3/position.py
+++ b/app/api/v3/position.py
@@ -529,7 +529,6 @@ class PositionShare(BasePositionShare):
     """
 
     def on_get(self, req, res, account_address=None, **kwargs):
-        LOG.info('v3.position.PositionShare(GET)')
         super().on_get_list(req, res, account_address)
 
 
@@ -542,7 +541,6 @@ class PositionStraightBond(BasePositionStraightBond):
     """
 
     def on_get(self, req, res, account_address=None, **kwargs):
-        LOG.info('v3.position.PositionStraightBond(GET)')
         super().on_get_list(req, res, account_address)
 
 
@@ -555,7 +553,6 @@ class PositionMembership(BasePositionMembership):
     """
 
     def on_get(self, req, res, account_address=None, **kwargs):
-        LOG.info('v3.position.PositionMembership(GET)')
         super().on_get_list(req, res, account_address)
 
 
@@ -568,7 +565,6 @@ class PositionCoupon(BasePositionCoupon):
     """
 
     def on_get(self, req, res, account_address=None, **kwargs):
-        LOG.info('v3.position.PositionCoupon(GET)')
         super().on_get_list(req, res, account_address)
 
 
@@ -581,7 +577,6 @@ class PositionShareContractAddress(BasePositionShare):
     """
 
     def on_get(self, req, res, account_address=None, contract_address=None):
-        LOG.info('v3.position.PositionShareContractAddress(GET)')
         super().on_get_from_contract_address(req, res, account_address, contract_address)
 
 
@@ -594,7 +589,6 @@ class PositionStraightBondContractAddress(BasePositionStraightBond):
     """
 
     def on_get(self, req, res, account_address=None, contract_address=None):
-        LOG.info('v3.position.PositionStraightBondContractAddress(StraightBond)')
         super().on_get_from_contract_address(req, res, account_address, contract_address)
 
 
@@ -607,7 +601,6 @@ class PositionMembershipContractAddress(BasePositionMembership):
     """
 
     def on_get(self, req, res, account_address=None, contract_address=None):
-        LOG.info('v3.position.PositionMembershipContractAddress(GET)')
         super().on_get_from_contract_address(req, res, account_address, contract_address)
 
 
@@ -620,5 +613,4 @@ class PositionCouponContractAddress(BasePositionCoupon):
     """
 
     def on_get(self, req, res, account_address=None, contract_address=None):
-        LOG.info('v3.position.PositionCouponContractAddress(GET)')
         super().on_get_from_contract_address(req, res, account_address, contract_address)

--- a/app/config.py
+++ b/app/config.py
@@ -88,6 +88,8 @@ DB_ECHO = True if CONFIG['database']['echo'] == 'yes' else False
 
 # ログ設定
 LOG_LEVEL = CONFIG['logging']['level']
+AUTH_LOGFILE = os.environ.get('AUTH_LOGFILE') or '/dev/stdout'
+ACCESS_LOGFILE = os.environ.get('ACCESS_LOGFILE') or '/dev/stdout'
 
 # 取扱トークン種別
 BOND_TOKEN_ENABLED = False if os.environ.get('BOND_TOKEN_ENABLED') == '0' else True

--- a/app/main.py
+++ b/app/main.py
@@ -16,14 +16,14 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 """
-
 import falcon
 
 from app import log
 from app.middleware import (
     JSONTranslator,
     DatabaseSessionManager,
-    CORSMiddleware
+    CORSMiddleware,
+    ResponseLoggerMiddleware
 )
 from app.database import (
     db_session,
@@ -190,7 +190,12 @@ class App(falcon.App):
 
 
 init_session()
-middleware = [JSONTranslator(), DatabaseSessionManager(db_session), CORSMiddleware()]
+middleware = [
+    JSONTranslator(),
+    DatabaseSessionManager(db_session),
+    CORSMiddleware(),
+    ResponseLoggerMiddleware()
+]
 application = App(middleware=middleware)
 application.req_options.strip_url_path_trailing_slash = True
 

--- a/app/middleware/__init__.py
+++ b/app/middleware/__init__.py
@@ -16,7 +16,7 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 """
-
 from .session_manager import DatabaseSessionManager
 from .translator import JSONTranslator
 from .cors import CORSMiddleware
+from .response_logger import ResponseLoggerMiddleware

--- a/app/middleware/response_logger.py
+++ b/app/middleware/response_logger.py
@@ -1,0 +1,44 @@
+"""
+Copyright BOOSTRY Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+import logging
+
+import falcon
+
+from app import config
+
+logging.basicConfig(level=config.LOG_LEVEL)
+ACCESS_LOG = logging.getLogger("ibet_wallet_access")
+ACCESS_LOG.propagate = False
+
+LOG_FORMAT = "[%(asctime)s] [%(process)d] [%(levelname)s] {} %(message)s"
+TIMESTAMP_FORMAT = "%Y-%m-%d %H:%M:%S %z"
+
+stream_handler_access = logging.StreamHandler(open(config.ACCESS_LOGFILE, "a"))
+formatter_access = logging.Formatter(LOG_FORMAT.format("[ACCESS-LOG]"), TIMESTAMP_FORMAT)
+stream_handler_access.setFormatter(formatter_access)
+ACCESS_LOG.addHandler(stream_handler_access)
+
+
+class ResponseLoggerMiddleware(object):
+    """Response Logger Middleware"""
+
+    def process_response(self, req: falcon.Request, res: falcon.Response, resource, req_succeeded):
+        if req.relative_uri != "/":
+            log_msg = f"{req.method} {req.relative_uri} {res.status}"
+            ACCESS_LOG.info(log_msg)


### PR DESCRIPTION
Changed the implementation method of API access logs.

Currently, the routing function performs `LOG.info` to output the access log, but this has been refactored to be performed by the falcon middleware.
The log output by the new method differs from the current method in that it is a response log.

In case of normal response
```
[2022-07-07 19:02:05 +0900] [82957] [INFO] [ACCESS-LOG] GET /v2/ABI/Coupon 200 OK
```

In case of error response
```
[2022-07-07 19:02:10 +0900] [82957] [INFO] [ACCESS-LOG] GET /v2/ABI/Coupooon 404 Not Found
```