### PR TITLE
feat: add response time to response log

### DIFF
--- a/app/middleware/response_logger.py
+++ b/app/middleware/response_logger.py
@@ -17,6 +17,7 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 import logging
+from datetime import datetime
 
 import falcon
 
@@ -38,7 +39,11 @@ ACCESS_LOG.addHandler(stream_handler_access)
 class ResponseLoggerMiddleware(object):
     """Response Logger Middleware"""
 
+    def process_request(self, req, res):
+        req.context["request_start_time"] = datetime.utcnow()
+
     def process_response(self, req: falcon.Request, res: falcon.Response, resource, req_succeeded):
         if req.relative_uri != "/":
-            log_msg = f"{req.method} {req.relative_uri} {res.status}"
+            response_time = (datetime.utcnow() - req.context["request_start_time"]).total_seconds()
+            log_msg = f"{req.method} {req.relative_uri} {res.status} ({response_time}sec)"
             ACCESS_LOG.info(log_msg)


### PR DESCRIPTION
I have made improvements to the response log.
I added API response times to the response log to make it easier to analyze API response performance.

> レスポンスログの改善を行いました。APIの応答性能の分析が簡単に行えるようにするために、レスポンスログにAPI応答時間を追加しました。

#### Sample log
```
[2022-07-23 23:57:32 +0900] [16452] [INFO] [ACCESS-LOG] GET /v1/Accounts 200 OK (0.141566sec)
```
