### PR TITLE
fix: token_address validation error is not handled in ```v3/token``` API endpoint

### DIFF
--- a/app/api/v3/token.py
+++ b/app/api/v3/token.py
@@ -23,6 +23,7 @@ from sqlalchemy import (
     desc,
 )
 from typing import Optional
+from web3 import Web3
 
 from app import log
 from app.api.common import BaseResource
@@ -67,7 +68,14 @@ class StraightBondTokens(BaseResource):
         # Validation
         request_json = StraightBondTokens.validate(req)
 
-        target_address_list = [to_checksum_address(address) for address in request_json["address_list"]]
+        target_address_list = []
+        for address in request_json["address_list"]:
+            try:
+                target_address_list.append(to_checksum_address(address))
+            except ValueError:
+                description = f"invalid token_address: {address}"
+                raise InvalidParameterError(description=description)
+
         owner_address: Optional[str] = request_json.get("owner_address", None)
         name: Optional[str] = request_json.get("name", None)
         symbol: Optional[str] = request_json.get("symbol", None)
@@ -529,7 +537,14 @@ class ShareTokens(BaseResource):
         # Validation
         request_json = ShareTokens.validate(req)
 
-        target_address_list = [to_checksum_address(address) for address in request_json["address_list"]]
+        target_address_list = []
+        for address in request_json["address_list"]:
+            try:
+                target_address_list.append(to_checksum_address(address))
+            except ValueError:
+                description = f"invalid token_address: {address}"
+                raise InvalidParameterError(description=description)
+
         owner_address: Optional[str] = request_json.get("owner_address", None)
         name: Optional[str] = request_json.get("name", None)
         symbol: Optional[str] = request_json.get("symbol", None)
@@ -991,7 +1006,14 @@ class MembershipTokens(BaseResource):
         # Validation
         request_json = MembershipTokens.validate(req)
 
-        target_address_list = [to_checksum_address(address) for address in request_json["address_list"]]
+        target_address_list = []
+        for address in request_json["address_list"]:
+            try:
+                target_address_list.append(to_checksum_address(address))
+            except ValueError:
+                description = f"invalid token_address: {address}"
+                raise InvalidParameterError(description=description)
+
         owner_address: Optional[str] = request_json.get("owner_address", None)
         name: Optional[str] = request_json.get("name", None)
         symbol: Optional[str] = request_json.get("symbol", None)
@@ -1391,7 +1413,14 @@ class CouponTokens(BaseResource):
         # Validation
         request_json = CouponTokens.validate(req)
 
-        target_address_list = [to_checksum_address(address) for address in request_json["address_list"]]
+        target_address_list = []
+        for address in request_json["address_list"]:
+            try:
+                target_address_list.append(to_checksum_address(address))
+            except ValueError:
+                description = f"invalid token_address: {address}"
+                raise InvalidParameterError(description=description)
+
         owner_address: Optional[str] = request_json.get("owner_address", None)
         name: Optional[str] = request_json.get("name", None)
         symbol: Optional[str] = request_json.get("symbol", None)

--- a/app/api/v3/token.py
+++ b/app/api/v3/token.py
@@ -23,7 +23,6 @@ from sqlalchemy import (
     desc,
 )
 from typing import Optional
-from web3 import Web3
 
 from app import log
 from app.api.common import BaseResource

--- a/app/api/v3/token.py
+++ b/app/api/v3/token.py
@@ -1795,5 +1795,3 @@ class CouponTokenAddresses(BaseResource):
             raise InvalidParameterError(validator.errors)
 
         return validator.document
-
-

--- a/app/api/v3/token.py
+++ b/app/api/v3/token.py
@@ -68,14 +68,6 @@ class StraightBondTokens(BaseResource):
         # Validation
         request_json = StraightBondTokens.validate(req)
 
-        target_address_list = []
-        for address in request_json["address_list"]:
-            try:
-                target_address_list.append(to_checksum_address(address))
-            except ValueError:
-                description = f"invalid token_address: {address}"
-                raise InvalidParameterError(description=description)
-
         owner_address: Optional[str] = request_json.get("owner_address", None)
         name: Optional[str] = request_json.get("name", None)
         symbol: Optional[str] = request_json.get("symbol", None)
@@ -98,8 +90,8 @@ class StraightBondTokens(BaseResource):
         query = session.query(IDXBondToken).\
             join(Listing, Listing.token_address == IDXBondToken.token_address).\
             filter(Listing.is_public == True)
-        if len(target_address_list) > 0:
-            query = query.filter(IDXBondToken.token_address.in_(target_address_list))
+        if len(request_json["address_list"]) > 0:
+            query = query.filter(IDXBondToken.token_address.in_(request_json["address_list"]))
         total = query.count()
 
         # Search Filter
@@ -288,6 +280,13 @@ class StraightBondTokens(BaseResource):
                 "nullable": True,
             },
         })
+
+        for address in request_json["address_list"]:
+            try:
+                to_checksum_address(address)
+            except ValueError:
+                description = f"invalid token_address: {address}"
+                raise InvalidParameterError(description=description)
 
         if not validator.validate(request_json):
             raise InvalidParameterError(validator.errors)
@@ -537,14 +536,6 @@ class ShareTokens(BaseResource):
         # Validation
         request_json = ShareTokens.validate(req)
 
-        target_address_list = []
-        for address in request_json["address_list"]:
-            try:
-                target_address_list.append(to_checksum_address(address))
-            except ValueError:
-                description = f"invalid token_address: {address}"
-                raise InvalidParameterError(description=description)
-
         owner_address: Optional[str] = request_json.get("owner_address", None)
         name: Optional[str] = request_json.get("name", None)
         symbol: Optional[str] = request_json.get("symbol", None)
@@ -567,8 +558,8 @@ class ShareTokens(BaseResource):
         query = session.query(IDXShareToken).\
             join(Listing, Listing.token_address == IDXShareToken.token_address).\
             filter(Listing.is_public == True)
-        if len(target_address_list) > 0:
-            query = query.filter(IDXShareToken.token_address.in_(target_address_list))
+        if len(request_json["address_list"]) > 0:
+            query = query.filter(IDXShareToken.token_address.in_(request_json["address_list"]))
         total = query.count()
 
         # Search Filter
@@ -760,6 +751,13 @@ class ShareTokens(BaseResource):
 
         if not validator.validate(request_json):
             raise InvalidParameterError(validator.errors)
+
+        for address in request_json["address_list"]:
+            try:
+                to_checksum_address(address)
+            except ValueError:
+                description = f"invalid token_address: {address}"
+                raise InvalidParameterError(description=description)
 
         return validator.document
 
@@ -1006,14 +1004,6 @@ class MembershipTokens(BaseResource):
         # Validation
         request_json = MembershipTokens.validate(req)
 
-        target_address_list = []
-        for address in request_json["address_list"]:
-            try:
-                target_address_list.append(to_checksum_address(address))
-            except ValueError:
-                description = f"invalid token_address: {address}"
-                raise InvalidParameterError(description=description)
-
         owner_address: Optional[str] = request_json.get("owner_address", None)
         name: Optional[str] = request_json.get("name", None)
         symbol: Optional[str] = request_json.get("symbol", None)
@@ -1033,8 +1023,8 @@ class MembershipTokens(BaseResource):
         query = session.query(IDXMembershipToken).\
             join(Listing, Listing.token_address == IDXMembershipToken.token_address).\
             filter(Listing.is_public == True)
-        if len(target_address_list) > 0:
-            query = query.filter(IDXMembershipToken.token_address.in_(target_address_list))
+        if len(request_json["address_list"]) > 0:
+            query = query.filter(IDXMembershipToken.token_address.in_(request_json["address_list"]))
         total = query.count()
 
         # Search Filter
@@ -1198,6 +1188,13 @@ class MembershipTokens(BaseResource):
 
         if not validator.validate(request_json):
             raise InvalidParameterError(validator.errors)
+
+        for address in request_json["address_list"]:
+            try:
+                to_checksum_address(address)
+            except ValueError:
+                description = f"invalid token_address: {address}"
+                raise InvalidParameterError(description=description)
 
         return validator.document
 
@@ -1413,14 +1410,6 @@ class CouponTokens(BaseResource):
         # Validation
         request_json = CouponTokens.validate(req)
 
-        target_address_list = []
-        for address in request_json["address_list"]:
-            try:
-                target_address_list.append(to_checksum_address(address))
-            except ValueError:
-                description = f"invalid token_address: {address}"
-                raise InvalidParameterError(description=description)
-
         owner_address: Optional[str] = request_json.get("owner_address", None)
         name: Optional[str] = request_json.get("name", None)
         symbol: Optional[str] = request_json.get("symbol", None)
@@ -1440,8 +1429,8 @@ class CouponTokens(BaseResource):
         query = session.query(IDXCouponToken).\
             join(Listing, Listing.token_address == IDXCouponToken.token_address).\
             filter(Listing.is_public == True)
-        if len(target_address_list) > 0:
-            query = query.filter(IDXCouponToken.token_address.in_(target_address_list))
+        if len(request_json["address_list"]) > 0:
+            query = query.filter(IDXCouponToken.token_address.in_(request_json["address_list"]))
         total = query.count()
 
         # Search Filter
@@ -1605,6 +1594,13 @@ class CouponTokens(BaseResource):
 
         if not validator.validate(request_json):
             raise InvalidParameterError(validator.errors)
+
+        for address in request_json["address_list"]:
+            try:
+                to_checksum_address(address)
+            except ValueError:
+                description = f"invalid token_address: {address}"
+                raise InvalidParameterError(description=description)
 
         return validator.document
 

--- a/tests/app/v3_token_coupontokens_test.py
+++ b/tests/app/v3_token_coupontokens_test.py
@@ -828,12 +828,12 @@ class TestV3TokenCouponTokens:
         processor.SEC_PER_RECORD = 0
         processor.process()
 
-        invalid_key_value = {
+        invalid_key_value_1 = {
             "transferable": "invalid_param",
             "status": "invalid_param",
             "initial_offering_status": "invalid_param",
         }
-        for key, value in invalid_key_value.items():
+        for key, value in invalid_key_value_1.items():
             resp: _ResultBase = client.simulate_get(self.apiurl, params={
                 key: value
             })
@@ -842,12 +842,12 @@ class TestV3TokenCouponTokens:
             assert resp.json["title"] == "Invalid parameter"
             assert resp.json["description"] == f'The "{key}" parameter is invalid. The value of the parameter must be "true" or "false".'
 
-        invalid_key_value = {
+        invalid_key_value_2 = {
             "offset": "invalid_param",
             "limit": "invalid_param"
         }
-        for key, value in invalid_key_value.items():
-            resp: _ResultBase = client.simulate_get(self.apiurl, params={
+        for key, value in invalid_key_value_2.items():
+            resp = client.simulate_get(self.apiurl, params={
                 key: value
             })
 
@@ -862,3 +862,20 @@ class TestV3TokenCouponTokens:
                     ]
                 }
             }
+
+        invalid_key_value_list = [
+            {"address_list": ["invalid_address2", "invalid_address1"]},
+            {"address_list": ["invalid_address1", "0x000000000000000000000000000000"]}
+        ]
+        for invalid_key_value in  invalid_key_value_list:
+            for key in invalid_key_value.keys():
+                resp = client.simulate_get(self.apiurl, params={
+                    key: invalid_key_value[key]
+                })
+
+                assert resp.status_code == 400
+                assert resp.json["meta"] == {
+                    "code": 88,
+                    "message": "Invalid Parameter",
+                    "description": f"invalid token_address: {invalid_key_value[key][0]}"
+                }

--- a/tests/app/v3_token_membershiptokens_test.py
+++ b/tests/app/v3_token_membershiptokens_test.py
@@ -828,12 +828,12 @@ class TestV3TokenMembershipTokens:
         processor.SEC_PER_RECORD = 0
         processor.process()
 
-        invalid_key_value = {
+        invalid_key_value_1 = {
             "transferable": "invalid_param",
             "status": "invalid_param",
             "initial_offering_status": "invalid_param",
         }
-        for key, value in invalid_key_value.items():
+        for key, value in invalid_key_value_1.items():
             resp: _ResultBase = client.simulate_get(self.apiurl, params={
                 key: value
             })
@@ -842,12 +842,12 @@ class TestV3TokenMembershipTokens:
             assert resp.json["title"] == "Invalid parameter"
             assert resp.json["description"] == f'The "{key}" parameter is invalid. The value of the parameter must be "true" or "false".'
 
-        invalid_key_value = {
+        invalid_key_value_2 = {
             "offset": "invalid_param",
             "limit": "invalid_param"
         }
-        for key, value in invalid_key_value.items():
-            resp: _ResultBase = client.simulate_get(self.apiurl, params={
+        for key, value in invalid_key_value_2.items():
+            resp = client.simulate_get(self.apiurl, params={
                 key: value
             })
 
@@ -862,3 +862,20 @@ class TestV3TokenMembershipTokens:
                     ]
                 }
             }
+
+        invalid_key_value_list = [
+            {"address_list": ["invalid_address2", "invalid_address1"]},
+            {"address_list": ["invalid_address1", "0x000000000000000000000000000000"]}
+        ]
+        for invalid_key_value in  invalid_key_value_list:
+            for key in invalid_key_value.keys():
+                resp = client.simulate_get(self.apiurl, params={
+                    key: invalid_key_value[key]
+                })
+
+                assert resp.status_code == 400
+                assert resp.json["meta"] == {
+                    "code": 88,
+                    "message": "Invalid Parameter",
+                    "description": f"invalid token_address: {invalid_key_value[key][0]}"
+                }

--- a/tests/app/v3_token_sharetokens_test.py
+++ b/tests/app/v3_token_sharetokens_test.py
@@ -863,14 +863,14 @@ class TestV3TokenShareTokens:
         processor.SEC_PER_RECORD = 0
         processor.process()
 
-        invalid_key_value = {
+        invalid_key_value_1 = {
             "is_offering": "invalid_param",
             "transferable": "invalid_param",
             "status": "invalid_param",
             "transfer_approval_required": "invalid_param",
             "is_canceled": "invalid_param"
         }
-        for key, value in invalid_key_value.items():
+        for key, value in invalid_key_value_1.items():
             resp: _ResultBase = client.simulate_get(self.apiurl, params={
                 key: value
             })
@@ -879,12 +879,12 @@ class TestV3TokenShareTokens:
             assert resp.json["title"] == "Invalid parameter"
             assert resp.json["description"] == f'The "{key}" parameter is invalid. The value of the parameter must be "true" or "false".'
 
-        invalid_key_value = {
+        invalid_key_value_2 = {
             "offset": "invalid_param",
             "limit": "invalid_param"
         }
-        for key, value in invalid_key_value.items():
-            resp: _ResultBase = client.simulate_get(self.apiurl, params={
+        for key, value in invalid_key_value_2.items():
+            resp = client.simulate_get(self.apiurl, params={
                 key: value
             })
 
@@ -899,3 +899,20 @@ class TestV3TokenShareTokens:
                     ]
                 }
             }
+
+        invalid_key_value_list = [
+            {"address_list": ["invalid_address2", "invalid_address1"]},
+            {"address_list": ["invalid_address1", "0x000000000000000000000000000000"]}
+        ]
+        for invalid_key_value in  invalid_key_value_list:
+            for key in invalid_key_value.keys():
+                resp = client.simulate_get(self.apiurl, params={
+                    key: invalid_key_value[key]
+                })
+
+                assert resp.status_code == 400
+                assert resp.json["meta"] == {
+                    "code": 88,
+                    "message": "Invalid Parameter",
+                    "description": f"invalid token_address: {invalid_key_value[key][0]}"
+                }

--- a/tests/app/v3_token_straightbondtokens_test.py
+++ b/tests/app/v3_token_straightbondtokens_test.py
@@ -931,14 +931,14 @@ class TestV3TokenStraightBondTokens:
         processor.SEC_PER_RECORD = 0
         processor.process()
 
-        invalid_key_value = {
+        invalid_key_value_1 = {
             "is_redeemed": "invalid_param",
             "is_offering": "invalid_param",
             "transferable": "invalid_param",
             "status": "invalid_param",
             "transfer_approval_required": "invalid_param",
         }
-        for key, value in invalid_key_value.items():
+        for key, value in invalid_key_value_1.items():
             resp: _ResultBase = client.simulate_get(self.apiurl, params={
                 key: value
             })
@@ -947,12 +947,12 @@ class TestV3TokenStraightBondTokens:
             assert resp.json["title"] == "Invalid parameter"
             assert resp.json["description"] == f'The "{key}" parameter is invalid. The value of the parameter must be "true" or "false".'
 
-        invalid_key_value = {
+        invalid_key_value_2 = {
             "offset": "invalid_param",
             "limit": "invalid_param"
         }
-        for key, value in invalid_key_value.items():
-            resp: _ResultBase = client.simulate_get(self.apiurl, params={
+        for key, value in invalid_key_value_2.items():
+            resp = client.simulate_get(self.apiurl, params={
                 key: value
             })
 
@@ -967,3 +967,20 @@ class TestV3TokenStraightBondTokens:
                     ]
                 }
             }
+
+        invalid_key_value_list = [
+            {"address_list": ["invalid_address2", "invalid_address1"]},
+            {"address_list": ["invalid_address1", "0x000000000000000000000000000000"]}
+        ]
+        for invalid_key_value in  invalid_key_value_list:
+            for key in invalid_key_value.keys():
+                resp = client.simulate_get(self.apiurl, params={
+                    key: invalid_key_value[key]
+                })
+
+                assert resp.status_code == 400
+                assert resp.json["meta"] == {
+                    "code": 88,
+                    "message": "Invalid Parameter",
+                    "description": f"invalid token_address: {invalid_key_value[key][0]}"
+                }


### PR DESCRIPTION
Close #1185 

## Change Behavior

- GET: /v3/Token/StraightBond
- GET: /v3/Token/Share
- GET: /v3/Token/Membership
- GET: /v3/Token/Coupon

### Request
```
curl --location --request GET 'http://localhost:5000/v3/Token/StraightBond?
address_list=0x012345678901234567890123456789012' \
--header 'Accept: */*'
```

### Response
```
{
    "meta": {
        "code": 88,
        "message": "Invalid Parameter",
        "description": "invalid token_address: 0x012345678901234567890123456789012"
    }
}
```