### PR TITLE
feat: token notification type(`ApplyTransfer`/`CancelTransfer`/`ApproveTransfer`)

### DIFF
--- a/app/api/v3/notification.py
+++ b/app/api/v3/notification.py
@@ -140,7 +140,10 @@ class Notifications(BaseResource):
                     "SellAgreement",
                     "SellSettlementOK",
                     "SellSettlementNG",
-                    "Transfer"
+                    "Transfer",
+                    "ApplyForTransfer",
+                    "ApproveTransfer",
+                    "CancelTransfer"
                 ],
             },
             "priority": {

--- a/app/config.py
+++ b/app/config.py
@@ -151,3 +151,6 @@ BASIC_AUTH_PASS = os.environ.get('BASIC_AUTH_PASS')
 
 # トークン関連通知
 TOKEN_NOTIFICATION_ENABLED = False if os.environ.get('TOKEN_NOTIFICATION_ENABLED') == '0' else True
+
+# Exchange関連通知
+EXCHANGE_NOTIFICATION_ENABLED = False if os.environ.get("EXCHANGE_NOTIFICATION_ENABLED") == "0" else True

--- a/app/model/db/notification.py
+++ b/app/model/db/notification.py
@@ -145,3 +145,6 @@ class NotificationType(Enum):
     SELL_SETTLEMENT_OK = "SellSettlementOK"
     SELL_SETTLEMENT_NG = "SellSettlementNG"
     TRANSFER = "Transfer"
+    APPLY_FOR_TRANSFER = "ApplyForTransfer"
+    APPROVE_TRANSFER = "ApproveTransfer"
+    CANCEL_TRANSFER = "CancelTransfer"

--- a/bin/healthcheck_processor_notification.sh
+++ b/bin/healthcheck_processor_notification.sh
@@ -23,27 +23,29 @@ if [ "${TOKEN_NOTIFICATION_ENABLED}" = 1 ]; then
   PROC_LIST="${PROC_LIST} batch/processor_Notifications_Token.py"
 fi
 
-if [ "${BOND_TOKEN_ENABLED}" = 1 ]; then
-  if [ ! -z "${IBET_SB_EXCHANGE_CONTRACT_ADDRESS}" ]; then
-    PROC_LIST="${PROC_LIST} batch/processor_Notifications_Bond_Exchange.py"
+if [ -z "$EXCHANGE_NOTIFICATION_ENABLED" ] || [ "$EXCHANGE_NOTIFICATION_ENABLED" -ne 0 ]; then
+  if [ "${BOND_TOKEN_ENABLED}" = 1 ]; then
+    if [ ! -z "${IBET_SB_EXCHANGE_CONTRACT_ADDRESS}" ]; then
+      PROC_LIST="${PROC_LIST} batch/processor_Notifications_Bond_Exchange.py"
+    fi
   fi
-fi
 
-if [ "${SHARE_TOKEN_ENABLED}" = 1 ]; then
-  if [ ! -z "${IBET_SHARE_EXCHANGE_CONTRACT_ADDRESS}" ]; then
-    PROC_LIST="${PROC_LIST} batch/processor_Notifications_Share_Exchange.py"
+  if [ "${SHARE_TOKEN_ENABLED}" = 1 ]; then
+    if [ ! -z "${IBET_SHARE_EXCHANGE_CONTRACT_ADDRESS}" ]; then
+      PROC_LIST="${PROC_LIST} batch/processor_Notifications_Share_Exchange.py"
+    fi
   fi
-fi
 
-if [ "${MEMBERSHIP_TOKEN_ENABLED}" = 1 ]; then
-  if [ ! -z "${IBET_MEMBERSHIP_EXCHANGE_CONTRACT_ADDRESS}" ]; then
-    PROC_LIST="${PROC_LIST} batch/processor_Notifications_Membership_Exchange.py"
+  if [ "${MEMBERSHIP_TOKEN_ENABLED}" = 1 ]; then
+    if [ ! -z "${IBET_MEMBERSHIP_EXCHANGE_CONTRACT_ADDRESS}" ]; then
+      PROC_LIST="${PROC_LIST} batch/processor_Notifications_Membership_Exchange.py"
+    fi
   fi
-fi
 
-if [ "${COUPON_TOKEN_ENABLED}" = 1 ]; then
-  if [ ! -z "${IBET_CP_EXCHANGE_CONTRACT_ADDRESS}" ]; then
-    PROC_LIST="${PROC_LIST} batch/processor_Notifications_Coupon_Exchange.py"
+  if [ "${COUPON_TOKEN_ENABLED}" = 1 ]; then
+    if [ ! -z "${IBET_CP_EXCHANGE_CONTRACT_ADDRESS}" ]; then
+      PROC_LIST="${PROC_LIST} batch/processor_Notifications_Coupon_Exchange.py"
+    fi
   fi
 fi
 

--- a/bin/healthcheck_processor_notification.sh
+++ b/bin/healthcheck_processor_notification.sh
@@ -23,7 +23,7 @@ if [ "${TOKEN_NOTIFICATION_ENABLED}" = 1 ]; then
   PROC_LIST="${PROC_LIST} batch/processor_Notifications_Token.py"
 fi
 
-if [ -z "$EXCHANGE_NOTIFICATION_ENABLED" ] || [ "$EXCHANGE_NOTIFICATION_ENABLED" -ne 0 ]; then
+if [ "${EXCHANGE_NOTIFICATION_ENABLED}" = 1 ]; then
   if [ "${BOND_TOKEN_ENABLED}" = 1 ]; then
     if [ ! -z "${IBET_SB_EXCHANGE_CONTRACT_ADDRESS}" ]; then
       PROC_LIST="${PROC_LIST} batch/processor_Notifications_Bond_Exchange.py"

--- a/bin/run_processor_notification.sh
+++ b/bin/run_processor_notification.sh
@@ -27,7 +27,7 @@ if [ "$TOKEN_NOTIFICATION_ENABLED" = 1 ]; then
   python batch/processor_Notifications_Token.py &
 fi
 
-if [ -z "$EXCHANGE_NOTIFICATION_ENABLED" ] || [ "$EXCHANGE_NOTIFICATION_ENABLED" -ne 0 ]; then
+if [ "$EXCHANGE_NOTIFICATION_ENABLED" = 1 ]; then
   if [ "$BOND_TOKEN_ENABLED" = 1 ]; then
     if [ ! -z "${IBET_SB_EXCHANGE_CONTRACT_ADDRESS}" ]; then
       python batch/processor_Notifications_Bond_Exchange.py &

--- a/bin/run_processor_notification.sh
+++ b/bin/run_processor_notification.sh
@@ -20,33 +20,36 @@
 # shellcheck disable=SC1090
 source ~/.bash_profile
 
+# shellcheck disable=SC2164
 cd /app/ibet-Wallet-API
 
 if [ "$TOKEN_NOTIFICATION_ENABLED" = 1 ]; then
   python batch/processor_Notifications_Token.py &
 fi
 
-if [ "$BOND_TOKEN_ENABLED" = 1 ]; then
-  if [ ! -z "${IBET_SB_EXCHANGE_CONTRACT_ADDRESS}" ]; then
-    python batch/processor_Notifications_Bond_Exchange.py &
+if [ -z "$EXCHANGE_NOTIFICATION_ENABLED" ] || [ "$EXCHANGE_NOTIFICATION_ENABLED" -ne 0 ]; then
+  if [ "$BOND_TOKEN_ENABLED" = 1 ]; then
+    if [ ! -z "${IBET_SB_EXCHANGE_CONTRACT_ADDRESS}" ]; then
+      python batch/processor_Notifications_Bond_Exchange.py &
+    fi
   fi
-fi
 
-if [ "$SHARE_TOKEN_ENABLED" = 1 ]; then
-  if [ ! -z "${IBET_SHARE_EXCHANGE_CONTRACT_ADDRESS}" ]; then
-    python batch/processor_Notifications_Share_Exchange.py &
+  if [ "$SHARE_TOKEN_ENABLED" = 1 ]; then
+    if [ ! -z "${IBET_SHARE_EXCHANGE_CONTRACT_ADDRESS}" ]; then
+      python batch/processor_Notifications_Share_Exchange.py &
+    fi
   fi
-fi
 
-if [ "$MEMBERSHIP_TOKEN_ENABLED" = 1 ]; then
-  if [ ! -z "${IBET_MEMBERSHIP_EXCHANGE_CONTRACT_ADDRESS}" ]; then
-    python batch/processor_Notifications_Membership_Exchange.py &
+  if [ "$MEMBERSHIP_TOKEN_ENABLED" = 1 ]; then
+    if [ ! -z "${IBET_MEMBERSHIP_EXCHANGE_CONTRACT_ADDRESS}" ]; then
+      python batch/processor_Notifications_Membership_Exchange.py &
+    fi
   fi
-fi
 
-if [ "$COUPON_TOKEN_ENABLED" = 1 ]; then
-  if [ ! -z "${IBET_CP_EXCHANGE_CONTRACT_ADDRESS}" ]; then
-    python batch/processor_Notifications_Coupon_Exchange.py &
+  if [ "$COUPON_TOKEN_ENABLED" = 1 ]; then
+    if [ ! -z "${IBET_CP_EXCHANGE_CONTRACT_ADDRESS}" ]; then
+      python batch/processor_Notifications_Coupon_Exchange.py &
+    fi
   fi
 fi
 

--- a/docs/ibet_wallet_api_v2.yaml
+++ b/docs/ibet_wallet_api_v2.yaml
@@ -4868,6 +4868,9 @@ paths:
                               SellSettlementOK,
                               SellSettlementNG,
                               Transfer,
+                              ApplyForTransfer,
+                              ApproveTransfer,
+                              CancelTransfer
                             ]
                         id:
                           type: string
@@ -4902,7 +4905,7 @@ paths:
                             token_type:
                               type: string
                               enum:
-                                [IbetStraightBond, IbetMembership, IbetCoupon]
+                                [IbetStraightBond, IbetShare, IbetMembership, IbetCoupon]
                         account_address:
                           type: string
                         sort_id:
@@ -4969,6 +4972,9 @@ paths:
                         SellSettlementOK,
                         SellSettlementNG,
                         Transfer,
+                        ApplyForTransfer,
+                        ApproveTransfer,
+                        CancelTransfer
                       ]
                   id:
                     type: string

--- a/docs/ibet_wallet_api_v3.yaml
+++ b/docs/ibet_wallet_api_v3.yaml
@@ -1059,7 +1059,10 @@ paths:
             "SellAgreement",
             "SellSettlementOK",
             "SellSettlementNG",
-            "Transfer"
+            "Transfer",
+            "ApplyForTransfer",
+            "ApproveTransfer",
+            "CancelTransfer"
           ]
         - name: priority
           in: query
@@ -1123,7 +1126,10 @@ paths:
                             SellAgreement,
                             SellSettlementOK,
                             SellSettlementNG,
-                            Transfer
+                            Transfer,
+                            ApplyForTransfer,
+                            ApproveTransfer,
+                            CancelTransfer
                           ]
                         id:
                           type: string
@@ -1158,7 +1164,7 @@ paths:
                               type: string
                             token_type:
                               type: string
-                              enum: [IbetStraightBond,IbetMembership,IbetCoupon]
+                              enum: [IbetStraightBond, IbetShare, IbetMembership, IbetCoupon]
                         account_address:
                           type: string
                         sort_id:

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -29,6 +29,9 @@ elif [ "${RUN_MODE}" == "indexer" ]; then
   ./bin/healthcheck_indexer.sh
 elif [ "${RUN_MODE}" == "processor_notification" ]; then
   ./bin/healthcheck_processor_notification.sh
+elif [ "${RUN_MODE}" == "batch" ]; then
+  ./bin/healthcheck_indexer.sh || exit 1
+  ./bin/healthcheck_processor_notification.sh
 else
   echo "RUN_MODE is invalid value." >&2
   exit 1

--- a/run.sh
+++ b/run.sh
@@ -29,6 +29,10 @@ elif [ "${RUN_MODE}" == "indexer" ]; then
   ./bin/run_indexer.sh
 elif [ "${RUN_MODE}" == "processor_notification" ]; then
   ./bin/run_processor_notification.sh
+elif [ "${RUN_MODE}" == "batch" ]; then
+  ./bin/run_indexer.sh &
+  ./bin/run_processor_notification.sh &
+  tail -f /dev/null
 else
   echo "RUN_MODE is invalid value." >&2
   exit 1

--- a/tests/batch/processor_Notifications_Token_test.py
+++ b/tests/batch/processor_Notifications_Token_test.py
@@ -44,8 +44,10 @@ from tests.contract_modules import (
     register_share_list,
     share_set_transfer_approval_required,
     share_apply_for_transfer,
-    share_transfer_to_exchange,
-    register_personalinfo, transfer_token, transfer_share_token, share_approve_transfer, share_cancel_transfer
+    register_personalinfo,
+    transfer_share_token,
+    share_approve_transfer,
+    share_cancel_transfer
 )
 
 if TYPE_CHECKING:

--- a/tests/batch/processor_Notifications_Token_test.py
+++ b/tests/batch/processor_Notifications_Token_test.py
@@ -16,11 +16,13 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 """
+from __future__ import annotations
 import pytest
 from unittest import mock
 from unittest.mock import MagicMock
 from importlib import reload
-
+from sqlalchemy.orm import Session
+from typing import Callable, TYPE_CHECKING
 from web3 import Web3
 from web3.middleware import geth_poa_middleware
 
@@ -31,20 +33,30 @@ from app.model.db import (
     Listing
 )
 from tests.account_config import eth_account
+from tests.conftest import SharedContract, DeployedContract, TestAccount
 from tests.contract_modules import (
     issue_coupon_token,
     coupon_register_list,
     transfer_coupon_token,
     coupon_transfer_to_exchange,
-    coupon_withdraw_from_exchange
+    coupon_withdraw_from_exchange,
+    issue_share_token,
+    register_share_list,
+    share_set_transfer_approval_required,
+    share_apply_for_transfer,
+    share_transfer_to_exchange,
+    register_personalinfo, transfer_token, transfer_share_token, share_approve_transfer, share_cancel_transfer
 )
+
+if TYPE_CHECKING:
+    from batch.processor_Notifications_Token import Watcher
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
 web3.middleware_onion.inject(geth_poa_middleware, layer=0)
 
 
 @pytest.fixture(scope="function")
-def watcher_factory(session, shared_contract):
+def watcher_factory(session: Session, shared_contract: SharedContract) -> Callable[[str], Watcher]:
     def _watcher(cls_name):
         config.TOKEN_LIST_CONTRACT_ADDRESS = shared_contract["TokenList"]["address"]
 
@@ -60,7 +72,7 @@ def watcher_factory(session, shared_contract):
     return _watcher
 
 
-def issue_token(issuer, exchange, token_list, session):
+def prepare_coupon_token(issuer: TestAccount, exchange: DeployedContract, token_list: DeployedContract, session: Session):
     # Issue token
     args = {
         'name': 'テストクーポン',
@@ -90,6 +102,44 @@ def issue_token(issuer, exchange, token_list, session):
     return token
 
 
+def prepare_share_token(issuer: TestAccount,
+                        exchange: DeployedContract,
+                        token_list: DeployedContract,
+                        personal_info: DeployedContract,
+                        session: Session):
+    # Issue token
+    args = {
+        "name": "テスト株式",
+        "symbol": "SHARE",
+        "tradableExchange": exchange["address"],
+        "personalInfoAddress": personal_info["address"],
+        "totalSupply": 1000000,
+        "issuePrice": 10000,
+        "principalValue": 10000,
+        "dividends": 101,
+        "dividendRecordDate": "20200909",
+        "dividendPaymentDate": "20201001",
+        "cancellationDate": "20210101",
+        "contactInformation": "問い合わせ先",
+        "privacyPolicy": "プライバシーポリシー",
+        "memo": "メモ",
+        "transferable": True
+    }
+    token = issue_share_token(issuer, args)
+    register_share_list(issuer, token, token_list)
+
+    _listing = Listing()
+    _listing.token_address = token["address"]
+    _listing.is_public = True
+    _listing.max_holding_quantity = 1000000
+    _listing.max_sell_amount = 1000000
+    _listing.owner_address = issuer["account_address"]
+    session.add(_listing)
+    session.commit()
+
+    return token
+
+
 class TestWatchTransfer:
     issuer = eth_account["issuer"]
     trader = eth_account["trader"]
@@ -106,7 +156,7 @@ class TestWatchTransfer:
 
         exchange_contract = shared_contract["IbetCouponExchange"]
         token_list_contract = shared_contract["TokenList"]
-        token = issue_token(self.issuer, exchange_contract, token_list_contract, session)
+        token = prepare_coupon_token(self.issuer, exchange_contract, token_list_contract, session)
 
         # Transfer
         transfer_coupon_token(self.issuer, token, self.trader["account_address"], 100)
@@ -143,7 +193,7 @@ class TestWatchTransfer:
 
         exchange_contract = shared_contract["IbetCouponExchange"]
         token_list_contract = shared_contract["TokenList"]
-        token = issue_token(self.issuer, exchange_contract, token_list_contract, session)
+        token = prepare_coupon_token(self.issuer, exchange_contract, token_list_contract, session)
 
         # Transfer
         transfer_coupon_token(self.issuer, token, self.trader["account_address"], 100)
@@ -200,7 +250,7 @@ class TestWatchTransfer:
 
         exchange_contract = shared_contract["IbetCouponExchange"]
         token_list_contract = shared_contract["TokenList"]
-        token = issue_token(self.issuer, exchange_contract, token_list_contract, session)
+        token = prepare_coupon_token(self.issuer, exchange_contract, token_list_contract, session)
 
         # Not Transfer
         # Run target process
@@ -217,7 +267,7 @@ class TestWatchTransfer:
 
         exchange_contract = shared_contract["IbetCouponExchange"]
         token_list_contract = shared_contract["TokenList"]
-        token = issue_token(self.issuer, exchange_contract, token_list_contract, session)
+        token = prepare_coupon_token(self.issuer, exchange_contract, token_list_contract, session)
 
         # Transfer to DEX
         coupon_transfer_to_exchange(
@@ -277,7 +327,549 @@ class TestWatchTransfer:
 
         exchange_contract = shared_contract["IbetCouponExchange"]
         token_list_contract = shared_contract["TokenList"]
-        issue_token(self.issuer, exchange_contract, token_list_contract, session)
+        prepare_coupon_token(self.issuer, exchange_contract, token_list_contract, session)
+
+        # Run target process
+        watcher.loop()
+
+        # Assertion
+        _notification = session.query(Notification).order_by(Notification.created).first()
+        assert _notification is None
+
+
+class TestWatchApplyForTransfer:
+    issuer = eth_account["issuer"]
+    trader = eth_account["trader"]
+    trader2 = eth_account["deployer"]
+
+    ###########################################################################
+    # Normal Case
+    ###########################################################################
+
+    # <Normal_1>
+    # Single event logs
+    def test_normal_1(self, watcher_factory, session, shared_contract, mocked_company_list):
+        watcher = watcher_factory("WatchApplyForTransfer")
+
+        exchange_contract = shared_contract["IbetShareExchange"]
+        token_list_contract = shared_contract["TokenList"]
+        personal_info_contract = shared_contract["PersonalInfo"]
+        token = prepare_share_token(self.issuer, exchange_contract, token_list_contract, personal_info_contract, session)
+
+        register_personalinfo(self.trader, personal_info_contract)
+        register_personalinfo(self.trader2, personal_info_contract)
+
+        transfer_share_token(self.issuer, self.trader, token, 100)
+        share_set_transfer_approval_required(self.issuer, token, True)
+
+        share_apply_for_transfer(self.trader, token, self.trader2, 100, "TEST_DATA")
+
+        # Run target process
+        watcher.loop()
+
+        # Assertion
+        block_number = web3.eth.block_number
+        _notification = session.query(Notification).order_by(Notification.created).first()
+        assert _notification.notification_id == "0x{:012x}{:06x}{:06x}{:02x}".format(block_number, 0, 0, 0)
+        assert _notification.notification_type == NotificationType.APPLY_FOR_TRANSFER.value
+        assert _notification.priority == 0
+        assert _notification.address == self.trader2["account_address"]
+        assert _notification.block_timestamp is not None
+        assert _notification.args == {
+            "index": 0,
+            "from": self.trader["account_address"],
+            "to": self.trader2["account_address"],
+            "value": 100,
+            "data": "TEST_DATA"
+        }
+        assert _notification.metainfo == {
+            "company_name": "株式会社DEMO",
+            "token_address": token["address"],
+            "token_name": "テスト株式",
+            "exchange_address": "",
+            "token_type": "IbetShare"
+        }
+
+    # <Normal_2>
+    # Multi event logs
+    def test_normal_2(self, watcher_factory, session, shared_contract, mocked_company_list):
+        watcher = watcher_factory("WatchApplyForTransfer")
+
+        exchange_contract = shared_contract["IbetShareExchange"]
+        token_list_contract = shared_contract["TokenList"]
+        personal_info_contract = shared_contract["PersonalInfo"]
+
+        token = prepare_share_token(self.issuer, exchange_contract, token_list_contract, personal_info_contract, session)
+
+        register_personalinfo(self.trader, personal_info_contract)
+        register_personalinfo(self.trader2, personal_info_contract)
+
+        transfer_share_token(self.issuer, self.trader, token, 100)
+        share_set_transfer_approval_required(self.issuer, token, True)
+
+        # Transfer
+        share_apply_for_transfer(self.trader, token, self.trader2, 10, "TEST_DATA1")
+        share_apply_for_transfer(self.trader, token, self.trader2, 20, "TEST_DATA2")
+
+        # Run target process
+        watcher.loop()
+
+        # Assertion
+        block_number = web3.eth.block_number
+        _notification_list = session.query(Notification).order_by(Notification.created).all()
+        assert len(_notification_list) == 2
+        _notification = _notification_list[0]
+        assert _notification.notification_id == "0x{:012x}{:06x}{:06x}{:02x}".format(block_number - 1, 0, 0, 0)
+        assert _notification.notification_type == NotificationType.APPLY_FOR_TRANSFER.value
+        assert _notification.priority == 0
+        assert _notification.address == self.trader2["account_address"]
+        assert _notification.block_timestamp is not None
+        assert _notification.args == {
+            "index": 0,
+            "from": self.trader["account_address"],
+            "to": self.trader2["account_address"],
+            "value": 10,
+            "data": "TEST_DATA1"
+        }
+        assert _notification.metainfo == {
+            "company_name": "株式会社DEMO",
+            "token_address": token["address"],
+            "token_name": "テスト株式",
+            "exchange_address": "",
+            "token_type": "IbetShare"
+        }
+        _notification = _notification_list[1]
+        assert _notification.notification_id == "0x{:012x}{:06x}{:06x}{:02x}".format(block_number, 0, 0, 0)
+        assert _notification.notification_type == NotificationType.APPLY_FOR_TRANSFER.value
+        assert _notification.priority == 0
+        assert _notification.address == self.trader2["account_address"]
+        assert _notification.block_timestamp is not None
+        assert _notification.args == {
+            "index": 1,
+            "from": self.trader["account_address"],
+            "to": self.trader2["account_address"],
+            "value": 20,
+            "data": "TEST_DATA2"
+        }
+        assert _notification.metainfo == {
+            "company_name": "株式会社DEMO",
+            "token_address": token["address"],
+            "token_name": "テスト株式",
+            "exchange_address": "",
+            "token_type": "IbetShare"
+        }
+
+    # <Normal_3>
+    # No event logs
+    def test_normal_3(self, watcher_factory, session, shared_contract, mocked_company_list):
+        watcher = watcher_factory("WatchApplyForTransfer")
+
+        exchange_contract = shared_contract["IbetShareExchange"]
+        token_list_contract = shared_contract["TokenList"]
+        personal_info_contract = shared_contract["PersonalInfo"]
+
+        token = prepare_share_token(self.issuer, exchange_contract, token_list_contract, personal_info_contract, session)
+
+        register_personalinfo(self.trader, personal_info_contract)
+        register_personalinfo(self.trader2, personal_info_contract)
+
+        transfer_share_token(self.issuer, self.trader, token, 100)
+        share_set_transfer_approval_required(self.issuer, token, True)
+
+        # Not Transfer
+        # Run target process
+        watcher.loop()
+
+        # Assertion
+        _notification = session.query(Notification).order_by(Notification.created).first()
+        assert _notification is None
+
+    ###########################################################################
+    # Error Case
+    ###########################################################################
+
+    # <Error_1>
+    # Error occur
+    @mock.patch("web3.contract.ContractEvent.getLogs", MagicMock(side_effect=Exception()))
+    def test_error_1(self, watcher_factory, session, shared_contract, mocked_company_list):
+        watcher = watcher_factory("WatchApplyForTransfer")
+
+        exchange_contract = shared_contract["IbetShareExchange"]
+        token_list_contract = shared_contract["TokenList"]
+        personal_info_contract = shared_contract["PersonalInfo"]
+
+        token = prepare_share_token(self.issuer, exchange_contract, token_list_contract, personal_info_contract, session)
+
+        register_personalinfo(self.trader, personal_info_contract)
+        register_personalinfo(self.trader2, personal_info_contract)
+
+        transfer_share_token(self.issuer, self.trader, token, 100)
+        share_set_transfer_approval_required(self.issuer, token, True)
+
+        # Transfer
+        share_apply_for_transfer(self.trader, token, self.trader2, 10, "TEST_DATA1")
+
+        # Run target process
+        watcher.loop()
+
+        # Assertion
+        _notification = session.query(Notification).order_by(Notification.created).first()
+        assert _notification is None
+
+
+class TestWatchApproveTransfer:
+    issuer = eth_account["issuer"]
+    trader = eth_account["trader"]
+    trader2 = eth_account["deployer"]
+
+    ###########################################################################
+    # Normal Case
+    ###########################################################################
+
+    # <Normal_1>
+    # Single event logs
+    def test_normal_1(self, watcher_factory, session, shared_contract, mocked_company_list):
+        watcher = watcher_factory("WatchApproveTransfer")
+
+        exchange_contract = shared_contract["IbetShareExchange"]
+        token_list_contract = shared_contract["TokenList"]
+        personal_info_contract = shared_contract["PersonalInfo"]
+        token = prepare_share_token(self.issuer, exchange_contract, token_list_contract, personal_info_contract, session)
+
+        register_personalinfo(self.trader, personal_info_contract)
+        register_personalinfo(self.trader2, personal_info_contract)
+
+        transfer_share_token(self.issuer, self.trader, token, 100)
+        share_set_transfer_approval_required(self.issuer, token, True)
+
+        share_apply_for_transfer(self.trader, token, self.trader2, 100, "TEST_DATA")
+        share_approve_transfer(self.issuer, token, 0, "TEST_DATA")
+
+        # Run target process
+        watcher.loop()
+
+        # Assertion
+        block_number = web3.eth.block_number
+        _notification = session.query(Notification).order_by(Notification.created).first()
+        assert _notification.notification_id == "0x{:012x}{:06x}{:06x}{:02x}".format(block_number, 0, 0, 0)
+        assert _notification.notification_type == NotificationType.APPROVE_TRANSFER.value
+        assert _notification.priority == 0
+        assert _notification.address == self.trader["account_address"]
+        assert _notification.block_timestamp is not None
+        assert _notification.args == {
+            "index": 0,
+            "from": self.trader["account_address"],
+            "to": self.trader2["account_address"],
+            "data": "TEST_DATA"
+        }
+        assert _notification.metainfo == {
+            "company_name": "株式会社DEMO",
+            "token_address": token["address"],
+            "token_name": "テスト株式",
+            "exchange_address": "",
+            "token_type": "IbetShare"
+        }
+
+    # <Normal_2>
+    # Multi event logs
+    def test_normal_2(self, watcher_factory, session, shared_contract, mocked_company_list):
+        watcher = watcher_factory("WatchApproveTransfer")
+
+        exchange_contract = shared_contract["IbetShareExchange"]
+        token_list_contract = shared_contract["TokenList"]
+        personal_info_contract = shared_contract["PersonalInfo"]
+
+        token = prepare_share_token(self.issuer, exchange_contract, token_list_contract, personal_info_contract, session)
+
+        register_personalinfo(self.trader, personal_info_contract)
+        register_personalinfo(self.trader2, personal_info_contract)
+
+        transfer_share_token(self.issuer, self.trader, token, 100)
+        share_set_transfer_approval_required(self.issuer, token, True)
+
+        # Transfer
+        share_apply_for_transfer(self.trader, token, self.trader2, 10, "TEST_DATA1")
+        share_apply_for_transfer(self.trader, token, self.trader2, 20, "TEST_DATA2")
+        share_approve_transfer(self.issuer, token, 0, "TEST_DATA1")
+        share_approve_transfer(self.issuer, token, 1, "TEST_DATA2")
+
+        # Run target process
+        watcher.loop()
+
+        # Assertion
+        block_number = web3.eth.block_number
+        _notification_list = session.query(Notification).order_by(Notification.created).all()
+        assert len(_notification_list) == 2
+        _notification = _notification_list[0]
+        assert _notification.notification_id == "0x{:012x}{:06x}{:06x}{:02x}".format(block_number - 1, 0, 0, 0)
+        assert _notification.notification_type == NotificationType.APPROVE_TRANSFER.value
+        assert _notification.priority == 0
+        assert _notification.address == self.trader["account_address"]
+        assert _notification.block_timestamp is not None
+        assert _notification.args == {
+            "index": 0,
+            "from": self.trader["account_address"],
+            "to": self.trader2["account_address"],
+            "data": "TEST_DATA1"
+        }
+        assert _notification.metainfo == {
+            "company_name": "株式会社DEMO",
+            "token_address": token["address"],
+            "token_name": "テスト株式",
+            "exchange_address": "",
+            "token_type": "IbetShare"
+        }
+        _notification = _notification_list[1]
+        assert _notification.notification_id == "0x{:012x}{:06x}{:06x}{:02x}".format(block_number, 0, 0, 0)
+        assert _notification.notification_type == NotificationType.APPROVE_TRANSFER.value
+        assert _notification.priority == 0
+        assert _notification.address == self.trader["account_address"]
+        assert _notification.block_timestamp is not None
+        assert _notification.args == {
+            "index": 1,
+            "from": self.trader["account_address"],
+            "to": self.trader2["account_address"],
+            "data": "TEST_DATA2"
+        }
+        assert _notification.metainfo == {
+            "company_name": "株式会社DEMO",
+            "token_address": token["address"],
+            "token_name": "テスト株式",
+            "exchange_address": "",
+            "token_type": "IbetShare"
+        }
+
+    # <Normal_3>
+    # No event logs
+    def test_normal_3(self, watcher_factory, session, shared_contract, mocked_company_list):
+        watcher = watcher_factory("WatchApplyForTransfer")
+
+        exchange_contract = shared_contract["IbetShareExchange"]
+        token_list_contract = shared_contract["TokenList"]
+        personal_info_contract = shared_contract["PersonalInfo"]
+
+        token = prepare_share_token(self.issuer, exchange_contract, token_list_contract, personal_info_contract, session)
+
+        register_personalinfo(self.trader, personal_info_contract)
+        register_personalinfo(self.trader2, personal_info_contract)
+
+        transfer_share_token(self.issuer, self.trader, token, 100)
+        share_set_transfer_approval_required(self.issuer, token, True)
+
+        # Not Transfer
+        # Run target process
+        watcher.loop()
+
+        # Assertion
+        _notification = session.query(Notification).order_by(Notification.created).first()
+        assert _notification is None
+
+    ###########################################################################
+    # Error Case
+    ###########################################################################
+
+    # <Error_1>
+    # Error occur
+    @mock.patch("web3.contract.ContractEvent.getLogs", MagicMock(side_effect=Exception()))
+    def test_error_1(self, watcher_factory, session, shared_contract, mocked_company_list):
+        watcher = watcher_factory("WatchApplyForTransfer")
+
+        exchange_contract = shared_contract["IbetShareExchange"]
+        token_list_contract = shared_contract["TokenList"]
+        personal_info_contract = shared_contract["PersonalInfo"]
+
+        token = prepare_share_token(self.issuer, exchange_contract, token_list_contract, personal_info_contract, session)
+
+        register_personalinfo(self.trader, personal_info_contract)
+        register_personalinfo(self.trader2, personal_info_contract)
+
+        transfer_share_token(self.issuer, self.trader, token, 100)
+        share_set_transfer_approval_required(self.issuer, token, True)
+
+        # Transfer
+        share_apply_for_transfer(self.trader, token, self.trader2, 10, "TEST_DATA1")
+        share_approve_transfer(self.issuer, token, 0, "TEST_DATA1")
+
+        # Run target process
+        watcher.loop()
+
+        # Assertion
+        _notification = session.query(Notification).order_by(Notification.created).first()
+        assert _notification is None
+
+
+class TestWatchCancelTransfer:
+    issuer = eth_account["issuer"]
+    trader = eth_account["trader"]
+    trader2 = eth_account["deployer"]
+
+    ###########################################################################
+    # Normal Case
+    ###########################################################################
+
+    # <Normal_1>
+    # Single event logs
+    def test_normal_1(self, watcher_factory, session, shared_contract, mocked_company_list):
+        watcher = watcher_factory("WatchCancelTransfer")
+
+        exchange_contract = shared_contract["IbetShareExchange"]
+        token_list_contract = shared_contract["TokenList"]
+        personal_info_contract = shared_contract["PersonalInfo"]
+        token = prepare_share_token(self.issuer, exchange_contract, token_list_contract, personal_info_contract, session)
+
+        register_personalinfo(self.trader, personal_info_contract)
+        register_personalinfo(self.trader2, personal_info_contract)
+
+        transfer_share_token(self.issuer, self.trader, token, 100)
+        share_set_transfer_approval_required(self.issuer, token, True)
+
+        share_apply_for_transfer(self.trader, token, self.trader2, 100, "TEST_DATA")
+        share_cancel_transfer(self.issuer, token, 0, "TEST_DATA")
+
+        # Run target process
+        watcher.loop()
+
+        # Assertion
+        block_number = web3.eth.block_number
+        _notification = session.query(Notification).order_by(Notification.created).first()
+        assert _notification.notification_id == "0x{:012x}{:06x}{:06x}{:02x}".format(block_number, 0, 0, 0)
+        assert _notification.notification_type == NotificationType.CANCEL_TRANSFER.value
+        assert _notification.priority == 0
+        assert _notification.address == self.trader["account_address"]
+        assert _notification.block_timestamp is not None
+        assert _notification.args == {
+            "index": 0,
+            "from": self.trader["account_address"],
+            "to": self.trader2["account_address"],
+            "data": "TEST_DATA"
+        }
+        assert _notification.metainfo == {
+            "company_name": "株式会社DEMO",
+            "token_address": token["address"],
+            "token_name": "テスト株式",
+            "exchange_address": "",
+            "token_type": "IbetShare"
+        }
+
+    # <Normal_2>
+    # Multi event logs
+    def test_normal_2(self, watcher_factory, session, shared_contract, mocked_company_list):
+        watcher = watcher_factory("WatchCancelTransfer")
+
+        exchange_contract = shared_contract["IbetShareExchange"]
+        token_list_contract = shared_contract["TokenList"]
+        personal_info_contract = shared_contract["PersonalInfo"]
+
+        token = prepare_share_token(self.issuer, exchange_contract, token_list_contract, personal_info_contract, session)
+
+        register_personalinfo(self.trader, personal_info_contract)
+        register_personalinfo(self.trader2, personal_info_contract)
+
+        transfer_share_token(self.issuer, self.trader, token, 100)
+        share_set_transfer_approval_required(self.issuer, token, True)
+
+        # Transfer
+        share_apply_for_transfer(self.trader, token, self.trader2, 10, "TEST_DATA1")
+        share_apply_for_transfer(self.trader, token, self.trader2, 20, "TEST_DATA2")
+        share_cancel_transfer(self.issuer, token, 0, "TEST_DATA1")
+        share_cancel_transfer(self.issuer, token, 1, "TEST_DATA2")
+
+        # Run target process
+        watcher.loop()
+
+        # Assertion
+        block_number = web3.eth.block_number
+        _notification_list = session.query(Notification).order_by(Notification.created).all()
+        assert len(_notification_list) == 2
+        _notification = _notification_list[0]
+        assert _notification.notification_id == "0x{:012x}{:06x}{:06x}{:02x}".format(block_number - 1, 0, 0, 0)
+        assert _notification.notification_type == NotificationType.CANCEL_TRANSFER.value
+        assert _notification.priority == 0
+        assert _notification.address == self.trader["account_address"]
+        assert _notification.block_timestamp is not None
+        assert _notification.args == {
+            "index": 0,
+            "from": self.trader["account_address"],
+            "to": self.trader2["account_address"],
+            "data": "TEST_DATA1"
+        }
+        assert _notification.metainfo == {
+            "company_name": "株式会社DEMO",
+            "token_address": token["address"],
+            "token_name": "テスト株式",
+            "exchange_address": "",
+            "token_type": "IbetShare"
+        }
+        _notification = _notification_list[1]
+        assert _notification.notification_id == "0x{:012x}{:06x}{:06x}{:02x}".format(block_number, 0, 0, 0)
+        assert _notification.notification_type == NotificationType.CANCEL_TRANSFER.value
+        assert _notification.priority == 0
+        assert _notification.address == self.trader["account_address"]
+        assert _notification.block_timestamp is not None
+        assert _notification.args == {
+            "index": 1,
+            "from": self.trader["account_address"],
+            "to": self.trader2["account_address"],
+            "data": "TEST_DATA2"
+        }
+        assert _notification.metainfo == {
+            "company_name": "株式会社DEMO",
+            "token_address": token["address"],
+            "token_name": "テスト株式",
+            "exchange_address": "",
+            "token_type": "IbetShare"
+        }
+
+    # <Normal_3>
+    # No event logs
+    def test_normal_3(self, watcher_factory, session, shared_contract, mocked_company_list):
+        watcher = watcher_factory("WatchCancelTransfer")
+
+        exchange_contract = shared_contract["IbetShareExchange"]
+        token_list_contract = shared_contract["TokenList"]
+        personal_info_contract = shared_contract["PersonalInfo"]
+
+        token = prepare_share_token(self.issuer, exchange_contract, token_list_contract, personal_info_contract, session)
+
+        register_personalinfo(self.trader, personal_info_contract)
+        register_personalinfo(self.trader2, personal_info_contract)
+
+        transfer_share_token(self.issuer, self.trader, token, 100)
+        share_set_transfer_approval_required(self.issuer, token, True)
+
+        # Not Transfer
+        # Run target process
+        watcher.loop()
+
+        # Assertion
+        _notification = session.query(Notification).order_by(Notification.created).first()
+        assert _notification is None
+
+    ###########################################################################
+    # Error Case
+    ###########################################################################
+
+    # <Error_1>
+    # Error occur
+    @mock.patch("web3.contract.ContractEvent.getLogs", MagicMock(side_effect=Exception()))
+    def test_error_1(self, watcher_factory, session, shared_contract, mocked_company_list):
+        watcher = watcher_factory("WatchApplyForTransfer")
+
+        exchange_contract = shared_contract["IbetShareExchange"]
+        token_list_contract = shared_contract["TokenList"]
+        personal_info_contract = shared_contract["PersonalInfo"]
+
+        token = prepare_share_token(self.issuer, exchange_contract, token_list_contract, personal_info_contract, session)
+
+        register_personalinfo(self.trader, personal_info_contract)
+        register_personalinfo(self.trader2, personal_info_contract)
+
+        transfer_share_token(self.issuer, self.trader, token, 100)
+        share_set_transfer_approval_required(self.issuer, token, True)
+
+        # Transfer
+        share_apply_for_transfer(self.trader, token, self.trader2, 10, "TEST_DATA1")
+        share_cancel_transfer(self.issuer, token, 0, "TEST_DATA1")
 
         # Run target process
         watcher.loop()

--- a/tests/contract_modules.py
+++ b/tests/contract_modules.py
@@ -26,6 +26,7 @@ from eth_utils import to_checksum_address
 from app import config
 from app.contracts import Contract
 from tests.account_config import eth_account
+from tests.conftest import TestAccount, DeployedContract
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
 web3.middleware_onion.inject(geth_poa_middleware, layer=0)
@@ -171,6 +172,17 @@ def bond_transfer_to_exchange(invoker, bond_exchange, bond_token, amount):
         'IbetStraightBond', bond_token['address'])
 
     tx_hash = TokenContract.functions.transfer(bond_exchange['address'], amount). \
+        transact({'from': invoker['account_address'], 'gas': 4000000})
+    web3.eth.wait_for_transaction_receipt(tx_hash)
+
+
+# 債券トークンの移転
+def transfer_bond_token(invoker: TestAccount, to: TestAccount, token: DeployedContract, amount: int):
+    web3.eth.default_account = invoker['account_address']
+    TokenContract = Contract. \
+        get_contract('IbetStraightBond', token['address'])
+    tx_hash = TokenContract.functions. \
+        transfer(to["account_address"], amount). \
         transact({'from': invoker['account_address'], 'gas': 4000000})
     web3.eth.wait_for_transaction_receipt(tx_hash)
 
@@ -395,6 +407,17 @@ def share_transfer_to_exchange(invoker, exchange, token, amount):
         get_contract('IbetShare', token['address'])
     tx_hash = TokenContract.functions. \
         transfer(exchange['address'], amount). \
+        transact({'from': invoker['account_address'], 'gas': 4000000})
+    web3.eth.wait_for_transaction_receipt(tx_hash)
+
+
+# 株式トークンの移転
+def transfer_share_token(invoker: TestAccount, to: TestAccount, token: DeployedContract, amount: int):
+    web3.eth.default_account = invoker['account_address']
+    TokenContract = Contract. \
+        get_contract('IbetShare', token['address'])
+    tx_hash = TokenContract.functions. \
+        transfer(to["account_address"], amount). \
         transact({'from': invoker['account_address'], 'gas': 4000000})
     web3.eth.wait_for_transaction_receipt(tx_hash)
 


### PR DESCRIPTION
Close: #1183 

## Changes

### Batch Behavior

- ```batch/processor_Notifications_Token.py```
  - Add watcher for ApplyTransfer/CancelTransfer/ApproveTransfer event.

> ApplyTransfer/CancelTransfer/ApproveTransferイベントの監視モジュールを追加しました。

### Environment variable
- ```EXCHANGE_NOTIFICATION_ENABLED```
  - Add new variable so that we choose notification processor to run.
  - If you do not provide a value for that, exchange notification processor will not start. This will affect those who are already using exchange notification batches.
- ```RUN_MODE```
  - Add "batch" mode so that indexer and processor run in one container.

> ```EXCHANGE_NOTIFICATION_ENABLED```
> 起動する通知バッチを選択できるようにしました。値が設定されていなければ、取引系通知バッチは起動しません。
> 既に取引系通知バッチを使用している場合は影響があります。

> ```RUN_MODE```
> batchモードを追加しました。