### PR TITLE
fix: timeout/poll_latency value of wait for transaction receipt in SendRawTransaction API

### DIFF
--- a/app/api/routers/eth.py
+++ b/app/api/routers/eth.py
@@ -190,7 +190,11 @@ class SendRawTransaction(BaseResource):
 
             # Handling a transaction execution result
             try:
-                tx = web3.eth.wait_for_transaction_receipt(tx_hash, timeout=config.TRANSACTION_WAIT_TIMEOUT)
+                tx = web3.eth.wait_for_transaction_receipt(
+                    tx_hash,
+                    timeout=config.TRANSACTION_WAIT_TIMEOUT,
+                    poll_latency=config.TRANSACTION_WAIT_POLL_LATENCY
+                )
                 if tx["status"] == 0:
                     # inspect reason of transaction fail
                     err_msg = self.inspect_tx_failure(tx_hash.hex())

--- a/app/config.py
+++ b/app/config.py
@@ -50,8 +50,10 @@ WEB3_HTTP_PROVIDER = os.environ.get("WEB3_HTTP_PROVIDER") or 'http://localhost:8
 WEB3_HTTP_PROVIDER_STANDBY = [node.strip() for node in os.environ.get("WEB3_HTTP_PROVIDER_STANDBY").split(",")] \
     if os.environ.get("WEB3_HTTP_PROVIDER_STANDBY") else []
 WEB3_CHAINID = os.environ.get("WEB3_CHAINID") or CONFIG['web3']['chainid']
+# トランザクションレシート待機時間（秒）
 TRANSACTION_WAIT_TIMEOUT = int(os.environ.get("TRANSACTION_WAIT_TIMEOUT")) \
     if os.environ.get("TRANSACTION_WAIT_TIMEOUT") else 5
+# トランザクションレシートポーリング間隔（秒）
 TRANSACTION_WAIT_POLL_LATENCY = int(os.environ.get("TRANSACTION_WAIT_POLL_LATENCY")) \
     if os.environ.get("TRANSACTION_WAIT_POLL_LATENCY") else 0.5
 

--- a/app/config.py
+++ b/app/config.py
@@ -51,7 +51,9 @@ WEB3_HTTP_PROVIDER_STANDBY = [node.strip() for node in os.environ.get("WEB3_HTTP
     if os.environ.get("WEB3_HTTP_PROVIDER_STANDBY") else []
 WEB3_CHAINID = os.environ.get("WEB3_CHAINID") or CONFIG['web3']['chainid']
 TRANSACTION_WAIT_TIMEOUT = int(os.environ.get("TRANSACTION_WAIT_TIMEOUT")) \
-    if os.environ.get("TRANSACTION_WAIT_TIMEOUT") else 120
+    if os.environ.get("TRANSACTION_WAIT_TIMEOUT") else 5
+TRANSACTION_WAIT_POLL_LATENCY = int(os.environ.get("TRANSACTION_WAIT_POLL_LATENCY")) \
+    if os.environ.get("TRANSACTION_WAIT_POLL_LATENCY") else 0.5
 
 # サーバ設定
 WORKER_COUNT = int(os.environ.get("WORKER_COUNT")) if os.environ.get("WORKER_COUNT") else 8

--- a/tests/app/eth_SendRawTransaction_test.py
+++ b/tests/app/eth_SendRawTransaction_test.py
@@ -1027,10 +1027,16 @@ class TestEthSendRawTransaction:
         request_body = json.dumps(request_params)
 
         # waitForTransactionReceiptエラー
-        with mock.patch("web3.eth.Eth.wait_for_transaction_receipt", MagicMock(side_effect=Exception())):
+        with mock.patch("web3.eth.Eth.wait_for_transaction_receipt", MagicMock(side_effect=Exception())) as m:
             resp = client.simulate_post(
                 self.apiurl, headers=headers, body=request_body)
 
+        # wait_for_transaction_receipt should be called with timeout/poll_latency value from config
+        m.assert_called_with(
+            signed_tx_1.hash,
+            timeout=config.TRANSACTION_WAIT_TIMEOUT,
+            poll_latency=config.TRANSACTION_WAIT_POLL_LATENCY
+        )
         assert resp.status_code == 200
         assert resp.json['meta'] == {'code': 200, 'message': 'OK'}
         assert resp.json['data'] == [{
@@ -1167,7 +1173,7 @@ class TestEthSendRawTransaction:
         # タイムアウト
         # queuedに滞留
         # NOTE: GanacheにはRPCメソッド:txpool_inspectが存在しないためMock化
-        with mock.patch("web3.eth.Eth.wait_for_transaction_receipt", MagicMock(side_effect=TimeExhausted())), mock.patch(
+        with mock.patch("web3.eth.Eth.wait_for_transaction_receipt", MagicMock(side_effect=TimeExhausted())) as m, mock.patch(
                 "web3.geth.GethTxPool.inspect", MagicMock(side_effect=[AttributeDict({
                     "pending": AttributeDict({}),
                     "queued": AttributeDict({
@@ -1178,6 +1184,13 @@ class TestEthSendRawTransaction:
                 })])):
             resp = client.simulate_post(
                 self.apiurl, headers=headers, body=request_body)
+
+        # wait_for_transaction_receipt should be called with timeout/poll_latency value from config
+        m.assert_called_with(
+            signed_tx_1.hash,
+            timeout=config.TRANSACTION_WAIT_TIMEOUT,
+            poll_latency=config.TRANSACTION_WAIT_POLL_LATENCY
+        )
 
         assert resp.status_code == 200
         assert resp.json['meta'] == {'code': 200, 'message': 'OK'}


### PR DESCRIPTION
Close: #1202 

## Changes
- Change default value of `TRANSACTION_WAIT_TIMEOUT` from 120sec to 5sec.
- Define `TRANSACTION_WAIT_POLL_LATENCY` (which is an argument to be passed to `wait_for_transaction()`) set default value of it 0.5 sec.

> `TRANSACTION_WAIT_TIMEOUT` のデフォルト値を120秒から5秒に変更しました。
> `TRANSACTION_WAIT_POLL_LATENCY`を新たに追加し、デフォルト値を0.5秒としました。

- Apply `TRANSACTION_WAIT_POLL_LATENCY` values to `wait_for_transaction_receipt()` in Get: `/Eth/SendRawTransaction`

> `TRANSACTION_WAIT_POLL_LATENCY`を`/Eth/SendRawTransaction`内の`wait_for_transaction_receipt()`で使用するようにしました。