### PR TITLE
feat: fix query parameter model so that parameter description is shown in openapi docs

### DIFF
--- a/app/api/routers/admin.py
+++ b/app/api/routers/admin.py
@@ -50,11 +50,12 @@ from app.model.db import (
 )
 from app.model.schema import (
     SuccessResponse,
-    RegisterAdminTokensRequest,
+    RegisterAdminTokenRequest,
     UpdateAdminTokenRequest,
     GenericSuccessResponse,
-    AdminToken,
-    AdminTokensType
+    ListAllAdminTokensResponse,
+    RetrieveAdminTokenResponse,
+    GetAdminTokenTypeResponse
 )
 from app.utils.docs_utils import get_routers_responses
 
@@ -74,7 +75,7 @@ router = APIRouter(
     "/Tokens",
     summary="List All Listed Tokens",
     operation_id="TokensGET",
-    response_model=GenericSuccessResponse[list[AdminToken]]
+    response_model=GenericSuccessResponse[ListAllAdminTokensResponse]
 )
 def list_all_admin_tokens(
     session: Session = Depends(db_session)
@@ -107,7 +108,7 @@ def list_all_admin_tokens(
     responses=get_routers_responses(DataConflictError, InvalidParameterError),
 )
 def register_admin_token(
-    data: RegisterAdminTokensRequest,
+    data: RegisterAdminTokenRequest,
     session: Session = Depends(db_session)
 ):
     """
@@ -191,10 +192,10 @@ def register_admin_token(
     "/Tokens/Type",
     summary="Available status by token type",
     operation_id="TokenType",
-    response_model=GenericSuccessResponse[AdminTokensType],
+    response_model=GenericSuccessResponse[GetAdminTokenTypeResponse],
     response_model_exclude_unset=True
 )
-def admin_token_type():
+def get_admin_token_type():
     """
     Endpoint: /Admin/Tokens/Type
       - GET: 取扱トークン種別
@@ -219,11 +220,11 @@ def admin_token_type():
     "/Tokens/{token_address}",
     summary="Retrieve a Listed Token",
     operation_id="TokenGET",
-    response_model=GenericSuccessResponse[AdminToken],
+    response_model=GenericSuccessResponse[RetrieveAdminTokenResponse],
     response_model_exclude_unset=True,
     responses=get_routers_responses(DataNotExistsError)
 )
-def retrieve_listed_token(
+def retrieve_admin_token(
     token_address: str = Path(description="Token Address"),
     session: Session = Depends(db_session)
 ):

--- a/app/api/routers/company_info.py
+++ b/app/api/routers/company_info.py
@@ -52,11 +52,9 @@ from app.model.blockchain import (
 from app.model.schema import (
     GenericSuccessResponse,
     SuccessResponse,
-    CompanyInfo,
-    ShareToken as ShareTokenSchema,
-    StraightBondToken as StraightBondTokenSchema,
-    MembershipToken as MembershipTokenSchema,
-    CouponToken as CouponTokenSchema
+    RetrieveCompanyInfoResponse,
+    ListAllCompanyInfoResponse,
+    ListAllCompanyTokensResponse
 )
 
 from app.utils.company_list import CompanyList
@@ -77,7 +75,7 @@ router = APIRouter(
     "",
     summary="Issuer Information List",
     operation_id="Companies",
-    response_model=GenericSuccessResponse[list[CompanyInfo]],
+    response_model=GenericSuccessResponse[ListAllCompanyInfoResponse],
     responses=get_routers_responses()
 )
 def list_all_companies(
@@ -160,7 +158,7 @@ def list_all_companies(
     "/{eth_address}",
     summary="Issuer Information",
     operation_id="Company",
-    response_model=GenericSuccessResponse[CompanyInfo],
+    response_model=GenericSuccessResponse[RetrieveCompanyInfoResponse],
     responses=get_routers_responses(DataNotExistsError, InvalidParameterError)
 )
 def retrieve_company(
@@ -190,7 +188,7 @@ def retrieve_company(
     "/{eth_address}/Tokens",
     summary="List of tokens issued by issuer",
     operation_id="",
-    response_model=GenericSuccessResponse[list[Union[StraightBondTokenSchema, ShareTokenSchema, MembershipTokenSchema, CouponTokenSchema]]],
+    response_model=GenericSuccessResponse[ListAllCompanyTokensResponse],
     responses=get_routers_responses()
 )
 def retrieve_company_tokens(

--- a/app/api/routers/dex_market.py
+++ b/app/api/routers/dex_market.py
@@ -45,14 +45,14 @@ from app.contracts import Contract
 from app.model.schema import (
     GenericSuccessResponse,
     SuccessResponse,
-    AgreementQuery,
-    OrderBookItem,
-    OrderBookRequest,
-    LastPrice,
-    LastPriceRequest,
-    TickRequest,
-    TicksResponse,
-    AgreementDetail
+    RetrieveAgreementQuery,
+    ListAllOrderBookItemResponse,
+    ListAllOrderBookRequest,
+    ListAllLastPriceResponse,
+    ListAllLastPriceRequest,
+    ListAllTickRequest,
+    ListAllTicksResponse,
+    RetrieveAgreementDetailResponse
 )
 from app.utils.docs_utils import get_routers_responses
 
@@ -69,12 +69,12 @@ router = APIRouter(
     "/Agreement",
     summary="Agreement Details",
     operation_id="GetAgreement",
-    response_model=GenericSuccessResponse[AgreementDetail],
+    response_model=GenericSuccessResponse[RetrieveAgreementDetailResponse],
     responses=get_routers_responses(NotSupportedError, InvalidParameterError)
 )
 def retrieve_agreement(
     req: Request,
-    request_query: AgreementQuery = Depends()
+    request_query: RetrieveAgreementQuery = Depends()
 ):
     """約定情報参照"""
     if (
@@ -151,12 +151,12 @@ def retrieve_agreement(
     "/OrderBook/StraightBond",
     summary="StraightBond Token Order Book",
     operation_id="StraightBondOrderBook",
-    response_model=GenericSuccessResponse[list[OrderBookItem]],
+    response_model=GenericSuccessResponse[ListAllOrderBookItemResponse],
     responses=get_routers_responses(NotSupportedError)
 )
 def list_all_straight_bond_order_book(
     req: Request,
-    data: OrderBookRequest,
+    data: ListAllOrderBookRequest,
     session: Session = Depends(db_session)
 ):
     """[普通社債]板情報取得"""
@@ -338,12 +338,12 @@ def list_all_straight_bond_order_book(
     "/LastPrice/StraightBond",
     summary="StraightBond Token Last Price (Bulk Get)",
     operation_id="StraightBondLastPrice",
-    response_model=GenericSuccessResponse[list[LastPrice]],
+    response_model=GenericSuccessResponse[ListAllLastPriceResponse],
     responses=get_routers_responses(NotSupportedError)
 )
 def list_all_straight_bond_last_price(
     req: Request,
-    data: LastPriceRequest
+    data: ListAllLastPriceRequest
 ):
     """[普通社債]現在値取得"""
     if config.BOND_TOKEN_ENABLED is False or config.IBET_SB_EXCHANGE_CONTRACT_ADDRESS is None:
@@ -378,12 +378,12 @@ def list_all_straight_bond_last_price(
     "/Tick/StraightBond",
     summary="StraightBond Token Tick (Bulk Get)",
     operation_id="StraightBondTick",
-    response_model=GenericSuccessResponse[list[TicksResponse]],
+    response_model=GenericSuccessResponse[ListAllTicksResponse],
     responses=get_routers_responses(NotSupportedError)
 )
 def list_all_straight_bond_tick(
     req: Request,
-    data: TickRequest,
+    data: ListAllTickRequest,
     session: Session = Depends(db_session)
 ):
     """[普通社債]歩み値取得"""
@@ -432,12 +432,12 @@ def list_all_straight_bond_tick(
     "/OrderBook/Membership",
     summary="Membership Token Order Book",
     operation_id="MembershipOrderBook",
-    response_model=GenericSuccessResponse[list[OrderBookItem]],
+    response_model=GenericSuccessResponse[ListAllOrderBookItemResponse],
     responses=get_routers_responses(NotSupportedError)
 )
 def list_all_membership_order_book(
     req: Request,
-    data: OrderBookRequest,
+    data: ListAllOrderBookRequest,
     session: Session = Depends(db_session)
 ):
     """[会員権]板情報取得"""
@@ -626,12 +626,12 @@ def list_all_membership_order_book(
     "/LastPrice/Membership",
     summary="Membership Token Last Price (Bulk Get)",
     operation_id="MembershipLastPrice",
-    response_model=GenericSuccessResponse[list[LastPrice]],
+    response_model=GenericSuccessResponse[ListAllLastPriceResponse],
     responses=get_routers_responses(NotSupportedError)
 )
 def list_all_membership_last_price(
     req: Request,
-    data: LastPriceRequest
+    data: ListAllLastPriceRequest
 ):
     """[会員権]現在値取得"""
     if config.MEMBERSHIP_TOKEN_ENABLED is False or config.IBET_MEMBERSHIP_EXCHANGE_CONTRACT_ADDRESS is None:
@@ -667,12 +667,12 @@ def list_all_membership_last_price(
     "/Tick/Membership",
     summary="Membership Token Tick (Bulk Get)",
     operation_id="MembershipTick",
-    response_model=GenericSuccessResponse[list[TicksResponse]],
+    response_model=GenericSuccessResponse[ListAllTicksResponse],
     responses=get_routers_responses(NotSupportedError)
 )
 def list_all_membership_tick(
     req: Request,
-    data: TickRequest,
+    data: ListAllTickRequest,
     session: Session = Depends(db_session)
 ):
     """[会員権]歩み値取得"""
@@ -722,12 +722,12 @@ def list_all_membership_tick(
     "/OrderBook/Coupon",
     summary="Coupon Token Order Book",
     operation_id="CouponOrderBook",
-    response_model=GenericSuccessResponse[list[OrderBookItem]],
+    response_model=GenericSuccessResponse[ListAllOrderBookItemResponse],
     responses=get_routers_responses(NotSupportedError)
 )
 def list_all_coupon_order_book(
     req: Request,
-    data: OrderBookRequest,
+    data: ListAllOrderBookRequest,
     session: Session = Depends(db_session)
 ):
     """[クーポン]板情報取得"""
@@ -916,12 +916,12 @@ def list_all_coupon_order_book(
     "/LastPrice/Coupon",
     summary="Coupon Token Last Price (Bulk Get)",
     operation_id="CouponLastPrice",
-    response_model=GenericSuccessResponse[list[LastPrice]],
+    response_model=GenericSuccessResponse[ListAllLastPriceResponse],
     responses=get_routers_responses(NotSupportedError)
 )
 def list_all_coupon_last_price(
     req: Request,
-    data: LastPriceRequest
+    data: ListAllLastPriceRequest
 ):
     """[クーポン]現在値取得"""
     if config.COUPON_TOKEN_ENABLED is False or config.IBET_CP_EXCHANGE_CONTRACT_ADDRESS is None:
@@ -956,12 +956,12 @@ def list_all_coupon_last_price(
     "/Tick/Coupon",
     summary="Coupon Token Tick (Bulk Get)",
     operation_id="CouponTick",
-    response_model=GenericSuccessResponse[list[TicksResponse]],
+    response_model=GenericSuccessResponse[ListAllTicksResponse],
     responses=get_routers_responses(NotSupportedError)
 )
 def list_all_coupon_tick(
     req: Request,
-    data: TickRequest,
+    data: ListAllTickRequest,
     session: Session = Depends(db_session)
 ):
     """[クーポン]歩み値取得"""

--- a/app/api/routers/dex_order_list.py
+++ b/app/api/routers/dex_order_list.py
@@ -47,15 +47,15 @@ from app.model.blockchain import (
     ShareToken
 )
 from app.model.schema import (
-    OrderListRequest,
+    ListAllOrderListRequest,
     GenericSuccessResponse,
-    OrderListResponse,
+    ListAllOrderListResponse,
     SuccessResponse,
     TokenAddress,
-    ShareToken as ShareTokenSchema,
-    StraightBondToken as StraightBondTokenSchema,
-    MembershipToken as MembershipTokenSchema,
-    CouponToken as CouponTokenSchema
+    RetrieveShareTokenResponse,
+    RetrieveStraightBondTokenResponse,
+    RetrieveMembershipTokenResponse,
+    RetrieveCouponTokenResponse
 )
 from app.utils.docs_utils import get_routers_responses
 
@@ -468,7 +468,7 @@ class StraightBondOrderList(BaseOrderList):
     def __call__(
         self,
         req: Request,
-        data: OrderListRequest,
+        data: ListAllOrderListRequest,
         session: Session = Depends(db_session)
     ):
         if config.BOND_TOKEN_ENABLED is False or config.IBET_SB_EXCHANGE_CONTRACT_ADDRESS is None:
@@ -529,11 +529,11 @@ class StraightBondOrderList(BaseOrderList):
     "/StraightBond",
     summary="Straight Bond Order History (Bulk Get)",
     operation_id="StraightBondOrderList",
-    response_model=GenericSuccessResponse[OrderListResponse[StraightBondTokenSchema]],
+    response_model=GenericSuccessResponse[ListAllOrderListResponse[RetrieveStraightBondTokenResponse]],
     responses=get_routers_responses(NotSupportedError)
 )
 def list_all_straight_bond_order_history(
-    order_list_res: OrderListResponse[StraightBondTokenSchema] = Depends(StraightBondOrderList())
+    order_list_res: ListAllOrderListResponse[RetrieveStraightBondTokenResponse] = Depends(StraightBondOrderList())
 ):
     """
     Endpoint: /DEX/OrderList/StraightBond
@@ -551,7 +551,7 @@ class MembershipOrderList(BaseOrderList):
     def __call__(
         self,
         req: Request,
-        data: OrderListRequest,
+        data: ListAllOrderListRequest,
         session: Session = Depends(db_session)
     ):
         if config.MEMBERSHIP_TOKEN_ENABLED is False or config.IBET_MEMBERSHIP_EXCHANGE_CONTRACT_ADDRESS is None:
@@ -613,11 +613,11 @@ class MembershipOrderList(BaseOrderList):
     "/Membership",
     summary="Membership Order History (Bulk Get)",
     operation_id="MembershipOrderList",
-    response_model=GenericSuccessResponse[OrderListResponse[MembershipTokenSchema]],
+    response_model=GenericSuccessResponse[ListAllOrderListResponse[RetrieveMembershipTokenResponse]],
     responses=get_routers_responses(NotSupportedError)
 )
 def list_all_membership_order_history(
-    order_list_res: OrderListResponse[MembershipTokenSchema] = Depends(MembershipOrderList())
+    order_list_res: ListAllOrderListResponse[RetrieveMembershipTokenResponse] = Depends(MembershipOrderList())
 ):
     """
     Endpoint: /DEX/OrderList/Membership
@@ -635,7 +635,7 @@ class CouponOrderList(BaseOrderList):
     def __call__(
         self,
         req: Request,
-        data: OrderListRequest,
+        data: ListAllOrderListRequest,
         session: Session = Depends(db_session)
     ):
         if config.COUPON_TOKEN_ENABLED is False or config.IBET_CP_EXCHANGE_CONTRACT_ADDRESS is None:
@@ -697,11 +697,11 @@ class CouponOrderList(BaseOrderList):
     "/Coupon",
     summary="Coupon Order History (Bulk Get)",
     operation_id="CouponOrderList",
-    response_model=GenericSuccessResponse[OrderListResponse[CouponTokenSchema]],
+    response_model=GenericSuccessResponse[ListAllOrderListResponse[RetrieveCouponTokenResponse]],
     responses=get_routers_responses(NotSupportedError)
 )
 def list_all_coupon_order_history(
-    order_list_res: OrderListResponse[CouponTokenSchema] = Depends(CouponOrderList())
+    order_list_res: ListAllOrderListResponse[RetrieveCouponTokenResponse] = Depends(CouponOrderList())
 ):
     """
     Endpoint: /DEX/OrderList/Coupon
@@ -719,7 +719,7 @@ class ShareOrderList(BaseOrderList):
     def __call__(
         self,
         req: Request,
-        data: OrderListRequest,
+        data: ListAllOrderListRequest,
         session: Session = Depends(db_session)
     ):
         if config.SHARE_TOKEN_ENABLED is False or config.IBET_SHARE_EXCHANGE_CONTRACT_ADDRESS is None:
@@ -781,11 +781,11 @@ class ShareOrderList(BaseOrderList):
     "/Share",
     summary="Share Order History (Bulk Get)",
     operation_id="ShareOrderList",
-    response_model=GenericSuccessResponse[OrderListResponse[ShareTokenSchema]],
+    response_model=GenericSuccessResponse[ListAllOrderListResponse[RetrieveShareTokenResponse]],
     responses=get_routers_responses(NotSupportedError)
 )
 def list_all_share_order_history(
-    order_list_res: OrderListResponse[ShareTokenSchema] = Depends(ShareOrderList())
+    order_list_res: ListAllOrderListResponse[RetrieveShareTokenResponse] = Depends(ShareOrderList())
 ):
     """
     Endpoint: /DEX/OrderList/Share
@@ -803,7 +803,7 @@ class OrderList(BaseOrderList):
     def __call__(
         self,
         req: Request,
-        data: OrderListRequest,
+        data: ListAllOrderListRequest,
         token_address: str = Path(),
         session: Session = Depends(db_session)
     ):
@@ -869,11 +869,11 @@ class OrderList(BaseOrderList):
     "/{token_address}",
     summary="Order History filtered by token (Bulk Get)",
     operation_id="IbetExchange",
-    response_model=GenericSuccessResponse[OrderListResponse[TokenAddress]],
+    response_model=GenericSuccessResponse[ListAllOrderListResponse[TokenAddress]],
     responses=get_routers_responses(NotSupportedError, InvalidParameterError)
 )
 def list_all_order_history_by_token_address(
-    order_list_res: OrderListResponse[TokenAddress] = Depends(OrderList())
+    order_list_res: ListAllOrderListResponse[TokenAddress] = Depends(OrderList())
 ):
     """
     Endpoint: /DEX/OrderList/{token_address}

--- a/app/api/routers/e2e_message.py
+++ b/app/api/routers/e2e_message.py
@@ -34,7 +34,7 @@ from app.errors import (
 )
 from app.model.schema import (
     GenericSuccessResponse,
-    E2EMessageEncryptionKey,
+    E2EMessageEncryptionKeyResponse,
     SuccessResponse
 )
 from app.utils.docs_utils import get_routers_responses
@@ -51,7 +51,7 @@ router = APIRouter(
     "/EncryptionKey/{account_address}",
     summary="Retrieve message encryption key",
     operation_id="EncryptionKey",
-    response_model=GenericSuccessResponse[E2EMessageEncryptionKey],
+    response_model=GenericSuccessResponse[E2EMessageEncryptionKeyResponse],
     responses=get_routers_responses(InvalidParameterError, DataNotExistsError)
 )
 def retrieve_encryption_key(

--- a/app/api/routers/eth.py
+++ b/app/api/routers/eth.py
@@ -42,13 +42,13 @@ from app.model.db import (
 )
 from app.model.schema import (
     GenericSuccessResponse,
-    TransactionCountQuery,
-    TransactionCount,
+    GetTransactionCountQuery,
+    TransactionCountResponse,
     SuccessResponse,
     SendRawTransactionRequest,
-    SendRawTransactionResult,
-    SendRawTransactionNoWaitResult,
-    WaitForTransactionReceiptResult,
+    SendRawTransactionsResponse,
+    SendRawTransactionsNoWaitResponse,
+    WaitForTransactionReceiptResponse,
     WaitForTransactionReceiptRequest,
 )
 from app.contracts import Contract
@@ -72,13 +72,13 @@ router = APIRouter(
     "/TransactionCount/{eth_address}",
     summary="Transaction count for the specified eth_address",
     operation_id="TransactionCount",
-    response_model=GenericSuccessResponse[TransactionCount],
+    response_model=GenericSuccessResponse[TransactionCountResponse],
     response_model_exclude_unset=True,
     responses=get_routers_responses(InvalidParameterError)
 )
 def get_transaction_count(
     eth_address: str,
-    query: TransactionCountQuery = Depends()
+    query: GetTransactionCountQuery = Depends()
 ):
     """
     Endpoint: /Eth/TransactionCount/{eth_address}
@@ -110,7 +110,7 @@ def get_transaction_count(
     "/SendRawTransaction",
     summary="Send signed transaction",
     operation_id="SendRawTransaction",
-    response_model=GenericSuccessResponse[list[SendRawTransactionResult]],
+    response_model=GenericSuccessResponse[SendRawTransactionsResponse],
     response_model_exclude_unset=True,
     responses=get_routers_responses(SuspendedTokenError)
 )
@@ -290,7 +290,7 @@ def send_raw_transaction(
     "/SendRawTransactionNoWait",
     summary="Send signed transaction",
     operation_id="SendRawTransactionNoWait",
-    response_model=GenericSuccessResponse[list[SendRawTransactionNoWaitResult]],
+    response_model=GenericSuccessResponse[SendRawTransactionsNoWaitResponse],
     response_model_exclude_unset=True,
     responses=get_routers_responses(SuspendedTokenError)
 )
@@ -406,7 +406,7 @@ def send_raw_transaction_no_wait(
     "/WaitForTransactionReceipt",
     summary="Wait for Transaction Receipt",
     operation_id="WaitForTransactionReceipt",
-    response_model=GenericSuccessResponse[WaitForTransactionReceiptResult],
+    response_model=GenericSuccessResponse[WaitForTransactionReceiptResponse],
     response_model_exclude_unset=True,
     responses=get_routers_responses(DataNotExistsError)
 )

--- a/app/api/routers/events.py
+++ b/app/api/routers/events.py
@@ -29,13 +29,13 @@ from app.contracts import Contract
 from app.errors import InvalidParameterError
 from app.model.schema import (
     GenericSuccessResponse,
-    Event as EventSchema,
     E2EMessagingEventsQuery,
     SuccessResponse,
     IbetEscrowEventsQuery,
     IbetSecurityTokenEscrowEventsQuery,
     E2EMessagingEventArguments,
-    EscrowEventArguments
+    EscrowEventArguments,
+    ListAllEventsResponse
 )
 from app.utils.docs_utils import get_routers_responses
 from app.utils.web3_utils import Web3Wrapper
@@ -56,7 +56,7 @@ router = APIRouter(
     "/E2EMessaging",
     summary="List all E2EMessaging event logs",
     operation_id="E2EMessagingEvents",
-    response_model=GenericSuccessResponse[list[EventSchema]],
+    response_model=GenericSuccessResponse[ListAllEventsResponse],
     responses=get_routers_responses(InvalidParameterError)
 )
 def list_all_e2e_messaging_event_logs(
@@ -120,7 +120,7 @@ def list_all_e2e_messaging_event_logs(
     "/IbetEscrow",
     summary="List all IbetEscrow event logs",
     operation_id="IbetEscrowEvents",
-    response_model=GenericSuccessResponse[list[EventSchema]],
+    response_model=GenericSuccessResponse[ListAllEventsResponse],
     responses=get_routers_responses(InvalidParameterError)
 )
 def list_all_ibet_escrow_event_logs(
@@ -195,7 +195,7 @@ def list_all_ibet_escrow_event_logs(
     "/IbetSecurityTokenEscrow",
     summary="List all IbetSecurityTokenEscrow event logs",
     operation_id="IbetSecurityTokenEscrowEvents",
-    response_model=GenericSuccessResponse[list[EventSchema]],
+    response_model=GenericSuccessResponse[ListAllEventsResponse],
     responses=get_routers_responses(InvalidParameterError)
 )
 def list_all_ibet_security_token_escrow_event_logs(

--- a/app/api/routers/node_info.py
+++ b/app/api/routers/node_info.py
@@ -31,9 +31,9 @@ from app.database import db_session
 from app.model.db import Node
 from app.model.schema import (
     GenericSuccessResponse,
-    NodeInfo,
+    GetNodeInfoResponse,
     SuccessResponse,
-    BlockSyncStatus
+    GetBlockSyncStatusResponse
 )
 from app.utils.web3_utils import Web3Wrapper
 
@@ -54,7 +54,7 @@ router = APIRouter(
     "",
     summary="Blockchain node information",
     operation_id="NodeInfo",
-    response_model=GenericSuccessResponse[NodeInfo]
+    response_model=GenericSuccessResponse[GetNodeInfoResponse]
 )
 def get_node_info():
     """
@@ -101,7 +101,7 @@ def get_node_info():
     "/BlockSyncStatus",
     summary="Block synchronization status of the connected blockchain node",
     operation_id="NodeInfoBlockSyncStatus",
-    response_model=GenericSuccessResponse[BlockSyncStatus]
+    response_model=GenericSuccessResponse[GetBlockSyncStatusResponse]
 )
 def get_block_sync_status(
     session: Session = Depends(db_session)

--- a/app/api/routers/position.py
+++ b/app/api/routers/position.py
@@ -65,7 +65,7 @@ from app.model.blockchain import (
     TokenClassTypes as BlockChainTokenModel
 )
 from app.model.schema import (
-    PositionQuery,
+    ListAllPositionQuery,
     GenericSuccessResponse,
     SuccessResponse,
     SecurityTokenPositionWithDetail,
@@ -77,8 +77,8 @@ from app.model.schema import (
     CouponPositionsResponse,
     CouponPositionWithDetail,
     CouponPositionWithAddress,
-    StraightBondToken as StraightBondTokenSchema,
-    ShareToken as ShareTokenSchema,
+    RetrieveStraightBondTokenResponse,
+    RetrieveShareTokenResponse,
 )
 from app.utils.docs_utils import get_routers_responses
 
@@ -110,7 +110,7 @@ class BasePosition:
         self.token_model = token_model
         self.idx_token_model = idx_token_model
 
-    def get_list(self, req: Request, request_query: PositionQuery, session: Session, account_address=None):
+    def get_list(self, req: Request, request_query: ListAllPositionQuery, session: Session, account_address=None):
 
         # API Enabled Check
         if self.token_enabled is False:
@@ -142,7 +142,7 @@ class BasePosition:
         )
         return data
 
-    def get_list_from_index(self, request_query: PositionQuery, session: Session, account_address: str):
+    def get_list_from_index(self, request_query: ListAllPositionQuery, session: Session, account_address: str):
         offset = request_query.offset
         limit = request_query.limit
         include_token_details = request_query.include_token_details
@@ -190,7 +190,7 @@ class BasePosition:
             "positions": position_list
         }
 
-    def get_list_from_contract(self, request_query: PositionQuery, session: Session, account_address: str):
+    def get_list_from_contract(self, request_query: ListAllPositionQuery, session: Session, account_address: str):
         offset = request_query.offset
         limit = request_query.limit
         include_token_details = request_query.include_token_details
@@ -534,7 +534,7 @@ class BasePositionMembership(BasePosition):
             IDXMembershipToken
         )
 
-    def get_list_from_index(self, request_query: PositionQuery, session: Session, account_address: str):
+    def get_list_from_index(self, request_query: ListAllPositionQuery, session: Session, account_address: str):
         offset = request_query.offset
         limit = request_query.limit
         include_token_details = request_query.include_token_details
@@ -591,7 +591,7 @@ class BasePositionCoupon(BasePosition):
             IDXCouponToken
         )
 
-    def get_list_from_index(self, request_query: PositionQuery, session: Session, account_address: str):
+    def get_list_from_index(self, request_query: ListAllPositionQuery, session: Session, account_address: str):
         offset = request_query.offset
         limit = request_query.limit
         include_token_details = request_query.include_token_details
@@ -769,7 +769,7 @@ class GetPositionList:
         self,
         req: Request,
         account_address: str = Path(),
-        request_query: PositionQuery = Depends(),
+        request_query: ListAllPositionQuery = Depends(),
         session: Session = Depends(db_session)
     ):
         return self.base_position().get_list(req, request_query, session, account_address)
@@ -797,7 +797,7 @@ class GetPosition:
     "/{account_address}/Share",
     summary="Share Token Position",
     operation_id="GetShareTokenPosition",
-    response_model=GenericSuccessResponse[GenericSecurityTokenPositionsResponse[ShareTokenSchema]],
+    response_model=GenericSuccessResponse[GenericSecurityTokenPositionsResponse[RetrieveShareTokenResponse]],
     responses=get_routers_responses(DataNotExistsError, NotSupportedError, InvalidParameterError)
 )
 def list_all_share_positions(
@@ -822,7 +822,7 @@ def list_all_share_positions(
     "/{account_address}/StraightBond",
     summary="StraightBond Token Position",
     operation_id="GetStraightBondTokenPosition",
-    response_model=GenericSuccessResponse[GenericSecurityTokenPositionsResponse[StraightBondTokenSchema]],
+    response_model=GenericSuccessResponse[GenericSecurityTokenPositionsResponse[RetrieveStraightBondTokenResponse]],
     responses=get_routers_responses(DataNotExistsError, NotSupportedError, InvalidParameterError)
 )
 def list_all_straight_bond_positions(
@@ -897,7 +897,7 @@ def list_all_coupon_positions(
     "/{account_address}/Share/{token_address}",
     summary="Share Token Position By Token Address",
     operation_id="GetShareTokenPositionByAddress",
-    response_model=GenericSuccessResponse[SecurityTokenPositionWithDetail[ShareTokenSchema]],
+    response_model=GenericSuccessResponse[SecurityTokenPositionWithDetail[RetrieveShareTokenResponse]],
     responses=get_routers_responses(DataNotExistsError, NotSupportedError, InvalidParameterError)
 )
 def retrieve_share_position_by_token_address(
@@ -919,7 +919,7 @@ def retrieve_share_position_by_token_address(
     "/{account_address}/StraightBond/{token_address}",
     summary="StraightBond Token Position By Token Address",
     operation_id="GetStraightBondTokenPositionByAddress",
-    response_model=GenericSuccessResponse[SecurityTokenPositionWithDetail[StraightBondTokenSchema]],
+    response_model=GenericSuccessResponse[SecurityTokenPositionWithDetail[RetrieveStraightBondTokenResponse]],
     responses=get_routers_responses(DataNotExistsError, NotSupportedError, InvalidParameterError)
 )
 def retrieve_straight_bond_position_by_token_address(

--- a/app/api/routers/token.py
+++ b/app/api/routers/token.py
@@ -42,17 +42,17 @@ from app import config
 from app.contracts import Contract
 from app.model.schema import (
     GenericSuccessResponse,
-    TokenStatus,
+    TokenStatusResponse,
     SuccessResponse,
-    TokenHolder as TokenHolderSchema,
-    TokenHoldersCount,
+    ResultSetQuery,
+    TokenHoldersResponse,
+    TokenHoldersCountResponse,
     CreateTokenHoldersCollectionResponse,
     CreateTokenHoldersCollectionRequest,
-    TokenHoldersCollection,
+    TokenHoldersCollectionResponse,
     TransferHistoriesResponse,
     TransferApprovalHistoriesResponse
 )
-from app.model.schema.base import ResultSetQuery
 from app.utils.docs_utils import get_routers_responses
 from app.utils.web3_utils import Web3Wrapper
 from app.model.db import (
@@ -78,7 +78,7 @@ router = APIRouter(
     "/{token_address}/Status",
     summary="Token Status",
     operation_id="TokenStatus",
-    response_model=GenericSuccessResponse[TokenStatus],
+    response_model=GenericSuccessResponse[TokenStatusResponse],
     responses=get_routers_responses(DataNotExistsError, InvalidParameterError)
 )
 def get_token_status(
@@ -153,7 +153,7 @@ def get_token_status(
     "/{token_address}/Holders",
     summary="Token holders",
     operation_id="TokenHolders",
-    response_model=GenericSuccessResponse[list[TokenHolderSchema]],
+    response_model=GenericSuccessResponse[TokenHoldersResponse],
     responses=get_routers_responses(DataNotExistsError, InvalidParameterError)
 )
 def get_token_holders(
@@ -212,7 +212,7 @@ def get_token_holders(
     "/{token_address}/Holders/Count",
     summary="Token holders count",
     operation_id="TokenHoldersCount",
-    response_model=GenericSuccessResponse[TokenHoldersCount],
+    response_model=GenericSuccessResponse[TokenHoldersCountResponse],
     responses=get_routers_responses(DataNotExistsError, InvalidParameterError)
 )
 def get_token_holders_count(
@@ -346,7 +346,7 @@ def create_token_holders_collection(
     "/{token_address}/Holders/Collection/{list_id}",
     summary="Token Holder At Specific BlockNumber",
     operation_id="TokenHoldersList",
-    response_model=GenericSuccessResponse[TokenHoldersCollection],
+    response_model=GenericSuccessResponse[TokenHoldersCollectionResponse],
     responses=get_routers_responses(DataNotExistsError, InvalidParameterError)
 )
 def get_token_holders_collection(

--- a/app/api/routers/token_bond.py
+++ b/app/api/routers/token_bond.py
@@ -39,11 +39,11 @@ from app import config
 from app.model.blockchain import BondToken
 from app.model.schema import (
     GenericSuccessResponse,
-    StraightBondTokensQuery,
-    StraightBondTokensResponse,
+    ListAllStraightBondTokensQuery,
+    ListAllStraightBondTokensResponse,
     SuccessResponse,
-    StraightBondTokenAddressesResponse,
-    StraightBondToken as StraightBondTokenSchema
+    ListAllStraightBondTokenAddressesResponse,
+    RetrieveStraightBondTokenResponse
 )
 from app.model.db import (
     Listing,
@@ -63,13 +63,13 @@ router = APIRouter(
     "",
     summary="Token detail list of StraightBond tokens",
     operation_id="StraightBondTokens",
-    response_model=GenericSuccessResponse[StraightBondTokensResponse],
+    response_model=GenericSuccessResponse[ListAllStraightBondTokensResponse],
     responses=get_routers_responses(NotSupportedError, InvalidParameterError)
 )
 def list_all_straight_bond_tokens(
     req: Request,
     address_list: list[str] = Query(default=[], description="list of token address (**this affects total number**)"),
-    request_query: StraightBondTokensQuery = Depends(),
+    request_query: ListAllStraightBondTokensQuery = Depends(),
     session: Session = Depends(db_session)
 ):
     """
@@ -176,12 +176,12 @@ def list_all_straight_bond_tokens(
     "/Addresses",
     summary="List of StraightBond token address",
     operation_id="StraightBondTokenAddresses",
-    response_model=GenericSuccessResponse[StraightBondTokenAddressesResponse],
+    response_model=GenericSuccessResponse[ListAllStraightBondTokenAddressesResponse],
     responses=get_routers_responses(NotSupportedError)
 )
 def list_all_straight_bond_token_addresses(
     req: Request,
-    request_query: StraightBondTokensQuery = Depends(),
+    request_query: ListAllStraightBondTokensQuery = Depends(),
     session: Session = Depends(db_session)
 ):
     """
@@ -277,7 +277,7 @@ def list_all_straight_bond_token_addresses(
     "/{token_address}",
     summary="StraightBond token details",
     operation_id="StraightBondTokenDetails",
-    response_model=GenericSuccessResponse[StraightBondTokenSchema],
+    response_model=GenericSuccessResponse[RetrieveStraightBondTokenResponse],
     responses=get_routers_responses(NotSupportedError, DataNotExistsError, InvalidParameterError)
 )
 def retrieve_straight_bond_token(

--- a/app/api/routers/token_coupon.py
+++ b/app/api/routers/token_coupon.py
@@ -39,11 +39,11 @@ from app import config
 from app.model.blockchain import CouponToken
 from app.model.schema import (
     GenericSuccessResponse,
-    CouponTokensQuery,
-    CouponTokensResponse,
+    ListAllCouponTokensQuery,
+    ListAllCouponTokensResponse,
     SuccessResponse,
-    CouponTokenAddressesResponse,
-    CouponToken as CouponTokenSchema
+    ListAllCouponTokenAddressesResponse,
+    RetrieveCouponTokenResponse
 )
 from app.model.db import (
     Listing,
@@ -63,13 +63,13 @@ router = APIRouter(
     "",
     summary="Token detail list of Coupon tokens",
     operation_id="CouponTokens",
-    response_model=GenericSuccessResponse[CouponTokensResponse],
+    response_model=GenericSuccessResponse[ListAllCouponTokensResponse],
     responses=get_routers_responses(NotSupportedError, InvalidParameterError)
 )
 def list_all_coupon_tokens(
     req: Request,
     address_list: list[str] = Query(default=[], description="list of token address (**this affects total number**)"),
-    request_query: CouponTokensQuery = Depends(),
+    request_query: ListAllCouponTokensQuery = Depends(),
     session: Session = Depends(db_session)
 ):
     """
@@ -167,12 +167,12 @@ def list_all_coupon_tokens(
     "/Addresses",
     summary="List of Coupon token address",
     operation_id="CouponTokenAddresses",
-    response_model=GenericSuccessResponse[CouponTokenAddressesResponse],
+    response_model=GenericSuccessResponse[ListAllCouponTokenAddressesResponse],
     responses=get_routers_responses(NotSupportedError)
 )
 def list_all_coupon_token_addresses(
     req: Request,
-    request_query: CouponTokensQuery = Depends(),
+    request_query: ListAllCouponTokensQuery = Depends(),
     session: Session = Depends(db_session)
 ):
     """
@@ -259,7 +259,7 @@ def list_all_coupon_token_addresses(
     "/{token_address}",
     summary="Coupon token details",
     operation_id="CouponTokenDetails",
-    response_model=GenericSuccessResponse[CouponTokenSchema],
+    response_model=GenericSuccessResponse[RetrieveCouponTokenResponse],
     responses=get_routers_responses(NotSupportedError, InvalidParameterError, DataNotExistsError)
 )
 def retrieve_coupon_token(

--- a/app/api/routers/token_membership.py
+++ b/app/api/routers/token_membership.py
@@ -39,11 +39,11 @@ from app import config
 from app.model.blockchain import MembershipToken
 from app.model.schema import (
     GenericSuccessResponse,
-    MembershipTokensQuery,
-    MembershipTokensResponse,
+    ListAllMembershipTokensQuery,
+    ListAllMembershipTokensResponse,
     SuccessResponse,
-    MembershipTokenAddressesResponse,
-    MembershipToken as MembershipTokenSchema
+    ListAllMembershipTokenAddressesResponse,
+    RetrieveMembershipTokenResponse
 )
 from app.model.db import (
     Listing,
@@ -63,13 +63,13 @@ router = APIRouter(
     "",
     summary="Token detail list of Membership tokens",
     operation_id="MembershipTokens",
-    response_model=GenericSuccessResponse[MembershipTokensResponse],
+    response_model=GenericSuccessResponse[ListAllMembershipTokensResponse],
     responses=get_routers_responses(NotSupportedError, InvalidParameterError)
 )
 def list_all_membership_tokens(
     req: Request,
     address_list: list[str] = Query(default=[], description="list of token address (**this affects total number**)"),
-    request_query: MembershipTokensQuery = Depends(),
+    request_query: ListAllMembershipTokensQuery = Depends(),
     session: Session = Depends(db_session)
 ):
     """
@@ -168,12 +168,12 @@ def list_all_membership_tokens(
     "/Addresses",
     summary="List of Membership token address",
     operation_id="MembershipTokenAddresses",
-    response_model=GenericSuccessResponse[MembershipTokenAddressesResponse],
+    response_model=GenericSuccessResponse[ListAllMembershipTokenAddressesResponse],
     responses=get_routers_responses(NotSupportedError)
 )
 def list_all_membership_token_addresses(
     req: Request,
-    request_query: MembershipTokensQuery = Depends(),
+    request_query: ListAllMembershipTokensQuery = Depends(),
     session: Session = Depends(db_session)
 ):
     """
@@ -260,7 +260,7 @@ def list_all_membership_token_addresses(
     "/{token_address}",
     summary="Membership token details",
     operation_id="MembershipTokenDetails",
-    response_model=GenericSuccessResponse[MembershipTokenSchema],
+    response_model=GenericSuccessResponse[RetrieveMembershipTokenResponse],
     responses=get_routers_responses(NotSupportedError, DataNotExistsError)
 )
 def retrieve_membership_token(

--- a/app/api/routers/token_share.py
+++ b/app/api/routers/token_share.py
@@ -39,11 +39,11 @@ from app import config
 from app.model.blockchain import ShareToken
 from app.model.schema import (
     GenericSuccessResponse,
-    ShareTokensQuery,
-    ShareTokensResponse,
+    ListAllShareTokensQuery,
+    ListAllShareTokensResponse,
     SuccessResponse,
-    ShareTokenAddressesResponse,
-    ShareToken as ShareTokenSchema
+    ListAllShareTokenAddressesResponse,
+    RetrieveShareTokenResponse
 )
 from app.model.db import (
     Listing,
@@ -63,13 +63,13 @@ router = APIRouter(
     "",
     summary="Token detail list of Share tokens",
     operation_id="ShareTokens",
-    response_model=GenericSuccessResponse[ShareTokensResponse],
+    response_model=GenericSuccessResponse[ListAllShareTokensResponse],
     responses=get_routers_responses(NotSupportedError, InvalidParameterError)
 )
 def list_all_share_tokens(
     req: Request,
     address_list: list[str] = Query(default=[], description="list of token address (**this affects total number**)"),
-    request_query: ShareTokensQuery = Depends(),
+    request_query: ListAllShareTokensQuery = Depends(),
     session: Session = Depends(db_session)
 ):
     """
@@ -176,12 +176,12 @@ def list_all_share_tokens(
     "/Addresses",
     summary="List of Share token address",
     operation_id="ShareTokenAddresses",
-    response_model=GenericSuccessResponse[ShareTokenAddressesResponse],
+    response_model=GenericSuccessResponse[ListAllShareTokenAddressesResponse],
     responses=get_routers_responses(NotSupportedError)
 )
 def list_all_share_token_addresses(
     req: Request,
-    request_query: ShareTokensQuery = Depends(),
+    request_query: ListAllShareTokensQuery = Depends(),
     session: Session = Depends(db_session)
 ):
     """
@@ -277,7 +277,7 @@ def list_all_share_token_addresses(
     "/{token_address}",
     summary="Share token details",
     operation_id="ShareTokenDetails",
-    response_model=GenericSuccessResponse[ShareTokenSchema],
+    response_model=GenericSuccessResponse[RetrieveShareTokenResponse],
     responses=get_routers_responses(NotSupportedError, InvalidParameterError)
 )
 def retrieve_share_token(

--- a/app/api/routers/user_info.py
+++ b/app/api/routers/user_info.py
@@ -28,10 +28,10 @@ from app.contracts import Contract
 from app.model.schema import (
     GenericSuccessResponse,
     SuccessResponse,
-    PaymentAccountQuery,
-    PaymentAccountRegistrationStatus,
-    PersonalInfoRegistrationStatus,
-    PersonalInfoQuery
+    RetrievePaymentAccountQuery,
+    RetrievePaymentAccountRegistrationStatusResponse,
+    RetrievePersonalInfoRegistrationStatusResponse,
+    RetrievePersonalInfoQuery
 )
 from app.utils.docs_utils import get_routers_responses
 
@@ -50,11 +50,11 @@ router = APIRouter(
     "/PaymentAccount",
     summary="Registration status to PaymentGateway Contract",
     operation_id="PaymentAccount",
-    response_model=GenericSuccessResponse[PaymentAccountRegistrationStatus],
+    response_model=GenericSuccessResponse[RetrievePaymentAccountRegistrationStatusResponse],
     responses=get_routers_responses()
 )
 def get_payment_account_registration_status(
-    query: PaymentAccountQuery = Depends()
+    query: RetrievePaymentAccountQuery = Depends()
 ):
     """
     Endpoint: /User/PaymentAccount
@@ -99,11 +99,11 @@ def get_payment_account_registration_status(
     "/PersonalInfo",
     summary="Registration status to PersonalInfo Contract",
     operation_id="PersonalInfo",
-    response_model=GenericSuccessResponse[PersonalInfoRegistrationStatus],
+    response_model=GenericSuccessResponse[RetrievePersonalInfoRegistrationStatusResponse],
     responses=get_routers_responses()
 )
 def get_personal_info_registration_status(
-    query: PersonalInfoQuery = Depends()
+    query: RetrievePersonalInfoQuery = Depends()
 ):
     """
     Endpoint: /User/PersonalInfo

--- a/app/main.py
+++ b/app/main.py
@@ -31,7 +31,6 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.middleware.cors import CORSMiddleware
 
 from app import log
-from app.config import BRAND_NAME
 from app.api.routers import (
     admin as routers_admin,
     node_info as routers_node_info,
@@ -69,9 +68,6 @@ from app.utils.docs_utils import custom_openapi
 LOG = log.get_logger()
 
 tags_metadata = [
-    {
-        "name": "Root"
-    },
     {
         "name": "Admin",
         "description": "System administration"
@@ -124,6 +120,7 @@ tags_metadata = [
 
 app = FastAPI(
     title="ibet Wallet API",
+    description="ibet Wallet API",
     terms_of_service="",
     version="22.12.0",
     contact={"email": "dev@boostry.co.jp"},
@@ -137,11 +134,6 @@ app.openapi = custom_openapi(app)  # type: ignore
 ###############################################################
 # ROUTER
 ###############################################################
-
-@app.get("/", tags=["Root"])
-def root():
-    return {"server": BRAND_NAME}
-
 
 app.include_router(routers_admin.router)
 app.include_router(routers_node_info.router)

--- a/app/main.py
+++ b/app/main.py
@@ -24,6 +24,7 @@ from fastapi import (
 from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
+from pydantic import ValidationError
 from sqlalchemy.exc import OperationalError
 from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -124,7 +125,7 @@ tags_metadata = [
 app = FastAPI(
     title="ibet Wallet API",
     terms_of_service="",
-    version="22.9.0",
+    version="22.12.0",
     contact={"email": "dev@boostry.co.jp"},
     license_info={"name": "Apache 2.0", "url": "http://www.apache.org/licenses/LICENSE-2.0.html"},
     openapi_tags=tags_metadata
@@ -338,6 +339,21 @@ async def data_not_exists_error_handler(request: Request, exc: DataNotExistsErro
 # 400:RequestValidationError
 @app.exception_handler(RequestValidationError)
 async def validation_exception_handler(request: Request, exc: RequestValidationError):
+    meta = {
+        "code": 88,
+        "message": "Invalid Parameter",
+        "description": exc.errors()
+    }
+    return JSONResponse(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        content=jsonable_encoder({"meta": meta}),
+    )
+
+
+# 400:ValidationError
+# NOTE: for exceptions raised directly from Pydantic validation
+@app.exception_handler(ValidationError)
+async def query_validation_exception_handler(request: Request, exc: ValidationError):
     meta = {
         "code": 88,
         "message": "Invalid Parameter",

--- a/app/model/schema/__init__.py
+++ b/app/model/schema/__init__.py
@@ -17,78 +17,102 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 from .base import (
+    # Request
+    ResultSetQuery,
+    # Response
     SuccessResponse,
     GenericSuccessResponse
 )
 from .admin import (
-    AdminToken,
-    AdminTokensType,
-    RegisterAdminTokensRequest,
-    UpdateAdminTokenRequest
+    # Request
+    RegisterAdminTokenRequest,
+    UpdateAdminTokenRequest,
+    # Response
+    RetrieveAdminTokenResponse,
+    ListAllAdminTokensResponse,
+    GetAdminTokenTypeResponse
 )
 from .node_info import (
-    NodeInfo,
-    BlockSyncStatus
+    # Response
+    GetNodeInfoResponse,
+    GetBlockSyncStatusResponse
 )
 from .contract_abi import (
     ABI
 )
 from .company_info import (
-    CompanyInfo,
-    CompanyToken
+    # Response
+    RetrieveCompanyInfoResponse,
+    ListAllCompanyInfoResponse,
+    ListAllCompanyTokensResponse
 )
 from .user_info import (
-    PaymentAccountQuery,
-    PersonalInfoQuery,
-    PaymentAccountRegistrationStatus,
-    PersonalInfoRegistrationStatus
+    # Request
+    RetrievePaymentAccountQuery,
+    RetrievePersonalInfoQuery,
+    # Response
+    RetrievePaymentAccountRegistrationStatusResponse,
+    RetrievePersonalInfoRegistrationStatusResponse
 )
 from .eth import (
-    TransactionCountQuery,
+    # Request
+    GetTransactionCountQuery,
     SendRawTransactionRequest,
     WaitForTransactionReceiptRequest,
-    TransactionCount,
-    SendRawTransactionResult,
-    SendRawTransactionNoWaitResult,
-    WaitForTransactionReceiptResult
+    # Response
+    TransactionCountResponse,
+    SendRawTransactionsResponse,
+    SendRawTransactionsNoWaitResponse,
+    WaitForTransactionReceiptResponse
 )
 from .token_bond import (
-    StraightBondTokensQuery,
-    StraightBondToken,
-    StraightBondTokensResponse,
-    StraightBondTokenAddressesResponse
+    # Request
+    ListAllStraightBondTokensQuery,
+    # Response
+    RetrieveStraightBondTokenResponse,
+    ListAllStraightBondTokensResponse,
+    ListAllStraightBondTokenAddressesResponse
 )
 from .token_share import (
-    ShareTokensQuery,
-    ShareToken,
-    ShareTokensResponse,
-    ShareTokenAddressesResponse
+    # Request
+    ListAllShareTokensQuery,
+    # Response
+    RetrieveShareTokenResponse,
+    ListAllShareTokensResponse,
+    ListAllShareTokenAddressesResponse
 )
 from .token_membership import (
-    MembershipTokensQuery,
-    MembershipToken,
-    MembershipTokensResponse,
-    MembershipTokenAddressesResponse
+    # Request
+    ListAllMembershipTokensQuery,
+    # Response
+    RetrieveMembershipTokenResponse,
+    ListAllMembershipTokensResponse,
+    ListAllMembershipTokenAddressesResponse
 )
 from .token_coupon import (
-    CouponTokensQuery,
-    CouponToken,
-    CouponTokensResponse,
-    CouponTokenAddressesResponse
+    # Request
+    ListAllCouponTokensQuery,
+    # Response
+    RetrieveCouponTokenResponse,
+    ListAllCouponTokensResponse,
+    ListAllCouponTokenAddressesResponse
 )
 from .token import (
+    # Request
     CreateTokenHoldersCollectionRequest,
-    TokenStatus,
-    TokenHolder,
-    TokenHoldersCount,
+    # Response
+    TokenStatusResponse,
+    TokenHoldersResponse,
+    TokenHoldersCountResponse,
     CreateTokenHoldersCollectionResponse,
-    TokenHoldersCollectionHolder,
-    TokenHoldersCollection,
+    TokenHoldersCollectionResponse,
     TransferHistoriesResponse,
     TransferApprovalHistoriesResponse
 )
 from .position import (
-    PositionQuery,
+    # Request
+    ListAllPositionQuery,
+    # Response
     SecurityTokenPosition,
     GenericSecurityTokenPositionsResponse,
     MembershipPositionsResponse,
@@ -104,40 +128,46 @@ from .position import (
     CouponPositionWithAddress
 )
 from .notification import (
-    NotificationsSortItem,
+    # Request
     NotificationsQuery,
     NotificationReadRequest,
     NotificationsCountQuery,
     UpdateNotificationRequest,
-    Notification,
+    # Response
     NotificationsResponse,
     NotificationsCountResponse,
     NotificationUpdateResponse
 )
 from .e2e_message import (
-    E2EMessageEncryptionKey
+    # Response
+    E2EMessageEncryptionKeyResponse
 )
 from .events import (
+    # Request
     E2EMessagingEventsQuery,
     IbetEscrowEventsQuery,
     IbetSecurityTokenEscrowEventsQuery,
-    Event,
     E2EMessagingEventArguments,
-    EscrowEventArguments
+    EscrowEventArguments,
+    # Response
+    ListAllEventsResponse
 )
 from .dex_market import (
-    OrderBookRequest,
-    LastPriceRequest,
-    TickRequest,
-    AgreementQuery,
-    OrderBookItem,
-    OrderBookList,
-    LastPrice,
-    TicksResponse,
-    AgreementDetail
+    # Request
+    ListAllOrderBookRequest,
+    ListAllLastPriceRequest,
+    ListAllTickRequest,
+    RetrieveAgreementQuery,
+    # Response
+    ListAllOrderBookItemResponse,
+    ListAllLastPriceResponse,
+    ListAllTicksResponse,
+    RetrieveAgreementDetailResponse
 )
 from .dex_order_list import (
-    OrderListRequest,
-    OrderListResponse,
+    # Request
+    ListAllOrderListRequest,
+    # Response
+    ListAllOrderListResponse,
     TokenAddress
 )

--- a/app/model/schema/admin.py
+++ b/app/model/schema/admin.py
@@ -34,7 +34,7 @@ from web3 import Web3
 ############################
 
 
-class RegisterAdminTokensRequest(BaseModel):
+class RegisterAdminTokenRequest(BaseModel):
     contract_address: str = Field(..., description="Token Address")
     is_public: bool = Field(..., description="Public and private listings")
     max_holding_quantity: int | None = Field(None, ge=0, description="Maximum holding quantity limit")
@@ -65,7 +65,7 @@ class UpdateAdminTokenRequest(BaseModel):
 ############################
 
 
-class AdminToken(BaseModel):
+class RetrieveAdminTokenResponse(BaseModel):
     id: int = Field(...)
     token_address: str = Field(...)
     is_public: bool = Field(...)
@@ -75,7 +75,11 @@ class AdminToken(BaseModel):
     created: str = Field(..., description="Create Datetime (JST)")
 
 
-class AdminTokensType(BaseModel):
+class ListAllAdminTokensResponse(BaseModel):
+    __root__: list[RetrieveAdminTokenResponse]
+
+
+class GetAdminTokenTypeResponse(BaseModel):
     IbetStraightBond: bool = Field(...)
     IbetShare: bool = Field(...)
     IbetMembership: bool = Field(...)

--- a/app/model/schema/base.py
+++ b/app/model/schema/base.py
@@ -17,15 +17,18 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 from enum import IntEnum
-from fastapi.exceptions import RequestValidationError
-from typing import TypeVar, Generic, Optional
+from fastapi import Query
+from typing import (
+    TypeVar,
+    Generic,
+    Optional
+)
 from pydantic import (
     BaseModel,
-    Field,
-    ValidationError
+    Field
 )
+from pydantic.dataclasses import dataclass
 from pydantic.generics import GenericModel
-from pydantic.error_wrappers import ErrorWrapper
 
 
 ############################
@@ -37,21 +40,10 @@ class SortOrder(IntEnum):
     DESC = 1
 
 
-class QueryModel(BaseModel):
-    def __init__(self, **kwargs):
-        try:
-            super().__init__(**kwargs)
-        except ValidationError as e:
-            errors: list[ErrorWrapper] = []
-            for error in e.raw_errors:
-                raw_error = ErrorWrapper(exc=error.exc, loc=("query",) + error.loc_tuple())
-                errors.append(raw_error)
-            raise RequestValidationError(errors=errors) from None
-
-
-class ResultSetQuery(QueryModel):
-    offset: Optional[int] = Field(description="start position", ge=0)
-    limit: Optional[int] = Field(description="number of set", ge=0)
+@dataclass
+class ResultSetQuery:
+    offset: Optional[int] = Query(default=None, description="start position", ge=0)
+    limit: Optional[int] = Query(default=None, description="number of set", ge=0)
 
 
 ############################

--- a/app/model/schema/company_info.py
+++ b/app/model/schema/company_info.py
@@ -16,8 +16,15 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 """
-from typing import Optional
+from typing import (
+    Optional,
+    Union
+)
 from pydantic import BaseModel
+from app.model.schema.token_bond import RetrieveStraightBondTokenResponse
+from app.model.schema.token_coupon import RetrieveCouponTokenResponse
+from app.model.schema.token_membership import RetrieveMembershipTokenResponse
+from app.model.schema.token_share import RetrieveShareTokenResponse
 
 ############################
 # COMMON
@@ -33,11 +40,19 @@ from pydantic import BaseModel
 # RESPONSE
 ############################
 
-class CompanyInfo(BaseModel):
+class RetrieveCompanyInfoResponse(BaseModel):
     address: str
     corporate_name: str
     rsa_publickey: str
     homepage: str
+
+
+class ListAllCompanyInfoResponse(BaseModel):
+    __root__: list[RetrieveCompanyInfoResponse]
+
+
+class ListAllCompanyTokensResponse(BaseModel):
+    __root__: list[Union[RetrieveStraightBondTokenResponse, RetrieveShareTokenResponse, RetrieveMembershipTokenResponse, RetrieveCouponTokenResponse]]
 
 
 class CompanyToken(BaseModel):

--- a/app/model/schema/dex_market.py
+++ b/app/model/schema/dex_market.py
@@ -17,15 +17,16 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 from enum import Enum
+from fastapi import Query
 from typing import Optional
 from pydantic import (
     BaseModel,
     Field,
     validator
 )
+from pydantic.dataclasses import dataclass
 from web3 import Web3
 
-from app.model.schema.base import QueryModel
 
 ############################
 # COMMON
@@ -41,7 +42,7 @@ class OrderType(str, Enum):
     sell = "sell"
 
 
-class OrderBookRequest(BaseModel):
+class ListAllOrderBookRequest(BaseModel):
     account_address: Optional[str] = Field(description="Orderer's account address. Orders from the given address "
                                                        "will not be included in the response.")
     token_address: str = Field(description="Token address")
@@ -62,7 +63,7 @@ class OrderBookRequest(BaseModel):
         return v
 
 
-class LastPriceRequest(BaseModel):
+class ListAllLastPriceRequest(BaseModel):
     address_list: list[str] = Field(description="Token address list")
 
     @validator("address_list")
@@ -74,7 +75,7 @@ class LastPriceRequest(BaseModel):
         return v
 
 
-class TickRequest(BaseModel):
+class ListAllTickRequest(BaseModel):
     address_list: list[str] = Field(description="Token address list")
 
     @validator("address_list")
@@ -86,10 +87,11 @@ class TickRequest(BaseModel):
         return v
 
 
-class AgreementQuery(QueryModel):
-    order_id: int = Field(description="order id")
-    agreement_id: int = Field(description="agreement id")
-    exchange_address: str = Field(description="exchange_address")
+@dataclass
+class RetrieveAgreementQuery:
+    order_id: int = Query(description="order id")
+    agreement_id: int = Query(description="agreement id")
+    exchange_address: str = Query(description="exchange_address")
 
     @validator("exchange_address")
     def exchange_address_is_valid_address(cls, v):
@@ -110,13 +112,17 @@ class OrderBookItem(BaseModel):
     account_address: str = Field(description="An orderrer of each order book")
 
 
-class OrderBookList(BaseModel):
+class ListAllOrderBookItemResponse(BaseModel):
     __root__: list[OrderBookItem]
 
 
 class LastPrice(BaseModel):
     token_address: str
     last_price: int
+
+
+class ListAllLastPriceResponse(BaseModel):
+    __root__: list[LastPrice]
 
 
 class Tick(BaseModel):
@@ -129,12 +135,16 @@ class Tick(BaseModel):
     amount: int
 
 
-class TicksResponse(BaseModel):
+class Ticks(BaseModel):
     token_address: str
     tick: list[Tick]
 
 
-class AgreementDetail(BaseModel):
+class ListAllTicksResponse(BaseModel):
+    __root__: list[Ticks]
+
+
+class RetrieveAgreementDetailResponse(BaseModel):
     token_address: str = Field(description="token address")
     counterpart: str = Field(description="taker account address")
     buyer_address: str = Field(description="buyer account address")

--- a/app/model/schema/dex_order_list.py
+++ b/app/model/schema/dex_order_list.py
@@ -16,7 +16,11 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 """
-from typing import Optional, Generic, TypeVar
+from typing import (
+    Optional,
+    Generic,
+    TypeVar
+)
 from pydantic import (
     BaseModel,
     Field,
@@ -24,12 +28,10 @@ from pydantic import (
 )
 from pydantic.generics import GenericModel
 from web3 import Web3
-from app.model.schema import (
-    StraightBondToken,
-    ShareToken,
-    MembershipToken,
-    CouponToken
-)
+from app.model.schema.token_bond import RetrieveStraightBondTokenResponse
+from app.model.schema.token_coupon import RetrieveCouponTokenResponse
+from app.model.schema.token_membership import RetrieveMembershipTokenResponse
+from app.model.schema.token_share import RetrieveShareTokenResponse
 
 ############################
 # COMMON
@@ -40,7 +42,7 @@ from app.model.schema import (
 # REQUEST
 ############################
 
-class OrderListRequest(BaseModel):
+class ListAllOrderListRequest(BaseModel):
     account_address_list: list[str] = Field(description="Account address list")
     include_canceled_items: Optional[bool] = Field(
         description="Whether to include canceled orders or canceled agreements."
@@ -73,7 +75,7 @@ class Order(BaseModel):
     order_timestamp: str
 
 
-TokenModel = TypeVar("TokenModel", StraightBondToken, ShareToken, MembershipToken, CouponToken, TokenAddress)
+TokenModel = TypeVar("TokenModel", RetrieveStraightBondTokenResponse, RetrieveShareTokenResponse, RetrieveMembershipTokenResponse, RetrieveCouponTokenResponse, TokenAddress)
 
 
 class OrderSet(GenericModel, Generic[TokenModel]):
@@ -104,7 +106,7 @@ class CompleteAgreementSet(AgreementSet, Generic[TokenModel]):
     settlement_timestamp: str = Field(description="settlement timestamp")
 
 
-class OrderListResponse(BaseModel, Generic[TokenModel]):
+class ListAllOrderListResponse(BaseModel, Generic[TokenModel]):
     order_list: list[OrderSet[TokenModel]]
     settlement_list: list[AgreementSet[TokenModel]]
     complete_list: list[CompleteAgreementSet[TokenModel]]

--- a/app/model/schema/e2e_message.py
+++ b/app/model/schema/e2e_message.py
@@ -20,7 +20,6 @@ from pydantic import (
     BaseModel,
     Field,
 )
-from app.model.schema.token import TokenType
 
 ############################
 # COMMON
@@ -36,6 +35,6 @@ from app.model.schema.token import TokenType
 # RESPONSE
 ############################
 
-class E2EMessageEncryptionKey(BaseModel):
+class E2EMessageEncryptionKeyResponse(BaseModel):
     key: str = Field(description="Message encryption key")
     key_type: str = Field(description="key type", example="RSA4096")

--- a/app/model/schema/eth.py
+++ b/app/model/schema/eth.py
@@ -17,14 +17,14 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 from enum import Enum
+from fastapi import Query
 from typing import Optional
 from pydantic import (
     BaseModel,
     Field,
     StrictStr
 )
-
-from app.model.schema.base import QueryModel
+from pydantic.dataclasses import dataclass
 
 ############################
 # COMMON
@@ -41,8 +41,9 @@ class BlockIdentifier(str, Enum):
     pending = "pending"
 
 
-class TransactionCountQuery(QueryModel):
-    block_identifier: Optional[BlockIdentifier]
+@dataclass
+class GetTransactionCountQuery:
+    block_identifier: Optional[BlockIdentifier] = Query(default=None)
 
 
 class SendRawTransactionRequest(BaseModel):
@@ -58,13 +59,13 @@ class WaitForTransactionReceiptRequest(BaseModel):
 # RESPONSE
 ############################
 
-class TransactionCount(BaseModel):
+class TransactionCountResponse(BaseModel):
     nonce: int = Field(..., example=34)
     gasprice: int = Field(..., example=0)
     chainid: str = Field(..., example="2017")
 
 
-class SendRawTransactionResult(BaseModel):
+class SendRawTransactionResponse(BaseModel):
     id: int = Field(..., example=1, description="transaction send order")
     status: int = Field(..., example=1, description="execution failure:0, execution success:1, execution success("
                                                     "pending transaction):2")
@@ -73,13 +74,21 @@ class SendRawTransactionResult(BaseModel):
     error_msg: Optional[str] = Field(example="Message sender is not token owner.", description="error msg")
 
 
-class SendRawTransactionNoWaitResult(BaseModel):
+class SendRawTransactionsResponse(BaseModel):
+    __root__: list[SendRawTransactionResponse]
+
+
+class SendRawTransactionNoWaitResponse(BaseModel):
     id: int = Field(..., example=1, description="transaction send order")
     status: int = Field(..., example=1, description="execution failure:0, execution success:1")
     transaction_hash: Optional[str] = Field(description="transaction hash")
 
 
-class WaitForTransactionReceiptResult(BaseModel):
+class SendRawTransactionsNoWaitResponse(BaseModel):
+    __root__: list[SendRawTransactionNoWaitResponse]
+
+
+class WaitForTransactionReceiptResponse(BaseModel):
     status: int = Field(..., example=1, description="transaction revert:0, transaction success:1")
     error_code: Optional[int] = Field(example=240202, description="error code thrown from contract")
     error_msg: Optional[str] = Field(example="Message sender is not token owner.", description="error msg")

--- a/app/model/schema/events.py
+++ b/app/model/schema/events.py
@@ -17,6 +17,7 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 from enum import Enum
+from fastapi import Query
 from typing import Optional
 from pydantic import (
     BaseModel,
@@ -24,8 +25,7 @@ from pydantic import (
     root_validator,
     StrictStr
 )
-
-from app.model.schema.base import QueryModel
+from pydantic.dataclasses import dataclass
 
 ############################
 # COMMON
@@ -36,9 +36,10 @@ from app.model.schema.base import QueryModel
 # REQUEST
 ############################
 
-class EventsQuery(QueryModel):
-    from_block: int = Field(description="from block number", ge=1)
-    to_block: int = Field(description="to block number", ge=1)
+@dataclass
+class EventsQuery:
+    from_block: int = Query(description="from block number", ge=1)
+    to_block: int = Query(description="to block number", ge=1)
 
     @root_validator
     def validate_block_number(cls, values):
@@ -58,9 +59,11 @@ class E2EMessagingEventArguments(BaseModel):
     who: Optional[StrictStr]
 
 
+@dataclass
 class E2EMessagingEventsQuery(EventsQuery):
-    event: Optional[E2EMessagingEventType] = Field(description="events to get")
-    argument_filters: Optional[str] = Field(
+    event: Optional[E2EMessagingEventType] = Query(default=None, description="events to get")
+    argument_filters: Optional[str] = Query(
+        default=None,
         description="filter argument. serialize obj to a JSON formatted str required."
                     "eg."
                     "```"
@@ -83,9 +86,11 @@ class EscrowEventArguments(BaseModel):
     escrowId: Optional[int]
 
 
+@dataclass
 class IbetEscrowEventsQuery(EventsQuery):
-    event: Optional[IbetEscrowEventType] = Field(description="events to get")
-    argument_filters: Optional[str] = Field(
+    event: Optional[IbetEscrowEventType] = Query(default=None, description="events to get")
+    argument_filters: Optional[str] = Query(
+        default=None,
         description="filter argument. serialize obj to a JSON formatted str required."
                     "eg."
                     "```"
@@ -110,9 +115,11 @@ class IbetSecurityTokenEscrowEventType(str, Enum):
     FinishTransfer = "FinishTransfer"
 
 
+@dataclass
 class IbetSecurityTokenEscrowEventsQuery(EventsQuery):
-    event: Optional[IbetSecurityTokenEscrowEventType] = Field(description="events to get")
-    argument_filters: Optional[str] = Field(
+    event: Optional[IbetSecurityTokenEscrowEventType] = Query(default=None, description="events to get")
+    argument_filters: Optional[str] = Query(
+        default=None,
         description="filter argument. serialize obj to a JSON formatted str required."
                     "eg."
                     "```"
@@ -135,3 +142,7 @@ class Event(BaseModel):
     block_number: int = Field(description="the block number where this log was in")
     block_timestamp: int = Field(description="timestamp where this log was in")
     log_index: int = Field(description="integer of the log index position in the block")
+
+
+class ListAllEventsResponse(BaseModel):
+    __root__: list[Event]

--- a/app/model/schema/node_info.py
+++ b/app/model/schema/node_info.py
@@ -39,7 +39,7 @@ from app.model.schema.base import SuccessResponse
 # RESPONSE
 ############################
 
-class NodeInfo(BaseModel):
+class GetNodeInfoResponse(BaseModel):
     payment_gateway_address: Optional[str]
     payment_gateway_abi: Optional[object]
     personal_info_address: Optional[str]
@@ -61,7 +61,7 @@ class NodeInfo(BaseModel):
     agent_address: Optional[str]
 
 
-class BlockSyncStatus(BaseModel):
+class GetBlockSyncStatusResponse(BaseModel):
     is_synced: bool = Field(..., description="block sync status")
     latest_block_number: Optional[int] = Field(..., description="latest block number (returns null if is_synced is "
                                                                 "false)")

--- a/app/model/schema/notification.py
+++ b/app/model/schema/notification.py
@@ -17,19 +17,20 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 from enum import Enum
+from fastapi import Query
 from typing import Optional
 from pydantic import (
     BaseModel,
     Field,
     validator
 )
+from pydantic.dataclasses import dataclass
 from web3 import Web3
 
 from app.model.db import NotificationType
 from app.model.schema.base import (
-    ResultSetQuery,
     ResultSet,
-    SortOrder, QueryModel
+    SortOrder
 )
 from app.model.schema.token import TokenType
 
@@ -49,16 +50,19 @@ class NotificationsSortItem(str, Enum):
     created = "created"
 
 
-class NotificationsQuery(ResultSetQuery):
-    address: Optional[str]
-    notification_type: Optional[NotificationType]
-    priority: Optional[int] = Field(ge=0, le=2)
+@dataclass
+class NotificationsQuery:
+    offset: Optional[int] = Query(default=None, description="start position", ge=0)
+    limit: Optional[int] = Query(default=None, description="number of set", ge=0)
+    address: Optional[str] = Query(default=None)
+    notification_type: Optional[NotificationType] = Query(default=None)
+    priority: Optional[int] = Query(default=None, ge=0, le=2)
 
-    sort_item: Optional[NotificationsSortItem] = Field(
+    sort_item: Optional[NotificationsSortItem] = Query(
         default=NotificationsSortItem.created,
         description="sort item"
     )
-    sort_order: Optional[SortOrder] = Field(default=SortOrder.ASC, description="sort order(0: ASC, 1: DESC)")
+    sort_order: Optional[SortOrder] = Query(default=SortOrder.ASC, description="sort order(0: ASC, 1: DESC)")
 
     @validator("address")
     def address_is_valid_address(cls, v):
@@ -79,7 +83,8 @@ class NotificationReadRequest(BaseModel):
         return v
 
 
-class NotificationsCountQuery(QueryModel):
+@dataclass
+class NotificationsCountQuery:
     address: str
 
     @validator("address")

--- a/app/model/schema/position.py
+++ b/app/model/schema/position.py
@@ -16,17 +16,16 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 """
+from fastapi import Query
 from typing import Optional, TypeVar, Generic, Union
 from pydantic import (
     BaseModel,
     Field,
 )
-from app.model.schema import CouponToken, MembershipToken
-
-from app.model.schema.base import (
-    ResultSetQuery,
-    ResultSet
-)
+from pydantic.dataclasses import dataclass
+from app.model.schema.base import ResultSet
+from app.model.schema.token_coupon import RetrieveCouponTokenResponse
+from app.model.schema.token_membership import RetrieveMembershipTokenResponse
 
 ############################
 # COMMON
@@ -37,9 +36,12 @@ from app.model.schema.base import (
 # REQUEST
 ############################
 
-class PositionQuery(ResultSetQuery):
-    include_token_details: Optional[bool] = Field(default=False, description="include token details")
-    enable_index: Optional[bool] = Field(default=False, description="enable using indexed position data")
+@dataclass
+class ListAllPositionQuery:
+    offset: Optional[int] = Query(default=None, description="start position", ge=0)
+    limit: Optional[int] = Query(default=None, description="number of set", ge=0)
+    include_token_details: Optional[bool] = Query(default=False, description="include token details")
+    enable_index: Optional[bool] = Query(default=False, description="enable using indexed position data")
 
 
 ############################
@@ -80,7 +82,7 @@ class MembershipPosition(BaseModel):
 
 
 class MembershipPositionWithDetail(MembershipPosition):
-    token: MembershipToken = Field(description="set when include_token_details=false or null")
+    token: RetrieveMembershipTokenResponse = Field(description="set when include_token_details=false or null")
 
 
 class MembershipPositionWithAddress(MembershipPosition):
@@ -100,7 +102,7 @@ class CouponPosition(BaseModel):
 
 
 class CouponPositionWithDetail(CouponPosition):
-    token: CouponToken = Field(description="set when include_token_details=false or null")
+    token: RetrieveCouponTokenResponse = Field(description="set when include_token_details=false or null")
 
 
 class CouponPositionWithAddress(CouponPosition):

--- a/app/model/schema/token.py
+++ b/app/model/schema/token.py
@@ -55,7 +55,7 @@ class CreateTokenHoldersCollectionRequest(BaseModel):
 # RESPONSE
 ############################
 
-class TokenStatus(BaseModel):
+class TokenStatusResponse(BaseModel):
     token_template: str = Field(example="IbetStraightBond")
     status: bool
     transferable: bool
@@ -70,7 +70,11 @@ class TokenHolder(BaseModel):
     exchange_commitment: Optional[int] = Field(default=0)
 
 
-class TokenHoldersCount(BaseModel):
+class TokenHoldersResponse(BaseModel):
+    __root__: list[TokenHolder]
+
+
+class TokenHoldersCountResponse(BaseModel):
     count: int
 
 
@@ -93,7 +97,7 @@ class TokenHoldersCollectionHolder(BaseModel):
                                           "This includes balance/pending_transfer/exchange_balance/exchange_commitment.")
 
 
-class TokenHoldersCollection(BaseModel):
+class TokenHoldersCollectionResponse(BaseModel):
     status: TokenHoldersCollectionBatchStatus
     holders: list[TokenHoldersCollectionHolder] = Field(description="Token holder list."
                                                                     "This list is excluding token owner address.")

--- a/app/model/schema/token_bond.py
+++ b/app/model/schema/token_bond.py
@@ -17,15 +17,16 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 from enum import Enum
+from fastapi import Query
 from typing import Optional
 from pydantic import (
     BaseModel,
     Field,
     StrictStr
 )
+from pydantic.dataclasses import dataclass
 
 from app.model.schema.base import (
-    ResultSetQuery,
     ResultSet,
     SortOrder
 )
@@ -55,32 +56,36 @@ class StraightBondTokensSortItem(str, Enum):
     created = "created"
 
 
-class StraightBondTokensQuery(ResultSetQuery):
-    owner_address: Optional[str] = Field(description="issuer address")
-    name: Optional[str] = Field(description="token name")
-    symbol: Optional[str] = Field(description="token symbol")
-    company_name: Optional[str] = Field(description="company name")
-    tradable_exchange: Optional[str] = Field(description="tradable exchange address")
-    status: Optional[bool] = Field(description="token status")
-    personal_info_address: Optional[str] = Field(description="personal information address")
-    transferable: Optional[bool] = Field(description="transferable status")
-    is_offering: Optional[bool] = Field(description="offering status")
-    transfer_approval_required: Optional[bool] = Field(description="transfer approval required status")
-    is_redeemed: Optional[bool] = Field(description="redeem status")
+@dataclass
+class ListAllStraightBondTokensQuery:
+    offset: Optional[int] = Query(default=None, description="start position", ge=0)
+    limit: Optional[int] = Query(default=None, description="number of set", ge=0)
 
-    sort_item: Optional[StraightBondTokensSortItem] = Field(
+    owner_address: Optional[str] = Query(default=None, description="issuer address")
+    name: Optional[str] = Query(default=None, description="token name")
+    symbol: Optional[str] = Query(default=None, description="token symbol")
+    company_name: Optional[str] = Query(default=None, description="company name")
+    tradable_exchange: Optional[str] = Query(default=None, description="tradable exchange address")
+    status: Optional[bool] = Query(default=None, description="token status")
+    personal_info_address: Optional[str] = Query(default=None, description="personal information address")
+    transferable: Optional[bool] = Query(default=None, description="transferable status")
+    is_offering: Optional[bool] = Query(default=None, description="offering status")
+    transfer_approval_required: Optional[bool] = Query(default=None, description="transfer approval required status")
+    is_redeemed: Optional[bool] = Query(default=None, description="redeem status")
+
+    sort_item: Optional[StraightBondTokensSortItem] = Query(
         default=StraightBondTokensSortItem.created,
         description="sort item"
     )
-    sort_order: Optional[SortOrder] = Field(default=SortOrder.ASC, description="sort order(0: ASC, 1: DESC)")
-    address_list: list[StrictStr] = Field(default=[], description="list of token address (**this affects total number**)")
+    sort_order: Optional[SortOrder] = Query(default=SortOrder.ASC, description="sort order(0: ASC, 1: DESC)")
+    address_list: list[StrictStr] = Query(default=[], description="list of token address (**this affects total number**)")
 
 
 ############################
 # RESPONSE
 ############################
 
-class StraightBondToken(BaseModel):
+class RetrieveStraightBondTokenResponse(BaseModel):
     token_address: str
     token_template: str = Field(example="IbetStraightBond")
     owner_address: str = Field(description="issuer address")
@@ -122,11 +127,11 @@ class StraightBondToken(BaseModel):
     is_redeemed: bool
 
 
-class StraightBondTokensResponse(BaseModel):
+class ListAllStraightBondTokensResponse(BaseModel):
     result_set: ResultSet
-    tokens: list[StraightBondToken]
+    tokens: list[RetrieveStraightBondTokenResponse]
 
 
-class StraightBondTokenAddressesResponse(BaseModel):
+class ListAllStraightBondTokenAddressesResponse(BaseModel):
     result_set: ResultSet
     address_list: list[str]

--- a/app/model/schema/token_coupon.py
+++ b/app/model/schema/token_coupon.py
@@ -17,14 +17,15 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 from enum import Enum
+from fastapi import Query
 from typing import Optional
 from pydantic import (
     BaseModel,
     Field
 )
+from pydantic.dataclasses import dataclass
 
 from app.model.schema.base import (
-    ResultSetQuery,
     ResultSet,
     SortOrder
 )
@@ -52,21 +53,24 @@ class CouponTokensSortItem(str, Enum):
     created = "created"
 
 
-class CouponTokensQuery(ResultSetQuery):
-    owner_address: Optional[str] = Field(description="issuer address")
-    name: Optional[str] = Field(description="token name")
-    symbol: Optional[str] = Field(description="token symbol")
-    company_name: Optional[str] = Field(description="company name")
-    tradable_exchange: Optional[str] = Field(description="tradable exchange address")
-    status: Optional[bool] = Field(description="token status")
-    transferable: Optional[bool] = Field(description="transferable status")
-    initial_offering_status: Optional[bool] = Field(description="offering status")
+@dataclass
+class ListAllCouponTokensQuery:
+    offset: Optional[int] = Query(default=None, description="start position", ge=0)
+    limit: Optional[int] = Query(default=None, description="number of set", ge=0)
+    owner_address: Optional[str] = Query(default=None, description="issuer address")
+    name: Optional[str] = Query(default=None, description="token name")
+    symbol: Optional[str] = Query(default=None, description="token symbol")
+    company_name: Optional[str] = Query(default=None, description="company name")
+    tradable_exchange: Optional[str] = Query(default=None, description="tradable exchange address")
+    status: Optional[bool] = Query(default=None, description="token status")
+    transferable: Optional[bool] = Query(default=None, description="transferable status")
+    initial_offering_status: Optional[bool] = Query(default=None, description="offering status")
 
-    sort_item: Optional[CouponTokensSortItem] = Field(
+    sort_item: Optional[CouponTokensSortItem] = Query(
         default=CouponTokensSortItem.created,
         description="sort item"
     )
-    sort_order: Optional[SortOrder] = Field(default=SortOrder.ASC, description="sort order(0: ASC, 1: DESC)")
+    sort_order: Optional[SortOrder] = Query(default=SortOrder.ASC, description="sort order(0: ASC, 1: DESC)")
 
 
 ############################
@@ -78,7 +82,7 @@ class CouponImage(BaseModel):
     url: str
 
 
-class CouponToken(BaseModel):
+class RetrieveCouponTokenResponse(BaseModel):
     token_address: str
     token_template: str = Field(example="IbetCoupon")
     owner_address: str = Field(description="issuer address")
@@ -102,11 +106,11 @@ class CouponToken(BaseModel):
     image_url: list[CouponImage]
 
 
-class CouponTokensResponse(BaseModel):
+class ListAllCouponTokensResponse(BaseModel):
     result_set: ResultSet
-    tokens: list[CouponToken]
+    tokens: list[RetrieveCouponTokenResponse]
 
 
-class CouponTokenAddressesResponse(BaseModel):
+class ListAllCouponTokenAddressesResponse(BaseModel):
     result_set: ResultSet
     address_list: list[str]

--- a/app/model/schema/token_membership.py
+++ b/app/model/schema/token_membership.py
@@ -17,14 +17,15 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 from enum import Enum
+from fastapi import Query
 from typing import Optional
 from pydantic import (
     BaseModel,
     Field,
 )
+from pydantic.dataclasses import dataclass
 
 from app.model.schema.base import (
-    ResultSetQuery,
     ResultSet,
     SortOrder
 )
@@ -52,21 +53,24 @@ class MembershipTokensSortItem(str, Enum):
     created = "created"
 
 
-class MembershipTokensQuery(ResultSetQuery):
-    owner_address: Optional[str] = Field(description="issuer address")
-    name: Optional[str] = Field(description="token name")
-    symbol: Optional[str] = Field(description="token symbol")
-    company_name: Optional[str] = Field(description="company name")
-    tradable_exchange: Optional[str] = Field(description="tradable exchange address")
-    status: Optional[bool] = Field(description="token status")
-    transferable: Optional[bool] = Field(description="transferable status")
-    initial_offering_status: Optional[bool] = Field(description="offering status")
+@dataclass
+class ListAllMembershipTokensQuery:
+    offset: Optional[int] = Query(default=None, description="start position", ge=0)
+    limit: Optional[int] = Query(default=None, description="number of set", ge=0)
+    owner_address: Optional[str] = Query(default=None, description="issuer address")
+    name: Optional[str] = Query(default=None, description="token name")
+    symbol: Optional[str] = Query(default=None, description="token symbol")
+    company_name: Optional[str] = Query(default=None, description="company name")
+    tradable_exchange: Optional[str] = Query(default=None, description="tradable exchange address")
+    status: Optional[bool] = Query(default=None, description="token status")
+    transferable: Optional[bool] = Query(default=None, description="transferable status")
+    initial_offering_status: Optional[bool] = Query(default=None, description="offering status")
 
-    sort_item: Optional[MembershipTokensSortItem] = Field(
+    sort_item: Optional[MembershipTokensSortItem] = Query(
         default=MembershipTokensSortItem.created,
         description="sort item"
     )
-    sort_order: Optional[SortOrder] = Field(default=SortOrder.ASC, description="sort order(0: ASC, 1: DESC)")
+    sort_order: Optional[SortOrder] = Query(default=SortOrder.ASC, description="sort order(0: ASC, 1: DESC)")
 
 
 ############################
@@ -78,7 +82,7 @@ class MembershipImage(BaseModel):
     url: str
 
 
-class MembershipToken(BaseModel):
+class RetrieveMembershipTokenResponse(BaseModel):
     token_address: str
     token_template: str = Field(example="IbetMembership")
     owner_address: str = Field(description="issuer address")
@@ -102,11 +106,11 @@ class MembershipToken(BaseModel):
     image_url: list[MembershipImage]
 
 
-class MembershipTokensResponse(BaseModel):
+class ListAllMembershipTokensResponse(BaseModel):
     result_set: ResultSet
-    tokens: list[MembershipToken]
+    tokens: list[RetrieveMembershipTokenResponse]
 
 
-class MembershipTokenAddressesResponse(BaseModel):
+class ListAllMembershipTokenAddressesResponse(BaseModel):
     result_set: ResultSet
     address_list: list[str]

--- a/app/model/schema/token_share.py
+++ b/app/model/schema/token_share.py
@@ -17,15 +17,16 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 from enum import Enum
+from fastapi import Query
 from typing import Optional
 from pydantic import (
     BaseModel,
     Field,
     condecimal
 )
+from pydantic.dataclasses import dataclass
 
 from app.model.schema.base import (
-    ResultSetQuery,
     ResultSet,
     SortOrder
 )
@@ -55,24 +56,28 @@ class ShareTokensSortItem(str, Enum):
     created = "created"
 
 
-class ShareTokensQuery(ResultSetQuery):
-    owner_address: Optional[str] = Field(description="issuer address")
-    name: Optional[str] = Field(description="token name")
-    symbol: Optional[str] = Field(description="token symbol")
-    company_name: Optional[str] = Field(description="company name")
-    tradable_exchange: Optional[str] = Field(description="tradable exchange address")
-    status: Optional[bool] = Field(description="token status")
-    personal_info_address: Optional[str] = Field(description="personal information address")
-    transferable: Optional[bool] = Field(description="transferable status")
-    is_offering: Optional[bool] = Field(description="offering status")
-    transfer_approval_required: Optional[bool] = Field(description="transfer approval required status")
-    is_canceled: Optional[bool] = Field(description="cancellation status")
+@dataclass
+class ListAllShareTokensQuery:
+    offset: Optional[int] = Query(default=None, description="start position", ge=0)
+    limit: Optional[int] = Query(default=None, description="number of set", ge=0)
 
-    sort_item: Optional[ShareTokensSortItem] = Field(
+    owner_address: Optional[str] = Query(default=None, description="issuer address")
+    name: Optional[str] = Query(default=None, description="token name")
+    symbol: Optional[str] = Query(default=None, description="token symbol")
+    company_name: Optional[str] = Query(default=None, description="company name")
+    tradable_exchange: Optional[str] = Query(default=None, description="tradable exchange address")
+    status: Optional[bool] = Query(default=None, description="token status")
+    personal_info_address: Optional[str] = Query(default=None, description="personal information address")
+    transferable: Optional[bool] = Query(default=None, description="transferable status")
+    is_offering: Optional[bool] = Query(default=None, description="offering status")
+    transfer_approval_required: Optional[bool] = Query(default=None, description="transfer approval required status")
+    is_canceled: Optional[bool] = Query(default=None, description="cancellation status")
+
+    sort_item: Optional[ShareTokensSortItem] = Query(
         default=ShareTokensSortItem.created,
         description="sort item"
     )
-    sort_order: Optional[SortOrder] = Field(default=SortOrder.ASC, description="sort order(0: ASC, 1: DESC)")
+    sort_order: Optional[SortOrder] = Query(default=SortOrder.ASC, description="sort order(0: ASC, 1: DESC)")
 
 
 ############################
@@ -85,7 +90,7 @@ class DividendInformation(BaseModel):
     dividend_payment_date: str = Field(example="20201001")
 
 
-class ShareToken(BaseModel):
+class RetrieveShareTokenResponse(BaseModel):
     token_address: str
     token_template: str = Field(example="IbetShare")
     owner_address: str = Field(description="issuer address")
@@ -112,11 +117,11 @@ class ShareToken(BaseModel):
     dividend_information: DividendInformation
 
 
-class ShareTokensResponse(BaseModel):
+class ListAllShareTokensResponse(BaseModel):
     result_set: ResultSet
-    tokens: list[ShareToken]
+    tokens: list[RetrieveShareTokenResponse]
 
 
-class ShareTokenAddressesResponse(BaseModel):
+class ListAllShareTokenAddressesResponse(BaseModel):
     result_set: ResultSet
     address_list: list[str]

--- a/app/model/schema/user_info.py
+++ b/app/model/schema/user_info.py
@@ -18,6 +18,7 @@ SPDX-License-Identifier: Apache-2.0
 """
 from enum import Enum
 from fastapi import Query
+from pydantic.dataclasses import dataclass
 from typing import Optional
 from pydantic import (
     BaseModel,
@@ -25,8 +26,6 @@ from pydantic import (
     validator
 )
 from web3 import Web3
-
-from app.model.schema.base import QueryModel
 
 ############################
 # COMMON
@@ -37,9 +36,10 @@ from app.model.schema.base import QueryModel
 # REQUEST
 ############################
 
-class PaymentAccountQuery(QueryModel):
-    account_address: str = Field(..., description="Account Address")
-    agent_address: str = Field(..., description="Agent Address")
+@dataclass
+class RetrievePaymentAccountQuery:
+    account_address: str = Query(..., description="Account Address")
+    agent_address: str = Query(..., description="Agent Address")
 
     @validator("account_address")
     def account_address_is_valid_address(cls, v):
@@ -54,7 +54,8 @@ class PaymentAccountQuery(QueryModel):
         return v
 
 
-class PersonalInfoQuery(QueryModel):
+@dataclass
+class RetrievePersonalInfoQuery:
     personal_info_address: Optional[str] = Query(default=None, description="PersonalInfo contract address")
     account_address: str = Query(..., description="account address")
     owner_address: str = Query(..., description="owner(issuer) address")
@@ -91,13 +92,13 @@ class ApprovalStatus(int, Enum):
     BAN = 4
 
 
-class PaymentAccountRegistrationStatus(BaseModel):
+class RetrievePaymentAccountRegistrationStatusResponse(BaseModel):
     account_address: str
     agent_address: str
     approval_status: ApprovalStatus = Field(description="approval status (NONE(0)/NG(1)/OK(2)/WARN(3)/BAN(4))")
 
 
-class PersonalInfoRegistrationStatus(BaseModel):
+class RetrievePersonalInfoRegistrationStatusResponse(BaseModel):
     account_address: str
     owner_address: str = Field(description="link address")
     registered: bool

--- a/app/utils/docs_utils.py
+++ b/app/utils/docs_utils.py
@@ -74,7 +74,7 @@ AppErrorType = TypeVar("AppErrorType", bound=AppError)
 
 
 @lru_cache(None)
-def create_error_model(app_error: Type[AppErrorType]):
+def create_error_model(app_error: Type[AppError]):
     """
     This function creates Pydantic Model from AppError.
     * create_model() generates a different model each time when called,
@@ -83,29 +83,16 @@ def create_error_model(app_error: Type[AppErrorType]):
     @param app_error: AppError defined in ibet-Wallet-API
     @return: pydantic Model created dynamically
     """
-    class ErrorConfig(BaseConfig):
-        schema_extra = {
-            "meta": {
-                "code": {
-                    "example": app_error.error_code
-                },
-                "message": {
-                    "example": app_error.message
-                }
-            }
-        }
 
     metainfo_model = create_model(
         f"{app_error.error_type.strip()}Metainfo",
         code=(int, Field(..., example=app_error.error_code)),
-        message=(str, Field(..., example=app_error.message)),
-        __base__=ErrorInfo
+        message=(str, Field(..., example=app_error.message))
     )
     error_model = create_model(
         f"{app_error.error_type.strip()}Response",
         meta=(metainfo_model, Field(...,)),
         details=(dict | None, Field(default=None, example=None)),
-        __config__=ErrorConfig
     )
     return error_model
 

--- a/docs/ibet_wallet_api.yaml
+++ b/docs/ibet_wallet_api.yaml
@@ -1,17 +1,9 @@
 openapi: 3.0.2
 info:
   title: ibet Wallet API
-  version: 22.9.0
+  description: ibet Wallet API
+  version: 22.12.0
 paths:
-  /:
-    get:
-      tags:
-        - Root
-      summary: Root
-      operationId: root__get
-      responses:
-        '200':
-          description: Successful Response
   /Admin/Tokens:
     get:
       tags:
@@ -27,8 +19,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: >-
-                  #/components/schemas/GenericSuccessResponse_list_app.model.schema.admin.AdminToken__
+                $ref: '#/components/schemas/GenericSuccessResponse_ListAllAdminTokensResponse_'
     post:
       tags:
         - Admin
@@ -41,7 +32,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/RegisterAdminTokensRequest'
+              $ref: '#/components/schemas/RegisterAdminTokenRequest'
         required: true
       responses:
         '200':
@@ -80,7 +71,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GenericSuccessResponse_AdminTokensType_'
+                $ref: '#/components/schemas/GenericSuccessResponse_GetAdminTokenTypeResponse_'
   /Admin/Tokens/{token_address}:
     get:
       tags:
@@ -105,7 +96,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GenericSuccessResponse_AdminToken_'
+                $ref: '#/components/schemas/GenericSuccessResponse_RetrieveAdminTokenResponse_'
         '400':
           description: Bad Request
           content:
@@ -212,7 +203,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GenericSuccessResponse_NodeInfo_'
+                $ref: '#/components/schemas/GenericSuccessResponse_GetNodeInfoResponse_'
   /NodeInfo/BlockSyncStatus:
     get:
       tags:
@@ -226,7 +217,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GenericSuccessResponse_BlockSyncStatus_'
+                $ref: '#/components/schemas/GenericSuccessResponse_GetBlockSyncStatusResponse_'
   /ABI/StraightBond:
     get:
       tags:
@@ -354,8 +345,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: >-
-                  #/components/schemas/GenericSuccessResponse_list_app.model.schema.company_info.CompanyInfo__
+                $ref: '#/components/schemas/GenericSuccessResponse_ListAllCompanyInfoResponse_'
         '400':
           description: Bad Request
           content:
@@ -384,7 +374,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GenericSuccessResponse_CompanyInfo_'
+                $ref: '#/components/schemas/GenericSuccessResponse_RetrieveCompanyInfoResponse_'
         '400':
           description: Bad Request
           content:
@@ -431,8 +421,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: >-
-                  #/components/schemas/GenericSuccessResponse_list_Union_app.model.schema.token_bond.StraightBondToken__app.model.schema.token_share.ShareToken__app.model.schema.token_membership.MembershipToken__app.model.schema.token_coupon.CouponToken___
+                $ref: '#/components/schemas/GenericSuccessResponse_ListAllCompanyTokensResponse_'
         '400':
           description: Bad Request
           content:
@@ -447,16 +436,20 @@ paths:
       description: 'Endpoint: /User/PaymentAccount'
       operationId: PaymentAccount
       parameters:
-        - required: true
+        - description: Account Address
+          required: true
           schema:
             title: Account Address
             type: string
+            description: Account Address
           name: account_address
           in: query
-        - required: true
+        - description: Agent Address
+          required: true
           schema:
             title: Agent Address
             type: string
+            description: Agent Address
           name: agent_address
           in: query
       responses:
@@ -465,8 +458,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: >-
-                  #/components/schemas/GenericSuccessResponse_PaymentAccountRegistrationStatus_
+                $ref: '#/components/schemas/GenericSuccessResponse_RetrievePaymentAccountRegistrationStatusResponse_'
         '400':
           description: Bad Request
           content:
@@ -481,22 +473,28 @@ paths:
       description: 'Endpoint: /User/PersonalInfo'
       operationId: PersonalInfo
       parameters:
-        - required: false
+        - description: PersonalInfo contract address
+          required: false
           schema:
             title: Personal Info Address
             type: string
+            description: PersonalInfo contract address
           name: personal_info_address
           in: query
-        - required: true
+        - description: account address
+          required: true
           schema:
             title: Account Address
             type: string
+            description: account address
           name: account_address
           in: query
-        - required: true
+        - description: owner(issuer) address
+          required: true
           schema:
             title: Owner Address
             type: string
+            description: owner(issuer) address
           name: owner_address
           in: query
       responses:
@@ -505,8 +503,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: >-
-                  #/components/schemas/GenericSuccessResponse_PersonalInfoRegistrationStatus_
+                $ref: '#/components/schemas/GenericSuccessResponse_RetrievePersonalInfoRegistrationStatusResponse_'
         '400':
           description: Bad Request
           content:
@@ -538,7 +535,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GenericSuccessResponse_TransactionCount_'
+                $ref: '#/components/schemas/GenericSuccessResponse_TransactionCountResponse_'
         '400':
           description: Bad Request
           content:
@@ -567,8 +564,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: >-
-                  #/components/schemas/GenericSuccessResponse_list_app.model.schema.eth.SendRawTransactionResult__
+                $ref: '#/components/schemas/GenericSuccessResponse_SendRawTransactionsResponse_'
         '400':
           description: Bad Request
           content:
@@ -597,8 +593,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: >-
-                  #/components/schemas/GenericSuccessResponse_list_app.model.schema.eth.SendRawTransactionNoWaitResult__
+                $ref: '#/components/schemas/GenericSuccessResponse_SendRawTransactionsNoWaitResponse_'
         '400':
           description: Bad Request
           content:
@@ -627,8 +622,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: >-
-                  #/components/schemas/GenericSuccessResponse_WaitForTransactionReceiptResult_
+                $ref: '#/components/schemas/GenericSuccessResponse_WaitForTransactionReceiptResponse_'
         '400':
           description: Bad Request
           content:
@@ -660,117 +654,137 @@ paths:
             default: []
           name: address_list
           in: query
-        - required: false
+        - description: start position
+          required: false
           schema:
             title: Offset
             minimum: 0
             type: integer
+            description: start position
           name: offset
           in: query
-        - required: false
+        - description: number of set
+          required: false
           schema:
             title: Limit
             minimum: 0
             type: integer
+            description: number of set
           name: limit
           in: query
-        - required: false
+        - description: issuer address
+          required: false
           schema:
             title: Owner Address
             type: string
+            description: issuer address
           name: owner_address
           in: query
-        - required: false
+        - description: token name
+          required: false
           schema:
             title: Name
             type: string
+            description: token name
           name: name
           in: query
-        - required: false
+        - description: token symbol
+          required: false
           schema:
             title: Symbol
             type: string
+            description: token symbol
           name: symbol
           in: query
-        - required: false
+        - description: company name
+          required: false
           schema:
             title: Company Name
             type: string
+            description: company name
           name: company_name
           in: query
-        - required: false
+        - description: tradable exchange address
+          required: false
           schema:
             title: Tradable Exchange
             type: string
+            description: tradable exchange address
           name: tradable_exchange
           in: query
-        - required: false
+        - description: token status
+          required: false
           schema:
             title: Status
             type: boolean
+            description: token status
           name: status
           in: query
-        - required: false
+        - description: personal information address
+          required: false
           schema:
             title: Personal Info Address
             type: string
+            description: personal information address
           name: personal_info_address
           in: query
-        - required: false
+        - description: transferable status
+          required: false
           schema:
             title: Transferable
             type: boolean
+            description: transferable status
           name: transferable
           in: query
-        - required: false
+        - description: offering status
+          required: false
           schema:
             title: Is Offering
             type: boolean
+            description: offering status
           name: is_offering
           in: query
-        - required: false
+        - description: transfer approval required status
+          required: false
           schema:
             title: Transfer Approval Required
             type: boolean
+            description: transfer approval required status
           name: transfer_approval_required
           in: query
-        - required: false
+        - description: redeem status
+          required: false
           schema:
             title: Is Redeemed
             type: boolean
+            description: redeem status
           name: is_redeemed
           in: query
-        - required: false
+        - description: sort item
+          required: false
           schema:
             allOf:
               - $ref: '#/components/schemas/StraightBondTokensSortItem'
+            description: sort item
             default: created
           name: sort_item
           in: query
-        - required: false
+        - description: 'sort order(0: ASC, 1: DESC)'
+          required: false
           schema:
             allOf:
               - $ref: '#/components/schemas/SortOrder'
+            description: 'sort order(0: ASC, 1: DESC)'
             default: 0
           name: sort_order
           in: query
-      requestBody:
-        content:
-          application/json:
-            schema:
-              title: Address List
-              type: array
-              items:
-                type: string
-              default: []
       responses:
         '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: >-
-                  #/components/schemas/GenericSuccessResponse_StraightBondTokensResponse_
+                $ref: '#/components/schemas/GenericSuccessResponse_ListAllStraightBondTokensResponse_'
         '400':
           description: Bad Request
           content:
@@ -794,117 +808,148 @@ paths:
       description: 'Endpoint: /Token/StraightBond/Addresses'
       operationId: StraightBondTokenAddresses
       parameters:
-        - required: false
+        - description: start position
+          required: false
           schema:
             title: Offset
             minimum: 0
             type: integer
+            description: start position
           name: offset
           in: query
-        - required: false
+        - description: number of set
+          required: false
           schema:
             title: Limit
             minimum: 0
             type: integer
+            description: number of set
           name: limit
           in: query
-        - required: false
+        - description: issuer address
+          required: false
           schema:
             title: Owner Address
             type: string
+            description: issuer address
           name: owner_address
           in: query
-        - required: false
+        - description: token name
+          required: false
           schema:
             title: Name
             type: string
+            description: token name
           name: name
           in: query
-        - required: false
+        - description: token symbol
+          required: false
           schema:
             title: Symbol
             type: string
+            description: token symbol
           name: symbol
           in: query
-        - required: false
+        - description: company name
+          required: false
           schema:
             title: Company Name
             type: string
+            description: company name
           name: company_name
           in: query
-        - required: false
+        - description: tradable exchange address
+          required: false
           schema:
             title: Tradable Exchange
             type: string
+            description: tradable exchange address
           name: tradable_exchange
           in: query
-        - required: false
+        - description: token status
+          required: false
           schema:
             title: Status
             type: boolean
+            description: token status
           name: status
           in: query
-        - required: false
+        - description: personal information address
+          required: false
           schema:
             title: Personal Info Address
             type: string
+            description: personal information address
           name: personal_info_address
           in: query
-        - required: false
+        - description: transferable status
+          required: false
           schema:
             title: Transferable
             type: boolean
+            description: transferable status
           name: transferable
           in: query
-        - required: false
+        - description: offering status
+          required: false
           schema:
             title: Is Offering
             type: boolean
+            description: offering status
           name: is_offering
           in: query
-        - required: false
+        - description: transfer approval required status
+          required: false
           schema:
             title: Transfer Approval Required
             type: boolean
+            description: transfer approval required status
           name: transfer_approval_required
           in: query
-        - required: false
+        - description: redeem status
+          required: false
           schema:
             title: Is Redeemed
             type: boolean
+            description: redeem status
           name: is_redeemed
           in: query
-        - required: false
+        - description: sort item
+          required: false
           schema:
             allOf:
               - $ref: '#/components/schemas/StraightBondTokensSortItem'
+            description: sort item
             default: created
           name: sort_item
           in: query
-        - required: false
+        - description: 'sort order(0: ASC, 1: DESC)'
+          required: false
           schema:
             allOf:
               - $ref: '#/components/schemas/SortOrder'
+            description: 'sort order(0: ASC, 1: DESC)'
             default: 0
           name: sort_order
           in: query
-      requestBody:
-        content:
-          application/json:
-            schema:
-              title: Address List
-              type: array
-              items:
-                type: string
-              default: []
+        - description: list of token address (**this affects total number**)
+          required: false
+          schema:
+            title: Address List
+            type: array
+            items:
+              type: string
+            description: list of token address (**this affects total number**)
+            default: []
+          name: address_list
+          in: query
       responses:
         '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: >-
-                  #/components/schemas/GenericSuccessResponse_StraightBondTokenAddressesResponse_
+                $ref: '#/components/schemas/GenericSuccessResponse_ListAllStraightBondTokenAddressesResponse_'
         '400':
           description: Bad Request
           content:
@@ -937,7 +982,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GenericSuccessResponse_StraightBondToken_'
+                $ref: '#/components/schemas/GenericSuccessResponse_RetrieveStraightBondTokenResponse_'
         '400':
           description: Bad Request
           content:
@@ -975,97 +1020,127 @@ paths:
             default: []
           name: address_list
           in: query
-        - required: false
+        - description: start position
+          required: false
           schema:
             title: Offset
             minimum: 0
             type: integer
+            description: start position
           name: offset
           in: query
-        - required: false
+        - description: number of set
+          required: false
           schema:
             title: Limit
             minimum: 0
             type: integer
+            description: number of set
           name: limit
           in: query
-        - required: false
+        - description: issuer address
+          required: false
           schema:
             title: Owner Address
             type: string
+            description: issuer address
           name: owner_address
           in: query
-        - required: false
+        - description: token name
+          required: false
           schema:
             title: Name
             type: string
+            description: token name
           name: name
           in: query
-        - required: false
+        - description: token symbol
+          required: false
           schema:
             title: Symbol
             type: string
+            description: token symbol
           name: symbol
           in: query
-        - required: false
+        - description: company name
+          required: false
           schema:
             title: Company Name
             type: string
+            description: company name
           name: company_name
           in: query
-        - required: false
+        - description: tradable exchange address
+          required: false
           schema:
             title: Tradable Exchange
             type: string
+            description: tradable exchange address
           name: tradable_exchange
           in: query
-        - required: false
+        - description: token status
+          required: false
           schema:
             title: Status
             type: boolean
+            description: token status
           name: status
           in: query
-        - required: false
+        - description: personal information address
+          required: false
           schema:
             title: Personal Info Address
             type: string
+            description: personal information address
           name: personal_info_address
           in: query
-        - required: false
+        - description: transferable status
+          required: false
           schema:
             title: Transferable
             type: boolean
+            description: transferable status
           name: transferable
           in: query
-        - required: false
+        - description: offering status
+          required: false
           schema:
             title: Is Offering
             type: boolean
+            description: offering status
           name: is_offering
           in: query
-        - required: false
+        - description: transfer approval required status
+          required: false
           schema:
             title: Transfer Approval Required
             type: boolean
+            description: transfer approval required status
           name: transfer_approval_required
           in: query
-        - required: false
+        - description: cancellation status
+          required: false
           schema:
             title: Is Canceled
             type: boolean
+            description: cancellation status
           name: is_canceled
           in: query
-        - required: false
+        - description: sort item
+          required: false
           schema:
             allOf:
               - $ref: '#/components/schemas/ShareTokensSortItem'
+            description: sort item
             default: created
           name: sort_item
           in: query
-        - required: false
+        - description: 'sort order(0: ASC, 1: DESC)'
+          required: false
           schema:
             allOf:
               - $ref: '#/components/schemas/SortOrder'
+            description: 'sort order(0: ASC, 1: DESC)'
             default: 0
           name: sort_order
           in: query
@@ -1075,8 +1150,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: >-
-                  #/components/schemas/GenericSuccessResponse_ShareTokensResponse_
+                $ref: '#/components/schemas/GenericSuccessResponse_ListAllShareTokensResponse_'
         '400':
           description: Bad Request
           content:
@@ -1100,97 +1174,127 @@ paths:
       description: 'Endpoint: /Token/Share/Addresses'
       operationId: ShareTokenAddresses
       parameters:
-        - required: false
+        - description: start position
+          required: false
           schema:
             title: Offset
             minimum: 0
             type: integer
+            description: start position
           name: offset
           in: query
-        - required: false
+        - description: number of set
+          required: false
           schema:
             title: Limit
             minimum: 0
             type: integer
+            description: number of set
           name: limit
           in: query
-        - required: false
+        - description: issuer address
+          required: false
           schema:
             title: Owner Address
             type: string
+            description: issuer address
           name: owner_address
           in: query
-        - required: false
+        - description: token name
+          required: false
           schema:
             title: Name
             type: string
+            description: token name
           name: name
           in: query
-        - required: false
+        - description: token symbol
+          required: false
           schema:
             title: Symbol
             type: string
+            description: token symbol
           name: symbol
           in: query
-        - required: false
+        - description: company name
+          required: false
           schema:
             title: Company Name
             type: string
+            description: company name
           name: company_name
           in: query
-        - required: false
+        - description: tradable exchange address
+          required: false
           schema:
             title: Tradable Exchange
             type: string
+            description: tradable exchange address
           name: tradable_exchange
           in: query
-        - required: false
+        - description: token status
+          required: false
           schema:
             title: Status
             type: boolean
+            description: token status
           name: status
           in: query
-        - required: false
+        - description: personal information address
+          required: false
           schema:
             title: Personal Info Address
             type: string
+            description: personal information address
           name: personal_info_address
           in: query
-        - required: false
+        - description: transferable status
+          required: false
           schema:
             title: Transferable
             type: boolean
+            description: transferable status
           name: transferable
           in: query
-        - required: false
+        - description: offering status
+          required: false
           schema:
             title: Is Offering
             type: boolean
+            description: offering status
           name: is_offering
           in: query
-        - required: false
+        - description: transfer approval required status
+          required: false
           schema:
             title: Transfer Approval Required
             type: boolean
+            description: transfer approval required status
           name: transfer_approval_required
           in: query
-        - required: false
+        - description: cancellation status
+          required: false
           schema:
             title: Is Canceled
             type: boolean
+            description: cancellation status
           name: is_canceled
           in: query
-        - required: false
+        - description: sort item
+          required: false
           schema:
             allOf:
               - $ref: '#/components/schemas/ShareTokensSortItem'
+            description: sort item
             default: created
           name: sort_item
           in: query
-        - required: false
+        - description: 'sort order(0: ASC, 1: DESC)'
+          required: false
           schema:
             allOf:
               - $ref: '#/components/schemas/SortOrder'
+            description: 'sort order(0: ASC, 1: DESC)'
             default: 0
           name: sort_order
           in: query
@@ -1200,8 +1304,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: >-
-                  #/components/schemas/GenericSuccessResponse_ShareTokenAddressesResponse_
+                $ref: '#/components/schemas/GenericSuccessResponse_ListAllShareTokenAddressesResponse_'
         '400':
           description: Bad Request
           content:
@@ -1234,7 +1337,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GenericSuccessResponse_ShareToken_'
+                $ref: '#/components/schemas/GenericSuccessResponse_RetrieveShareTokenResponse_'
         '400':
           description: Bad Request
           content:
@@ -1269,79 +1372,103 @@ paths:
             default: []
           name: address_list
           in: query
-        - required: false
+        - description: start position
+          required: false
           schema:
             title: Offset
             minimum: 0
             type: integer
+            description: start position
           name: offset
           in: query
-        - required: false
+        - description: number of set
+          required: false
           schema:
             title: Limit
             minimum: 0
             type: integer
+            description: number of set
           name: limit
           in: query
-        - required: false
+        - description: issuer address
+          required: false
           schema:
             title: Owner Address
             type: string
+            description: issuer address
           name: owner_address
           in: query
-        - required: false
+        - description: token name
+          required: false
           schema:
             title: Name
             type: string
+            description: token name
           name: name
           in: query
-        - required: false
+        - description: token symbol
+          required: false
           schema:
             title: Symbol
             type: string
+            description: token symbol
           name: symbol
           in: query
-        - required: false
+        - description: company name
+          required: false
           schema:
             title: Company Name
             type: string
+            description: company name
           name: company_name
           in: query
-        - required: false
+        - description: tradable exchange address
+          required: false
           schema:
             title: Tradable Exchange
             type: string
+            description: tradable exchange address
           name: tradable_exchange
           in: query
-        - required: false
+        - description: token status
+          required: false
           schema:
             title: Status
             type: boolean
+            description: token status
           name: status
           in: query
-        - required: false
+        - description: transferable status
+          required: false
           schema:
             title: Transferable
             type: boolean
+            description: transferable status
           name: transferable
           in: query
-        - required: false
+        - description: offering status
+          required: false
           schema:
             title: Initial Offering Status
             type: boolean
+            description: offering status
           name: initial_offering_status
           in: query
-        - required: false
+        - description: sort item
+          required: false
           schema:
             allOf:
               - $ref: '#/components/schemas/MembershipTokensSortItem'
+            description: sort item
             default: created
           name: sort_item
           in: query
-        - required: false
+        - description: 'sort order(0: ASC, 1: DESC)'
+          required: false
           schema:
             allOf:
               - $ref: '#/components/schemas/SortOrder'
+            description: 'sort order(0: ASC, 1: DESC)'
             default: 0
           name: sort_order
           in: query
@@ -1351,8 +1478,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: >-
-                  #/components/schemas/GenericSuccessResponse_MembershipTokensResponse_
+                $ref: '#/components/schemas/GenericSuccessResponse_ListAllMembershipTokensResponse_'
         '400':
           description: Bad Request
           content:
@@ -1376,79 +1502,103 @@ paths:
       description: 'Endpoint: /Token/Membership/Addresses'
       operationId: MembershipTokenAddresses
       parameters:
-        - required: false
+        - description: start position
+          required: false
           schema:
             title: Offset
             minimum: 0
             type: integer
+            description: start position
           name: offset
           in: query
-        - required: false
+        - description: number of set
+          required: false
           schema:
             title: Limit
             minimum: 0
             type: integer
+            description: number of set
           name: limit
           in: query
-        - required: false
+        - description: issuer address
+          required: false
           schema:
             title: Owner Address
             type: string
+            description: issuer address
           name: owner_address
           in: query
-        - required: false
+        - description: token name
+          required: false
           schema:
             title: Name
             type: string
+            description: token name
           name: name
           in: query
-        - required: false
+        - description: token symbol
+          required: false
           schema:
             title: Symbol
             type: string
+            description: token symbol
           name: symbol
           in: query
-        - required: false
+        - description: company name
+          required: false
           schema:
             title: Company Name
             type: string
+            description: company name
           name: company_name
           in: query
-        - required: false
+        - description: tradable exchange address
+          required: false
           schema:
             title: Tradable Exchange
             type: string
+            description: tradable exchange address
           name: tradable_exchange
           in: query
-        - required: false
+        - description: token status
+          required: false
           schema:
             title: Status
             type: boolean
+            description: token status
           name: status
           in: query
-        - required: false
+        - description: transferable status
+          required: false
           schema:
             title: Transferable
             type: boolean
+            description: transferable status
           name: transferable
           in: query
-        - required: false
+        - description: offering status
+          required: false
           schema:
             title: Initial Offering Status
             type: boolean
+            description: offering status
           name: initial_offering_status
           in: query
-        - required: false
+        - description: sort item
+          required: false
           schema:
             allOf:
               - $ref: '#/components/schemas/MembershipTokensSortItem'
+            description: sort item
             default: created
           name: sort_item
           in: query
-        - required: false
+        - description: 'sort order(0: ASC, 1: DESC)'
+          required: false
           schema:
             allOf:
               - $ref: '#/components/schemas/SortOrder'
+            description: 'sort order(0: ASC, 1: DESC)'
             default: 0
           name: sort_order
           in: query
@@ -1458,8 +1608,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: >-
-                  #/components/schemas/GenericSuccessResponse_MembershipTokenAddressesResponse_
+                $ref: '#/components/schemas/GenericSuccessResponse_ListAllMembershipTokenAddressesResponse_'
         '400':
           description: Bad Request
           content:
@@ -1492,7 +1641,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GenericSuccessResponse_MembershipToken_'
+                $ref: '#/components/schemas/GenericSuccessResponse_RetrieveMembershipTokenResponse_'
         '400':
           description: Bad Request
           content:
@@ -1527,79 +1676,103 @@ paths:
             default: []
           name: address_list
           in: query
-        - required: false
+        - description: start position
+          required: false
           schema:
             title: Offset
             minimum: 0
             type: integer
+            description: start position
           name: offset
           in: query
-        - required: false
+        - description: number of set
+          required: false
           schema:
             title: Limit
             minimum: 0
             type: integer
+            description: number of set
           name: limit
           in: query
-        - required: false
+        - description: issuer address
+          required: false
           schema:
             title: Owner Address
             type: string
+            description: issuer address
           name: owner_address
           in: query
-        - required: false
+        - description: token name
+          required: false
           schema:
             title: Name
             type: string
+            description: token name
           name: name
           in: query
-        - required: false
+        - description: token symbol
+          required: false
           schema:
             title: Symbol
             type: string
+            description: token symbol
           name: symbol
           in: query
-        - required: false
+        - description: company name
+          required: false
           schema:
             title: Company Name
             type: string
+            description: company name
           name: company_name
           in: query
-        - required: false
+        - description: tradable exchange address
+          required: false
           schema:
             title: Tradable Exchange
             type: string
+            description: tradable exchange address
           name: tradable_exchange
           in: query
-        - required: false
+        - description: token status
+          required: false
           schema:
             title: Status
             type: boolean
+            description: token status
           name: status
           in: query
-        - required: false
+        - description: transferable status
+          required: false
           schema:
             title: Transferable
             type: boolean
+            description: transferable status
           name: transferable
           in: query
-        - required: false
+        - description: offering status
+          required: false
           schema:
             title: Initial Offering Status
             type: boolean
+            description: offering status
           name: initial_offering_status
           in: query
-        - required: false
+        - description: sort item
+          required: false
           schema:
             allOf:
               - $ref: '#/components/schemas/CouponTokensSortItem'
+            description: sort item
             default: created
           name: sort_item
           in: query
-        - required: false
+        - description: 'sort order(0: ASC, 1: DESC)'
+          required: false
           schema:
             allOf:
               - $ref: '#/components/schemas/SortOrder'
+            description: 'sort order(0: ASC, 1: DESC)'
             default: 0
           name: sort_order
           in: query
@@ -1609,8 +1782,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: >-
-                  #/components/schemas/GenericSuccessResponse_CouponTokensResponse_
+                $ref: '#/components/schemas/GenericSuccessResponse_ListAllCouponTokensResponse_'
         '400':
           description: Bad Request
           content:
@@ -1634,79 +1806,103 @@ paths:
       description: 'Endpoint: /Token/Coupon/Addresses'
       operationId: CouponTokenAddresses
       parameters:
-        - required: false
+        - description: start position
+          required: false
           schema:
             title: Offset
             minimum: 0
             type: integer
+            description: start position
           name: offset
           in: query
-        - required: false
+        - description: number of set
+          required: false
           schema:
             title: Limit
             minimum: 0
             type: integer
+            description: number of set
           name: limit
           in: query
-        - required: false
+        - description: issuer address
+          required: false
           schema:
             title: Owner Address
             type: string
+            description: issuer address
           name: owner_address
           in: query
-        - required: false
+        - description: token name
+          required: false
           schema:
             title: Name
             type: string
+            description: token name
           name: name
           in: query
-        - required: false
+        - description: token symbol
+          required: false
           schema:
             title: Symbol
             type: string
+            description: token symbol
           name: symbol
           in: query
-        - required: false
+        - description: company name
+          required: false
           schema:
             title: Company Name
             type: string
+            description: company name
           name: company_name
           in: query
-        - required: false
+        - description: tradable exchange address
+          required: false
           schema:
             title: Tradable Exchange
             type: string
+            description: tradable exchange address
           name: tradable_exchange
           in: query
-        - required: false
+        - description: token status
+          required: false
           schema:
             title: Status
             type: boolean
+            description: token status
           name: status
           in: query
-        - required: false
+        - description: transferable status
+          required: false
           schema:
             title: Transferable
             type: boolean
+            description: transferable status
           name: transferable
           in: query
-        - required: false
+        - description: offering status
+          required: false
           schema:
             title: Initial Offering Status
             type: boolean
+            description: offering status
           name: initial_offering_status
           in: query
-        - required: false
+        - description: sort item
+          required: false
           schema:
             allOf:
               - $ref: '#/components/schemas/CouponTokensSortItem'
+            description: sort item
             default: created
           name: sort_item
           in: query
-        - required: false
+        - description: 'sort order(0: ASC, 1: DESC)'
+          required: false
           schema:
             allOf:
               - $ref: '#/components/schemas/SortOrder'
+            description: 'sort order(0: ASC, 1: DESC)'
             default: 0
           name: sort_order
           in: query
@@ -1716,8 +1912,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: >-
-                  #/components/schemas/GenericSuccessResponse_CouponTokenAddressesResponse_
+                $ref: '#/components/schemas/GenericSuccessResponse_ListAllCouponTokenAddressesResponse_'
         '400':
           description: Bad Request
           content:
@@ -1750,7 +1945,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GenericSuccessResponse_CouponToken_'
+                $ref: '#/components/schemas/GenericSuccessResponse_RetrieveCouponTokenResponse_'
         '400':
           description: Bad Request
           content:
@@ -1791,7 +1986,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GenericSuccessResponse_TokenStatus_'
+                $ref: '#/components/schemas/GenericSuccessResponse_TokenStatusResponse_'
         '400':
           description: Bad Request
           content:
@@ -1829,8 +2024,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: >-
-                  #/components/schemas/GenericSuccessResponse_list_app.model.schema.token.TokenHolder__
+                $ref: '#/components/schemas/GenericSuccessResponse_TokenHoldersResponse_'
         '400':
           description: Bad Request
           content:
@@ -1868,7 +2062,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GenericSuccessResponse_TokenHoldersCount_'
+                $ref: '#/components/schemas/GenericSuccessResponse_TokenHoldersCountResponse_'
         '400':
           description: Bad Request
           content:
@@ -1912,8 +2106,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: >-
-                  #/components/schemas/GenericSuccessResponse_CreateTokenHoldersCollectionResponse_
+                $ref: '#/components/schemas/GenericSuccessResponse_CreateTokenHoldersCollectionResponse_'
         '400':
           description: Bad Request
           content:
@@ -1945,16 +2138,12 @@ paths:
             description: token address
           name: token_address
           in: path
-        - description: >-
-            Unique id to be assigned to each token holder list.This must be
-            Version4 UUID.
+        - description: Unique id to be assigned to each token holder list.This must be Version4 UUID.
           required: true
           schema:
             title: List Id
             type: string
-            description: >-
-              Unique id to be assigned to each token holder list.This must be
-              Version4 UUID.
+            description: Unique id to be assigned to each token holder list.This must be Version4 UUID.
             format: uuid
           example: cfd83622-34dc-4efe-a68b-2cc275d3d824
           name: list_id
@@ -1965,8 +2154,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: >-
-                  #/components/schemas/GenericSuccessResponse_TokenHoldersCollection_
+                $ref: '#/components/schemas/GenericSuccessResponse_TokenHoldersCollectionResponse_'
         '400':
           description: Bad Request
           content:
@@ -1998,18 +2186,22 @@ paths:
             description: token address
           name: token_address
           in: path
-        - required: false
+        - description: start position
+          required: false
           schema:
             title: Offset
             minimum: 0
             type: integer
+            description: start position
           name: offset
           in: query
-        - required: false
+        - description: number of set
+          required: false
           schema:
             title: Limit
             minimum: 0
             type: integer
+            description: number of set
           name: limit
           in: query
       responses:
@@ -2018,8 +2210,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: >-
-                  #/components/schemas/GenericSuccessResponse_TransferHistoriesResponse_
+                $ref: '#/components/schemas/GenericSuccessResponse_TransferHistoriesResponse_'
         '400':
           description: Bad Request
           content:
@@ -2051,18 +2242,22 @@ paths:
             description: token address
           name: token_address
           in: path
-        - required: false
+        - description: start position
+          required: false
           schema:
             title: Offset
             minimum: 0
             type: integer
+            description: start position
           name: offset
           in: query
-        - required: false
+        - description: number of set
+          required: false
           schema:
             title: Limit
             minimum: 0
             type: integer
+            description: number of set
           name: limit
           in: query
       responses:
@@ -2071,8 +2266,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: >-
-                  #/components/schemas/GenericSuccessResponse_TransferApprovalHistoriesResponse_
+                $ref: '#/components/schemas/GenericSuccessResponse_TransferApprovalHistoriesResponse_'
         '400':
           description: Bad Request
           content:
@@ -2102,31 +2296,39 @@ paths:
             type: string
           name: account_address
           in: path
-        - required: false
+        - description: start position
+          required: false
           schema:
             title: Offset
             minimum: 0
             type: integer
+            description: start position
           name: offset
           in: query
-        - required: false
+        - description: number of set
+          required: false
           schema:
             title: Limit
             minimum: 0
             type: integer
+            description: number of set
           name: limit
           in: query
-        - required: false
+        - description: include token details
+          required: false
           schema:
             title: Include Token Details
             type: boolean
+            description: include token details
             default: false
           name: include_token_details
           in: query
-        - required: false
+        - description: enable using indexed position data
+          required: false
           schema:
             title: Enable Index
             type: boolean
+            description: enable using indexed position data
             default: false
           name: enable_index
           in: query
@@ -2136,8 +2338,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: >-
-                  #/components/schemas/GenericSuccessResponse_app.model.schema.position.GenericSecurityTokenPositionsResponse_app.model.schema.token_share.ShareToken__
+                $ref: '#/components/schemas/GenericSuccessResponse_app.model.schema.position.GenericSecurityTokenPositionsResponse_app.model.schema.token_share.RetrieveShareTokenResponse__'
         '400':
           description: Bad Request
           content:
@@ -2170,31 +2371,39 @@ paths:
             type: string
           name: account_address
           in: path
-        - required: false
+        - description: start position
+          required: false
           schema:
             title: Offset
             minimum: 0
             type: integer
+            description: start position
           name: offset
           in: query
-        - required: false
+        - description: number of set
+          required: false
           schema:
             title: Limit
             minimum: 0
             type: integer
+            description: number of set
           name: limit
           in: query
-        - required: false
+        - description: include token details
+          required: false
           schema:
             title: Include Token Details
             type: boolean
+            description: include token details
             default: false
           name: include_token_details
           in: query
-        - required: false
+        - description: enable using indexed position data
+          required: false
           schema:
             title: Enable Index
             type: boolean
+            description: enable using indexed position data
             default: false
           name: enable_index
           in: query
@@ -2204,8 +2413,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: >-
-                  #/components/schemas/GenericSuccessResponse_app.model.schema.position.GenericSecurityTokenPositionsResponse_app.model.schema.token_bond.StraightBondToken__
+                $ref: '#/components/schemas/GenericSuccessResponse_app.model.schema.position.GenericSecurityTokenPositionsResponse_app.model.schema.token_bond.RetrieveStraightBondTokenResponse__'
         '400':
           description: Bad Request
           content:
@@ -2238,31 +2446,39 @@ paths:
             type: string
           name: account_address
           in: path
-        - required: false
+        - description: start position
+          required: false
           schema:
             title: Offset
             minimum: 0
             type: integer
+            description: start position
           name: offset
           in: query
-        - required: false
+        - description: number of set
+          required: false
           schema:
             title: Limit
             minimum: 0
             type: integer
+            description: number of set
           name: limit
           in: query
-        - required: false
+        - description: include token details
+          required: false
           schema:
             title: Include Token Details
             type: boolean
+            description: include token details
             default: false
           name: include_token_details
           in: query
-        - required: false
+        - description: enable using indexed position data
+          required: false
           schema:
             title: Enable Index
             type: boolean
+            description: enable using indexed position data
             default: false
           name: enable_index
           in: query
@@ -2272,8 +2488,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: >-
-                  #/components/schemas/GenericSuccessResponse_MembershipPositionsResponse_
+                $ref: '#/components/schemas/GenericSuccessResponse_MembershipPositionsResponse_'
         '400':
           description: Bad Request
           content:
@@ -2306,31 +2521,39 @@ paths:
             type: string
           name: account_address
           in: path
-        - required: false
+        - description: start position
+          required: false
           schema:
             title: Offset
             minimum: 0
             type: integer
+            description: start position
           name: offset
           in: query
-        - required: false
+        - description: number of set
+          required: false
           schema:
             title: Limit
             minimum: 0
             type: integer
+            description: number of set
           name: limit
           in: query
-        - required: false
+        - description: include token details
+          required: false
           schema:
             title: Include Token Details
             type: boolean
+            description: include token details
             default: false
           name: include_token_details
           in: query
-        - required: false
+        - description: enable using indexed position data
+          required: false
           schema:
             title: Enable Index
             type: boolean
+            description: enable using indexed position data
             default: false
           name: enable_index
           in: query
@@ -2340,8 +2563,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: >-
-                  #/components/schemas/GenericSuccessResponse_CouponPositionsResponse_
+                $ref: '#/components/schemas/GenericSuccessResponse_CouponPositionsResponse_'
         '400':
           description: Bad Request
           content:
@@ -2386,8 +2608,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: >-
-                  #/components/schemas/GenericSuccessResponse_app.model.schema.position.SecurityTokenPositionWithDetail_app.model.schema.token_share.ShareToken__
+                $ref: '#/components/schemas/GenericSuccessResponse_app.model.schema.position.SecurityTokenPositionWithDetail_app.model.schema.token_share.RetrieveShareTokenResponse__'
         '400':
           description: Bad Request
           content:
@@ -2432,8 +2653,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: >-
-                  #/components/schemas/GenericSuccessResponse_app.model.schema.position.SecurityTokenPositionWithDetail_app.model.schema.token_bond.StraightBondToken__
+                $ref: '#/components/schemas/GenericSuccessResponse_app.model.schema.position.SecurityTokenPositionWithDetail_app.model.schema.token_bond.RetrieveStraightBondTokenResponse__'
         '400':
           description: Bad Request
           content:
@@ -2478,8 +2698,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: >-
-                  #/components/schemas/GenericSuccessResponse_MembershipPositionWithDetail_
+                $ref: '#/components/schemas/GenericSuccessResponse_MembershipPositionWithDetail_'
         '400':
           description: Bad Request
           content:
@@ -2524,8 +2743,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: >-
-                  #/components/schemas/GenericSuccessResponse_CouponPositionWithDetail_
+                $ref: '#/components/schemas/GenericSuccessResponse_CouponPositionWithDetail_'
         '400':
           description: Bad Request
           content:
@@ -2552,18 +2770,22 @@ paths:
       description: 'Endpoint: /Notifications/'
       operationId: GetNotifications
       parameters:
-        - required: false
+        - description: start position
+          required: false
           schema:
             title: Offset
             minimum: 0
             type: integer
+            description: start position
           name: offset
           in: query
-        - required: false
+        - description: number of set
+          required: false
           schema:
             title: Limit
             minimum: 0
             type: integer
+            description: number of set
           name: limit
           in: query
         - required: false
@@ -2585,17 +2807,21 @@ paths:
             type: integer
           name: priority
           in: query
-        - required: false
+        - description: sort item
+          required: false
           schema:
             allOf:
               - $ref: '#/components/schemas/NotificationsSortItem'
+            description: sort item
             default: created
           name: sort_item
           in: query
-        - required: false
+        - description: 'sort order(0: ASC, 1: DESC)'
+          required: false
           schema:
             allOf:
               - $ref: '#/components/schemas/SortOrder'
+            description: 'sort order(0: ASC, 1: DESC)'
             default: 0
           name: sort_order
           in: query
@@ -2605,8 +2831,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: >-
-                  #/components/schemas/GenericSuccessResponse_NotificationsResponse_
+                $ref: '#/components/schemas/GenericSuccessResponse_NotificationsResponse_'
         '400':
           description: Bad Request
           content:
@@ -2659,8 +2884,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: >-
-                  #/components/schemas/GenericSuccessResponse_NotificationsCountResponse_
+                $ref: '#/components/schemas/GenericSuccessResponse_NotificationsCountResponse_'
         '400':
           description: Bad Request
           content:
@@ -2695,8 +2919,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: >-
-                  #/components/schemas/GenericSuccessResponse_NotificationUpdateResponse_
+                $ref: '#/components/schemas/GenericSuccessResponse_NotificationUpdateResponse_'
         '400':
           description: Bad Request
           content:
@@ -2764,8 +2987,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: >-
-                  #/components/schemas/GenericSuccessResponse_E2EMessageEncryptionKey_
+                $ref: '#/components/schemas/GenericSuccessResponse_E2EMessageEncryptionKeyResponse_'
         '400':
           description: Bad Request
           content:
@@ -2789,29 +3011,38 @@ paths:
       description: List all E2EMessaging event logs
       operationId: E2EMessagingEvents
       parameters:
-        - required: true
+        - description: from block number
+          required: true
           schema:
             title: From Block
             minimum: 1
             type: integer
+            description: from block number
           name: from_block
           in: query
-        - required: true
+        - description: to block number
+          required: true
           schema:
             title: To Block
             minimum: 1
             type: integer
+            description: to block number
           name: to_block
           in: query
-        - required: false
+        - description: events to get
+          required: false
           schema:
-            $ref: '#/components/schemas/E2EMessagingEventType'
+            allOf:
+              - $ref: '#/components/schemas/E2EMessagingEventType'
+            description: events to get
           name: event
           in: query
-        - required: false
+        - description: 'filter argument. serialize obj to a JSON formatted str required.eg.```{"sender": "0x0000000000000000000000000000000000000000"}```'
+          required: false
           schema:
             title: Argument Filters
             type: string
+            description: 'filter argument. serialize obj to a JSON formatted str required.eg.```{"sender": "0x0000000000000000000000000000000000000000"}```'
           name: argument_filters
           in: query
       responses:
@@ -2820,8 +3051,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: >-
-                  #/components/schemas/GenericSuccessResponse_list_app.model.schema.events.Event__
+                $ref: '#/components/schemas/GenericSuccessResponse_ListAllEventsResponse_'
         '400':
           description: Bad Request
           content:
@@ -2839,29 +3069,38 @@ paths:
       description: List all IbetEscrow event logs
       operationId: IbetEscrowEvents
       parameters:
-        - required: true
+        - description: from block number
+          required: true
           schema:
             title: From Block
             minimum: 1
             type: integer
+            description: from block number
           name: from_block
           in: query
-        - required: true
+        - description: to block number
+          required: true
           schema:
             title: To Block
             minimum: 1
             type: integer
+            description: to block number
           name: to_block
           in: query
-        - required: false
+        - description: events to get
+          required: false
           schema:
-            $ref: '#/components/schemas/IbetEscrowEventType'
+            allOf:
+              - $ref: '#/components/schemas/IbetEscrowEventType'
+            description: events to get
           name: event
           in: query
-        - required: false
+        - description: 'filter argument. serialize obj to a JSON formatted str required.eg.```{    "escrowId": 0    "token": "0x0000000000000000000000000000000000000000"}```'
+          required: false
           schema:
             title: Argument Filters
             type: string
+            description: 'filter argument. serialize obj to a JSON formatted str required.eg.```{    "escrowId": 0    "token": "0x0000000000000000000000000000000000000000"}```'
           name: argument_filters
           in: query
       responses:
@@ -2870,8 +3109,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: >-
-                  #/components/schemas/GenericSuccessResponse_list_app.model.schema.events.Event__
+                $ref: '#/components/schemas/GenericSuccessResponse_ListAllEventsResponse_'
         '400':
           description: Bad Request
           content:
@@ -2889,29 +3127,38 @@ paths:
       description: List all IbetSecurityTokenEscrow event logs
       operationId: IbetSecurityTokenEscrowEvents
       parameters:
-        - required: true
+        - description: from block number
+          required: true
           schema:
             title: From Block
             minimum: 1
             type: integer
+            description: from block number
           name: from_block
           in: query
-        - required: true
+        - description: to block number
+          required: true
           schema:
             title: To Block
             minimum: 1
             type: integer
+            description: to block number
           name: to_block
           in: query
-        - required: false
+        - description: events to get
+          required: false
           schema:
-            $ref: '#/components/schemas/IbetSecurityTokenEscrowEventType'
+            allOf:
+              - $ref: '#/components/schemas/IbetSecurityTokenEscrowEventType'
+            description: events to get
           name: event
           in: query
-        - required: false
+        - description: 'filter argument. serialize obj to a JSON formatted str required.eg.```{    "escrowId": 0    "token": "0x0000000000000000000000000000000000000000"}```'
+          required: false
           schema:
             title: Argument Filters
             type: string
+            description: 'filter argument. serialize obj to a JSON formatted str required.eg.```{    "escrowId": 0    "token": "0x0000000000000000000000000000000000000000"}```'
           name: argument_filters
           in: query
       responses:
@@ -2920,8 +3167,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: >-
-                  #/components/schemas/GenericSuccessResponse_list_app.model.schema.events.Event__
+                $ref: '#/components/schemas/GenericSuccessResponse_ListAllEventsResponse_'
         '400':
           description: Bad Request
           content:
@@ -2939,22 +3185,28 @@ paths:
       description: 約定情報参照
       operationId: GetAgreement
       parameters:
-        - required: true
+        - description: order id
+          required: true
           schema:
             title: Order Id
             type: integer
+            description: order id
           name: order_id
           in: query
-        - required: true
+        - description: agreement id
+          required: true
           schema:
             title: Agreement Id
             type: integer
+            description: agreement id
           name: agreement_id
           in: query
-        - required: true
+        - description: exchange_address
+          required: true
           schema:
             title: Exchange Address
             type: string
+            description: exchange_address
           name: exchange_address
           in: query
       responses:
@@ -2963,7 +3215,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GenericSuccessResponse_AgreementDetail_'
+                $ref: '#/components/schemas/GenericSuccessResponse_RetrieveAgreementDetailResponse_'
         '400':
           description: Bad Request
           content:
@@ -2990,7 +3242,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/OrderBookRequest'
+              $ref: '#/components/schemas/ListAllOrderBookRequest'
         required: true
       responses:
         '200':
@@ -2998,8 +3250,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: >-
-                  #/components/schemas/GenericSuccessResponse_list_app.model.schema.dex_market.OrderBookItem__
+                $ref: '#/components/schemas/GenericSuccessResponse_ListAllOrderBookItemResponse_'
         '400':
           description: Bad Request
           content:
@@ -3023,7 +3274,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/LastPriceRequest'
+              $ref: '#/components/schemas/ListAllLastPriceRequest'
         required: true
       responses:
         '200':
@@ -3031,8 +3282,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: >-
-                  #/components/schemas/GenericSuccessResponse_list_app.model.schema.dex_market.LastPrice__
+                $ref: '#/components/schemas/GenericSuccessResponse_ListAllLastPriceResponse_'
         '400':
           description: Bad Request
           content:
@@ -3056,7 +3306,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TickRequest'
+              $ref: '#/components/schemas/ListAllTickRequest'
         required: true
       responses:
         '200':
@@ -3064,8 +3314,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: >-
-                  #/components/schemas/GenericSuccessResponse_list_app.model.schema.dex_market.TicksResponse__
+                $ref: '#/components/schemas/GenericSuccessResponse_ListAllTicksResponse_'
         '400':
           description: Bad Request
           content:
@@ -3089,7 +3338,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/OrderBookRequest'
+              $ref: '#/components/schemas/ListAllOrderBookRequest'
         required: true
       responses:
         '200':
@@ -3097,8 +3346,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: >-
-                  #/components/schemas/GenericSuccessResponse_list_app.model.schema.dex_market.OrderBookItem__
+                $ref: '#/components/schemas/GenericSuccessResponse_ListAllOrderBookItemResponse_'
         '400':
           description: Bad Request
           content:
@@ -3122,7 +3370,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/LastPriceRequest'
+              $ref: '#/components/schemas/ListAllLastPriceRequest'
         required: true
       responses:
         '200':
@@ -3130,8 +3378,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: >-
-                  #/components/schemas/GenericSuccessResponse_list_app.model.schema.dex_market.LastPrice__
+                $ref: '#/components/schemas/GenericSuccessResponse_ListAllLastPriceResponse_'
         '400':
           description: Bad Request
           content:
@@ -3155,7 +3402,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TickRequest'
+              $ref: '#/components/schemas/ListAllTickRequest'
         required: true
       responses:
         '200':
@@ -3163,8 +3410,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: >-
-                  #/components/schemas/GenericSuccessResponse_list_app.model.schema.dex_market.TicksResponse__
+                $ref: '#/components/schemas/GenericSuccessResponse_ListAllTicksResponse_'
         '400':
           description: Bad Request
           content:
@@ -3188,7 +3434,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/OrderBookRequest'
+              $ref: '#/components/schemas/ListAllOrderBookRequest'
         required: true
       responses:
         '200':
@@ -3196,8 +3442,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: >-
-                  #/components/schemas/GenericSuccessResponse_list_app.model.schema.dex_market.OrderBookItem__
+                $ref: '#/components/schemas/GenericSuccessResponse_ListAllOrderBookItemResponse_'
         '400':
           description: Bad Request
           content:
@@ -3221,7 +3466,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/LastPriceRequest'
+              $ref: '#/components/schemas/ListAllLastPriceRequest'
         required: true
       responses:
         '200':
@@ -3229,8 +3474,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: >-
-                  #/components/schemas/GenericSuccessResponse_list_app.model.schema.dex_market.LastPrice__
+                $ref: '#/components/schemas/GenericSuccessResponse_ListAllLastPriceResponse_'
         '400':
           description: Bad Request
           content:
@@ -3254,7 +3498,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TickRequest'
+              $ref: '#/components/schemas/ListAllTickRequest'
         required: true
       responses:
         '200':
@@ -3262,8 +3506,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: >-
-                  #/components/schemas/GenericSuccessResponse_list_app.model.schema.dex_market.TicksResponse__
+                $ref: '#/components/schemas/GenericSuccessResponse_ListAllTicksResponse_'
         '400':
           description: Bad Request
           content:
@@ -3287,7 +3530,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/OrderListRequest'
+              $ref: '#/components/schemas/ListAllOrderListRequest'
         required: true
       responses:
         '200':
@@ -3295,8 +3538,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: >-
-                  #/components/schemas/GenericSuccessResponse_app.model.schema.dex_order_list.OrderListResponse_app.model.schema.token_bond.StraightBondToken__
+                $ref: '#/components/schemas/GenericSuccessResponse_app.model.schema.dex_order_list.ListAllOrderListResponse_app.model.schema.token_bond.RetrieveStraightBondTokenResponse__'
         '400':
           description: Bad Request
           content:
@@ -3320,7 +3562,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/OrderListRequest'
+              $ref: '#/components/schemas/ListAllOrderListRequest'
         required: true
       responses:
         '200':
@@ -3328,8 +3570,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: >-
-                  #/components/schemas/GenericSuccessResponse_app.model.schema.dex_order_list.OrderListResponse_app.model.schema.token_membership.MembershipToken__
+                $ref: '#/components/schemas/GenericSuccessResponse_app.model.schema.dex_order_list.ListAllOrderListResponse_app.model.schema.token_membership.RetrieveMembershipTokenResponse__'
         '400':
           description: Bad Request
           content:
@@ -3353,7 +3594,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/OrderListRequest'
+              $ref: '#/components/schemas/ListAllOrderListRequest'
         required: true
       responses:
         '200':
@@ -3361,8 +3602,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: >-
-                  #/components/schemas/GenericSuccessResponse_app.model.schema.dex_order_list.OrderListResponse_app.model.schema.token_coupon.CouponToken__
+                $ref: '#/components/schemas/GenericSuccessResponse_app.model.schema.dex_order_list.ListAllOrderListResponse_app.model.schema.token_coupon.RetrieveCouponTokenResponse__'
         '400':
           description: Bad Request
           content:
@@ -3386,7 +3626,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/OrderListRequest'
+              $ref: '#/components/schemas/ListAllOrderListRequest'
         required: true
       responses:
         '200':
@@ -3394,8 +3634,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: >-
-                  #/components/schemas/GenericSuccessResponse_app.model.schema.dex_order_list.OrderListResponse_app.model.schema.token_share.ShareToken__
+                $ref: '#/components/schemas/GenericSuccessResponse_app.model.schema.dex_order_list.ListAllOrderListResponse_app.model.schema.token_share.RetrieveShareTokenResponse__'
         '400':
           description: Bad Request
           content:
@@ -3426,7 +3665,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/OrderListRequest'
+              $ref: '#/components/schemas/ListAllOrderListRequest'
         required: true
       responses:
         '200':
@@ -3434,8 +3673,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: >-
-                  #/components/schemas/GenericSuccessResponse_app.model.schema.dex_order_list.OrderListResponse_app.model.schema.dex_order_list.TokenAddress__
+                $ref: '#/components/schemas/GenericSuccessResponse_app.model.schema.dex_order_list.ListAllOrderListResponse_app.model.schema.dex_order_list.TokenAddress__'
         '400':
           description: Bad Request
           content:
@@ -3457,59 +3695,6 @@ components:
       title: ABI
       type: array
       items: {}
-    AdminToken:
-      title: AdminToken
-      required:
-        - id
-        - token_address
-        - is_public
-        - owner_address
-        - created
-      type: object
-      properties:
-        id:
-          title: Id
-          type: integer
-        token_address:
-          title: Token Address
-          type: string
-        is_public:
-          title: Is Public
-          type: boolean
-        max_holding_quantity:
-          title: Max Holding Quantity
-          type: integer
-        max_sell_amount:
-          title: Max Sell Amount
-          type: integer
-        owner_address:
-          title: Owner Address
-          type: string
-        created:
-          title: Created
-          type: string
-          description: Create Datetime (JST)
-    AdminTokensType:
-      title: AdminTokensType
-      required:
-        - IbetStraightBond
-        - IbetShare
-        - IbetMembership
-        - IbetCoupon
-      type: object
-      properties:
-        IbetStraightBond:
-          title: Ibetstraightbond
-          type: boolean
-        IbetShare:
-          title: Ibetshare
-          type: boolean
-        IbetMembership:
-          title: Ibetmembership
-          type: boolean
-        IbetCoupon:
-          title: Ibetcoupon
-          type: boolean
     Agreement:
       title: Agreement
       required:
@@ -3548,56 +3733,6 @@ components:
         agreement_timestamp:
           title: Agreement Timestamp
           type: string
-    AgreementDetail:
-      title: AgreementDetail
-      required:
-        - token_address
-        - counterpart
-        - buyer_address
-        - seller_address
-        - amount
-        - price
-        - canceled
-        - paid
-        - expiry
-      type: object
-      properties:
-        token_address:
-          title: Token Address
-          type: string
-          description: token address
-        counterpart:
-          title: Counterpart
-          type: string
-          description: taker account address
-        buyer_address:
-          title: Buyer Address
-          type: string
-          description: buyer account address
-        seller_address:
-          title: Seller Address
-          type: string
-          description: seller account address
-        amount:
-          title: Amount
-          type: integer
-          description: agreement token amount
-        price:
-          title: Price
-          type: integer
-          description: agreement price
-        canceled:
-          title: Canceled
-          type: boolean
-          description: agreement canceled status
-        paid:
-          title: Paid
-          type: boolean
-          description: agreement payment status
-        expiry:
-          title: Expiry
-          type: string
-          description: expiry (unixtime)
     AgreementSet:
       title: AgreementSet
       required:
@@ -3609,12 +3744,11 @@ components:
         token:
           title: Token
           anyOf:
-            - $ref: '#/components/schemas/StraightBondToken'
-            - $ref: '#/components/schemas/ShareToken'
-            - $ref: '#/components/schemas/MembershipToken'
-            - $ref: '#/components/schemas/CouponToken'
-            - $ref: >-
-                #/components/schemas/app__model__schema__dex_order_list__TokenAddress
+            - $ref: '#/components/schemas/RetrieveStraightBondTokenResponse'
+            - $ref: '#/components/schemas/RetrieveShareTokenResponse'
+            - $ref: '#/components/schemas/RetrieveMembershipTokenResponse'
+            - $ref: '#/components/schemas/RetrieveCouponTokenResponse'
+            - $ref: '#/components/schemas/app__model__schema__dex_order_list__TokenAddress'
         agreement:
           $ref: '#/components/schemas/Agreement'
         sort_id:
@@ -3635,11 +3769,6 @@ components:
           title: Message
           type: string
           example: ''
-        description:
-          title: Description
-          anyOf:
-            - type: string
-            - type: object
     AppErrorResponse:
       title: AppErrorResponse
       required:
@@ -3651,11 +3780,6 @@ components:
         details:
           title: Details
           type: object
-      meta:
-        code:
-          example: 0
-        message:
-          example: ''
     ApprovalStatus:
       title: ApprovalStatus
       enum:
@@ -3674,42 +3798,6 @@ components:
         - pending
       type: string
       description: An enumeration.
-    BlockSyncStatus:
-      title: BlockSyncStatus
-      required:
-        - is_synced
-        - latest_block_number
-      type: object
-      properties:
-        is_synced:
-          title: Is Synced
-          type: boolean
-          description: block sync status
-        latest_block_number:
-          title: Latest Block Number
-          type: integer
-          description: latest block number (returns null if is_synced is false)
-    CompanyInfo:
-      title: CompanyInfo
-      required:
-        - address
-        - corporate_name
-        - rsa_publickey
-        - homepage
-      type: object
-      properties:
-        address:
-          title: Address
-          type: string
-        corporate_name:
-          title: Corporate Name
-          type: string
-        rsa_publickey:
-          title: Rsa Publickey
-          type: string
-        homepage:
-          title: Homepage
-          type: string
     CompleteAgreementSet:
       title: CompleteAgreementSet
       required:
@@ -3722,12 +3810,11 @@ components:
         token:
           title: Token
           anyOf:
-            - $ref: '#/components/schemas/StraightBondToken'
-            - $ref: '#/components/schemas/ShareToken'
-            - $ref: '#/components/schemas/MembershipToken'
-            - $ref: '#/components/schemas/CouponToken'
-            - $ref: >-
-                #/components/schemas/app__model__schema__dex_order_list__TokenAddress
+            - $ref: '#/components/schemas/RetrieveStraightBondTokenResponse'
+            - $ref: '#/components/schemas/RetrieveShareTokenResponse'
+            - $ref: '#/components/schemas/RetrieveMembershipTokenResponse'
+            - $ref: '#/components/schemas/RetrieveCouponTokenResponse'
+            - $ref: '#/components/schemas/app__model__schema__dex_order_list__TokenAddress'
         agreement:
           $ref: '#/components/schemas/Agreement'
         sort_id:
@@ -3801,7 +3888,7 @@ components:
         token:
           title: Token
           allOf:
-            - $ref: '#/components/schemas/CouponToken'
+            - $ref: '#/components/schemas/RetrieveCouponTokenResponse'
           description: set when include_token_details=false or null
     CouponPositionsResponse:
       title: CouponPositionsResponse
@@ -3821,127 +3908,6 @@ components:
             - type: array
               items:
                 $ref: '#/components/schemas/CouponPositionWithAddress'
-    CouponToken:
-      title: CouponToken
-      required:
-        - token_address
-        - token_template
-        - owner_address
-        - company_name
-        - rsa_publickey
-        - name
-        - symbol
-        - total_supply
-        - tradable_exchange
-        - contact_information
-        - privacy_policy
-        - status
-        - details
-        - return_details
-        - expiration_date
-        - memo
-        - transferable
-        - initial_offering_status
-        - image_url
-      type: object
-      properties:
-        token_address:
-          title: Token Address
-          type: string
-        token_template:
-          title: Token Template
-          type: string
-          example: IbetCoupon
-        owner_address:
-          title: Owner Address
-          type: string
-          description: issuer address
-        company_name:
-          title: Company Name
-          type: string
-        rsa_publickey:
-          title: Rsa Publickey
-          type: string
-        name:
-          title: Name
-          type: string
-          description: token name
-        symbol:
-          title: Symbol
-          type: string
-          description: token symbol
-        total_supply:
-          title: Total Supply
-          type: integer
-        tradable_exchange:
-          title: Tradable Exchange
-          type: string
-        contact_information:
-          title: Contact Information
-          type: string
-        privacy_policy:
-          title: Privacy Policy
-          type: string
-        status:
-          title: Status
-          type: boolean
-        max_holding_quantity:
-          title: Max Holding Quantity
-          type: integer
-        max_sell_amount:
-          title: Max Sell Amount
-          type: integer
-        details:
-          title: Details
-          type: string
-        return_details:
-          title: Return Details
-          type: string
-        expiration_date:
-          title: Expiration Date
-          type: string
-        memo:
-          title: Memo
-          type: string
-        transferable:
-          title: Transferable
-          type: boolean
-        initial_offering_status:
-          title: Initial Offering Status
-          type: boolean
-        image_url:
-          title: Image Url
-          type: array
-          items:
-            $ref: '#/components/schemas/CouponImage'
-    CouponTokenAddressesResponse:
-      title: CouponTokenAddressesResponse
-      required:
-        - result_set
-        - address_list
-      type: object
-      properties:
-        result_set:
-          $ref: '#/components/schemas/ResultSet'
-        address_list:
-          title: Address List
-          type: array
-          items:
-            type: string
-    CouponTokensResponse:
-      title: CouponTokensResponse
-      required:
-        - result_set
-        - tokens
-      type: object
-      properties:
-        result_set:
-          $ref: '#/components/schemas/ResultSet'
-        tokens:
-          title: Tokens
-          type: array
-          items:
-            $ref: '#/components/schemas/CouponToken'
     CouponTokensSortItem:
       title: CouponTokensSortItem
       enum:
@@ -3968,9 +3934,7 @@ components:
         list_id:
           title: List Id
           type: string
-          description: >-
-            Unique id to be assigned to each token holder list.This must be
-            Version4 UUID.
+          description: Unique id to be assigned to each token holder list.This must be Version4 UUID.
           format: uuid
           example: cfd83622-34dc-4efe-a68b-2cc275d3d824
         block_number:
@@ -3987,9 +3951,7 @@ components:
         list_id:
           title: List Id
           type: string
-          description: >-
-            Unique id to be assigned to each token holder list.This must be
-            Version4 UUID.
+          description: Unique id to be assigned to each token holder list.This must be Version4 UUID.
           format: uuid
           example: cfd83622-34dc-4efe-a68b-2cc275d3d824
         status:
@@ -4011,11 +3973,6 @@ components:
           title: Message
           type: string
           example: Data Conflict
-        description:
-          title: Description
-          anyOf:
-            - type: string
-            - type: object
     DataConflictErrorResponse:
       title: DataConflictErrorResponse
       required:
@@ -4027,11 +3984,6 @@ components:
         details:
           title: Details
           type: object
-      meta:
-        code:
-          example: 40
-        message:
-          example: Data Conflict
     DataNotExistsErrorMetainfo:
       title: DataNotExistsErrorMetainfo
       required:
@@ -4047,11 +3999,6 @@ components:
           title: Message
           type: string
           example: Data Not Exists
-        description:
-          title: Description
-          anyOf:
-            - type: string
-            - type: object
     DataNotExistsErrorResponse:
       title: DataNotExistsErrorResponse
       required:
@@ -4063,11 +4010,6 @@ components:
         details:
           title: Details
           type: object
-      meta:
-        code:
-          example: 30
-        message:
-          example: Data Not Exists
     DividendInformation:
       title: DividendInformation
       required:
@@ -4088,8 +4030,8 @@ components:
           title: Dividend Payment Date
           type: string
           example: '20201001'
-    E2EMessageEncryptionKey:
-      title: E2EMessageEncryptionKey
+    E2EMessageEncryptionKeyResponse:
+      title: E2EMessageEncryptionKeyResponse
       required:
         - key
         - key_type
@@ -4178,86 +4120,6 @@ components:
             message: OK
         data:
           $ref: '#/components/schemas/ABI'
-    GenericSuccessResponse_AdminToken_:
-      title: GenericSuccessResponse[AdminToken]
-      required:
-        - meta
-        - data
-      type: object
-      properties:
-        meta:
-          title: Meta
-          allOf:
-            - $ref: '#/components/schemas/Success200MetaModel'
-          example:
-            code: 200
-            message: OK
-        data:
-          $ref: '#/components/schemas/AdminToken'
-    GenericSuccessResponse_AdminTokensType_:
-      title: GenericSuccessResponse[AdminTokensType]
-      required:
-        - meta
-        - data
-      type: object
-      properties:
-        meta:
-          title: Meta
-          allOf:
-            - $ref: '#/components/schemas/Success200MetaModel'
-          example:
-            code: 200
-            message: OK
-        data:
-          $ref: '#/components/schemas/AdminTokensType'
-    GenericSuccessResponse_AgreementDetail_:
-      title: GenericSuccessResponse[AgreementDetail]
-      required:
-        - meta
-        - data
-      type: object
-      properties:
-        meta:
-          title: Meta
-          allOf:
-            - $ref: '#/components/schemas/Success200MetaModel'
-          example:
-            code: 200
-            message: OK
-        data:
-          $ref: '#/components/schemas/AgreementDetail'
-    GenericSuccessResponse_BlockSyncStatus_:
-      title: GenericSuccessResponse[BlockSyncStatus]
-      required:
-        - meta
-        - data
-      type: object
-      properties:
-        meta:
-          title: Meta
-          allOf:
-            - $ref: '#/components/schemas/Success200MetaModel'
-          example:
-            code: 200
-            message: OK
-        data:
-          $ref: '#/components/schemas/BlockSyncStatus'
-    GenericSuccessResponse_CompanyInfo_:
-      title: GenericSuccessResponse[CompanyInfo]
-      required:
-        - meta
-        - data
-      type: object
-      properties:
-        meta:
-          title: Meta
-          allOf:
-            - $ref: '#/components/schemas/Success200MetaModel'
-          example:
-            code: 200
-            message: OK
-        data:
-          $ref: '#/components/schemas/CompanyInfo'
     GenericSuccessResponse_CouponPositionWithDetail_:
       title: GenericSuccessResponse[CouponPositionWithDetail]
       required:
@@ -4290,54 +4152,6 @@ components:
             message: OK
         data:
           $ref: '#/components/schemas/CouponPositionsResponse'
-    GenericSuccessResponse_CouponTokenAddressesResponse_:
-      title: GenericSuccessResponse[CouponTokenAddressesResponse]
-      required:
-        - meta
-        - data
-      type: object
-      properties:
-        meta:
-          title: Meta
-          allOf:
-            - $ref: '#/components/schemas/Success200MetaModel'
-          example:
-            code: 200
-            message: OK
-        data:
-          $ref: '#/components/schemas/CouponTokenAddressesResponse'
-    GenericSuccessResponse_CouponToken_:
-      title: GenericSuccessResponse[CouponToken]
-      required:
-        - meta
-        - data
-      type: object
-      properties:
-        meta:
-          title: Meta
-          allOf:
-            - $ref: '#/components/schemas/Success200MetaModel'
-          example:
-            code: 200
-            message: OK
-        data:
-          $ref: '#/components/schemas/CouponToken'
-    GenericSuccessResponse_CouponTokensResponse_:
-      title: GenericSuccessResponse[CouponTokensResponse]
-      required:
-        - meta
-        - data
-      type: object
-      properties:
-        meta:
-          title: Meta
-          allOf:
-            - $ref: '#/components/schemas/Success200MetaModel'
-          example:
-            code: 200
-            message: OK
-        data:
-          $ref: '#/components/schemas/CouponTokensResponse'
     GenericSuccessResponse_CreateTokenHoldersCollectionResponse_:
       title: GenericSuccessResponse[CreateTokenHoldersCollectionResponse]
       required:
@@ -4354,8 +4168,8 @@ components:
             message: OK
         data:
           $ref: '#/components/schemas/CreateTokenHoldersCollectionResponse'
-    GenericSuccessResponse_E2EMessageEncryptionKey_:
-      title: GenericSuccessResponse[E2EMessageEncryptionKey]
+    GenericSuccessResponse_E2EMessageEncryptionKeyResponse_:
+      title: GenericSuccessResponse[E2EMessageEncryptionKeyResponse]
       required:
         - meta
         - data
@@ -4369,7 +4183,295 @@ components:
             code: 200
             message: OK
         data:
-          $ref: '#/components/schemas/E2EMessageEncryptionKey'
+          $ref: '#/components/schemas/E2EMessageEncryptionKeyResponse'
+    GenericSuccessResponse_GetAdminTokenTypeResponse_:
+      title: GenericSuccessResponse[GetAdminTokenTypeResponse]
+      required:
+        - meta
+        - data
+      type: object
+      properties:
+        meta:
+          title: Meta
+          allOf:
+            - $ref: '#/components/schemas/Success200MetaModel'
+          example:
+            code: 200
+            message: OK
+        data:
+          $ref: '#/components/schemas/GetAdminTokenTypeResponse'
+    GenericSuccessResponse_GetBlockSyncStatusResponse_:
+      title: GenericSuccessResponse[GetBlockSyncStatusResponse]
+      required:
+        - meta
+        - data
+      type: object
+      properties:
+        meta:
+          title: Meta
+          allOf:
+            - $ref: '#/components/schemas/Success200MetaModel'
+          example:
+            code: 200
+            message: OK
+        data:
+          $ref: '#/components/schemas/GetBlockSyncStatusResponse'
+    GenericSuccessResponse_GetNodeInfoResponse_:
+      title: GenericSuccessResponse[GetNodeInfoResponse]
+      required:
+        - meta
+        - data
+      type: object
+      properties:
+        meta:
+          title: Meta
+          allOf:
+            - $ref: '#/components/schemas/Success200MetaModel'
+          example:
+            code: 200
+            message: OK
+        data:
+          $ref: '#/components/schemas/GetNodeInfoResponse'
+    GenericSuccessResponse_ListAllAdminTokensResponse_:
+      title: GenericSuccessResponse[ListAllAdminTokensResponse]
+      required:
+        - meta
+        - data
+      type: object
+      properties:
+        meta:
+          title: Meta
+          allOf:
+            - $ref: '#/components/schemas/Success200MetaModel'
+          example:
+            code: 200
+            message: OK
+        data:
+          $ref: '#/components/schemas/ListAllAdminTokensResponse'
+    GenericSuccessResponse_ListAllCompanyInfoResponse_:
+      title: GenericSuccessResponse[ListAllCompanyInfoResponse]
+      required:
+        - meta
+        - data
+      type: object
+      properties:
+        meta:
+          title: Meta
+          allOf:
+            - $ref: '#/components/schemas/Success200MetaModel'
+          example:
+            code: 200
+            message: OK
+        data:
+          $ref: '#/components/schemas/ListAllCompanyInfoResponse'
+    GenericSuccessResponse_ListAllCompanyTokensResponse_:
+      title: GenericSuccessResponse[ListAllCompanyTokensResponse]
+      required:
+        - meta
+        - data
+      type: object
+      properties:
+        meta:
+          title: Meta
+          allOf:
+            - $ref: '#/components/schemas/Success200MetaModel'
+          example:
+            code: 200
+            message: OK
+        data:
+          $ref: '#/components/schemas/ListAllCompanyTokensResponse'
+    GenericSuccessResponse_ListAllCouponTokenAddressesResponse_:
+      title: GenericSuccessResponse[ListAllCouponTokenAddressesResponse]
+      required:
+        - meta
+        - data
+      type: object
+      properties:
+        meta:
+          title: Meta
+          allOf:
+            - $ref: '#/components/schemas/Success200MetaModel'
+          example:
+            code: 200
+            message: OK
+        data:
+          $ref: '#/components/schemas/ListAllCouponTokenAddressesResponse'
+    GenericSuccessResponse_ListAllCouponTokensResponse_:
+      title: GenericSuccessResponse[ListAllCouponTokensResponse]
+      required:
+        - meta
+        - data
+      type: object
+      properties:
+        meta:
+          title: Meta
+          allOf:
+            - $ref: '#/components/schemas/Success200MetaModel'
+          example:
+            code: 200
+            message: OK
+        data:
+          $ref: '#/components/schemas/ListAllCouponTokensResponse'
+    GenericSuccessResponse_ListAllEventsResponse_:
+      title: GenericSuccessResponse[ListAllEventsResponse]
+      required:
+        - meta
+        - data
+      type: object
+      properties:
+        meta:
+          title: Meta
+          allOf:
+            - $ref: '#/components/schemas/Success200MetaModel'
+          example:
+            code: 200
+            message: OK
+        data:
+          $ref: '#/components/schemas/ListAllEventsResponse'
+    GenericSuccessResponse_ListAllLastPriceResponse_:
+      title: GenericSuccessResponse[ListAllLastPriceResponse]
+      required:
+        - meta
+        - data
+      type: object
+      properties:
+        meta:
+          title: Meta
+          allOf:
+            - $ref: '#/components/schemas/Success200MetaModel'
+          example:
+            code: 200
+            message: OK
+        data:
+          $ref: '#/components/schemas/ListAllLastPriceResponse'
+    GenericSuccessResponse_ListAllMembershipTokenAddressesResponse_:
+      title: GenericSuccessResponse[ListAllMembershipTokenAddressesResponse]
+      required:
+        - meta
+        - data
+      type: object
+      properties:
+        meta:
+          title: Meta
+          allOf:
+            - $ref: '#/components/schemas/Success200MetaModel'
+          example:
+            code: 200
+            message: OK
+        data:
+          $ref: '#/components/schemas/ListAllMembershipTokenAddressesResponse'
+    GenericSuccessResponse_ListAllMembershipTokensResponse_:
+      title: GenericSuccessResponse[ListAllMembershipTokensResponse]
+      required:
+        - meta
+        - data
+      type: object
+      properties:
+        meta:
+          title: Meta
+          allOf:
+            - $ref: '#/components/schemas/Success200MetaModel'
+          example:
+            code: 200
+            message: OK
+        data:
+          $ref: '#/components/schemas/ListAllMembershipTokensResponse'
+    GenericSuccessResponse_ListAllOrderBookItemResponse_:
+      title: GenericSuccessResponse[ListAllOrderBookItemResponse]
+      required:
+        - meta
+        - data
+      type: object
+      properties:
+        meta:
+          title: Meta
+          allOf:
+            - $ref: '#/components/schemas/Success200MetaModel'
+          example:
+            code: 200
+            message: OK
+        data:
+          $ref: '#/components/schemas/ListAllOrderBookItemResponse'
+    GenericSuccessResponse_ListAllShareTokenAddressesResponse_:
+      title: GenericSuccessResponse[ListAllShareTokenAddressesResponse]
+      required:
+        - meta
+        - data
+      type: object
+      properties:
+        meta:
+          title: Meta
+          allOf:
+            - $ref: '#/components/schemas/Success200MetaModel'
+          example:
+            code: 200
+            message: OK
+        data:
+          $ref: '#/components/schemas/ListAllShareTokenAddressesResponse'
+    GenericSuccessResponse_ListAllShareTokensResponse_:
+      title: GenericSuccessResponse[ListAllShareTokensResponse]
+      required:
+        - meta
+        - data
+      type: object
+      properties:
+        meta:
+          title: Meta
+          allOf:
+            - $ref: '#/components/schemas/Success200MetaModel'
+          example:
+            code: 200
+            message: OK
+        data:
+          $ref: '#/components/schemas/ListAllShareTokensResponse'
+    GenericSuccessResponse_ListAllStraightBondTokenAddressesResponse_:
+      title: GenericSuccessResponse[ListAllStraightBondTokenAddressesResponse]
+      required:
+        - meta
+        - data
+      type: object
+      properties:
+        meta:
+          title: Meta
+          allOf:
+            - $ref: '#/components/schemas/Success200MetaModel'
+          example:
+            code: 200
+            message: OK
+        data:
+          $ref: '#/components/schemas/ListAllStraightBondTokenAddressesResponse'
+    GenericSuccessResponse_ListAllStraightBondTokensResponse_:
+      title: GenericSuccessResponse[ListAllStraightBondTokensResponse]
+      required:
+        - meta
+        - data
+      type: object
+      properties:
+        meta:
+          title: Meta
+          allOf:
+            - $ref: '#/components/schemas/Success200MetaModel'
+          example:
+            code: 200
+            message: OK
+        data:
+          $ref: '#/components/schemas/ListAllStraightBondTokensResponse'
+    GenericSuccessResponse_ListAllTicksResponse_:
+      title: GenericSuccessResponse[ListAllTicksResponse]
+      required:
+        - meta
+        - data
+      type: object
+      properties:
+        meta:
+          title: Meta
+          allOf:
+            - $ref: '#/components/schemas/Success200MetaModel'
+          example:
+            code: 200
+            message: OK
+        data:
+          $ref: '#/components/schemas/ListAllTicksResponse'
     GenericSuccessResponse_MembershipPositionWithDetail_:
       title: GenericSuccessResponse[MembershipPositionWithDetail]
       required:
@@ -4402,70 +4504,6 @@ components:
             message: OK
         data:
           $ref: '#/components/schemas/MembershipPositionsResponse'
-    GenericSuccessResponse_MembershipTokenAddressesResponse_:
-      title: GenericSuccessResponse[MembershipTokenAddressesResponse]
-      required:
-        - meta
-        - data
-      type: object
-      properties:
-        meta:
-          title: Meta
-          allOf:
-            - $ref: '#/components/schemas/Success200MetaModel'
-          example:
-            code: 200
-            message: OK
-        data:
-          $ref: '#/components/schemas/MembershipTokenAddressesResponse'
-    GenericSuccessResponse_MembershipToken_:
-      title: GenericSuccessResponse[MembershipToken]
-      required:
-        - meta
-        - data
-      type: object
-      properties:
-        meta:
-          title: Meta
-          allOf:
-            - $ref: '#/components/schemas/Success200MetaModel'
-          example:
-            code: 200
-            message: OK
-        data:
-          $ref: '#/components/schemas/MembershipToken'
-    GenericSuccessResponse_MembershipTokensResponse_:
-      title: GenericSuccessResponse[MembershipTokensResponse]
-      required:
-        - meta
-        - data
-      type: object
-      properties:
-        meta:
-          title: Meta
-          allOf:
-            - $ref: '#/components/schemas/Success200MetaModel'
-          example:
-            code: 200
-            message: OK
-        data:
-          $ref: '#/components/schemas/MembershipTokensResponse'
-    GenericSuccessResponse_NodeInfo_:
-      title: GenericSuccessResponse[NodeInfo]
-      required:
-        - meta
-        - data
-      type: object
-      properties:
-        meta:
-          title: Meta
-          allOf:
-            - $ref: '#/components/schemas/Success200MetaModel'
-          example:
-            code: 200
-            message: OK
-        data:
-          $ref: '#/components/schemas/NodeInfo'
     GenericSuccessResponse_NotificationUpdateResponse_:
       title: GenericSuccessResponse[NotificationUpdateResponse]
       required:
@@ -4514,8 +4552,8 @@ components:
             message: OK
         data:
           $ref: '#/components/schemas/NotificationsResponse'
-    GenericSuccessResponse_PaymentAccountRegistrationStatus_:
-      title: GenericSuccessResponse[PaymentAccountRegistrationStatus]
+    GenericSuccessResponse_RetrieveAdminTokenResponse_:
+      title: GenericSuccessResponse[RetrieveAdminTokenResponse]
       required:
         - meta
         - data
@@ -4529,9 +4567,9 @@ components:
             code: 200
             message: OK
         data:
-          $ref: '#/components/schemas/PaymentAccountRegistrationStatus'
-    GenericSuccessResponse_PersonalInfoRegistrationStatus_:
-      title: GenericSuccessResponse[PersonalInfoRegistrationStatus]
+          $ref: '#/components/schemas/RetrieveAdminTokenResponse'
+    GenericSuccessResponse_RetrieveAgreementDetailResponse_:
+      title: GenericSuccessResponse[RetrieveAgreementDetailResponse]
       required:
         - meta
         - data
@@ -4545,9 +4583,9 @@ components:
             code: 200
             message: OK
         data:
-          $ref: '#/components/schemas/PersonalInfoRegistrationStatus'
-    GenericSuccessResponse_ShareTokenAddressesResponse_:
-      title: GenericSuccessResponse[ShareTokenAddressesResponse]
+          $ref: '#/components/schemas/RetrieveAgreementDetailResponse'
+    GenericSuccessResponse_RetrieveCompanyInfoResponse_:
+      title: GenericSuccessResponse[RetrieveCompanyInfoResponse]
       required:
         - meta
         - data
@@ -4561,9 +4599,9 @@ components:
             code: 200
             message: OK
         data:
-          $ref: '#/components/schemas/ShareTokenAddressesResponse'
-    GenericSuccessResponse_ShareToken_:
-      title: GenericSuccessResponse[ShareToken]
+          $ref: '#/components/schemas/RetrieveCompanyInfoResponse'
+    GenericSuccessResponse_RetrieveCouponTokenResponse_:
+      title: GenericSuccessResponse[RetrieveCouponTokenResponse]
       required:
         - meta
         - data
@@ -4577,9 +4615,9 @@ components:
             code: 200
             message: OK
         data:
-          $ref: '#/components/schemas/ShareToken'
-    GenericSuccessResponse_ShareTokensResponse_:
-      title: GenericSuccessResponse[ShareTokensResponse]
+          $ref: '#/components/schemas/RetrieveCouponTokenResponse'
+    GenericSuccessResponse_RetrieveMembershipTokenResponse_:
+      title: GenericSuccessResponse[RetrieveMembershipTokenResponse]
       required:
         - meta
         - data
@@ -4593,9 +4631,9 @@ components:
             code: 200
             message: OK
         data:
-          $ref: '#/components/schemas/ShareTokensResponse'
-    GenericSuccessResponse_StraightBondTokenAddressesResponse_:
-      title: GenericSuccessResponse[StraightBondTokenAddressesResponse]
+          $ref: '#/components/schemas/RetrieveMembershipTokenResponse'
+    GenericSuccessResponse_RetrievePaymentAccountRegistrationStatusResponse_:
+      title: GenericSuccessResponse[RetrievePaymentAccountRegistrationStatusResponse]
       required:
         - meta
         - data
@@ -4609,9 +4647,9 @@ components:
             code: 200
             message: OK
         data:
-          $ref: '#/components/schemas/StraightBondTokenAddressesResponse'
-    GenericSuccessResponse_StraightBondToken_:
-      title: GenericSuccessResponse[StraightBondToken]
+          $ref: '#/components/schemas/RetrievePaymentAccountRegistrationStatusResponse'
+    GenericSuccessResponse_RetrievePersonalInfoRegistrationStatusResponse_:
+      title: GenericSuccessResponse[RetrievePersonalInfoRegistrationStatusResponse]
       required:
         - meta
         - data
@@ -4625,9 +4663,9 @@ components:
             code: 200
             message: OK
         data:
-          $ref: '#/components/schemas/StraightBondToken'
-    GenericSuccessResponse_StraightBondTokensResponse_:
-      title: GenericSuccessResponse[StraightBondTokensResponse]
+          $ref: '#/components/schemas/RetrievePersonalInfoRegistrationStatusResponse'
+    GenericSuccessResponse_RetrieveShareTokenResponse_:
+      title: GenericSuccessResponse[RetrieveShareTokenResponse]
       required:
         - meta
         - data
@@ -4641,9 +4679,9 @@ components:
             code: 200
             message: OK
         data:
-          $ref: '#/components/schemas/StraightBondTokensResponse'
-    GenericSuccessResponse_TokenHoldersCollection_:
-      title: GenericSuccessResponse[TokenHoldersCollection]
+          $ref: '#/components/schemas/RetrieveShareTokenResponse'
+    GenericSuccessResponse_RetrieveStraightBondTokenResponse_:
+      title: GenericSuccessResponse[RetrieveStraightBondTokenResponse]
       required:
         - meta
         - data
@@ -4657,9 +4695,9 @@ components:
             code: 200
             message: OK
         data:
-          $ref: '#/components/schemas/TokenHoldersCollection'
-    GenericSuccessResponse_TokenHoldersCount_:
-      title: GenericSuccessResponse[TokenHoldersCount]
+          $ref: '#/components/schemas/RetrieveStraightBondTokenResponse'
+    GenericSuccessResponse_SendRawTransactionsNoWaitResponse_:
+      title: GenericSuccessResponse[SendRawTransactionsNoWaitResponse]
       required:
         - meta
         - data
@@ -4673,9 +4711,9 @@ components:
             code: 200
             message: OK
         data:
-          $ref: '#/components/schemas/TokenHoldersCount'
-    GenericSuccessResponse_TokenStatus_:
-      title: GenericSuccessResponse[TokenStatus]
+          $ref: '#/components/schemas/SendRawTransactionsNoWaitResponse'
+    GenericSuccessResponse_SendRawTransactionsResponse_:
+      title: GenericSuccessResponse[SendRawTransactionsResponse]
       required:
         - meta
         - data
@@ -4689,9 +4727,9 @@ components:
             code: 200
             message: OK
         data:
-          $ref: '#/components/schemas/TokenStatus'
-    GenericSuccessResponse_TransactionCount_:
-      title: GenericSuccessResponse[TransactionCount]
+          $ref: '#/components/schemas/SendRawTransactionsResponse'
+    GenericSuccessResponse_TokenHoldersCollectionResponse_:
+      title: GenericSuccessResponse[TokenHoldersCollectionResponse]
       required:
         - meta
         - data
@@ -4705,7 +4743,71 @@ components:
             code: 200
             message: OK
         data:
-          $ref: '#/components/schemas/TransactionCount'
+          $ref: '#/components/schemas/TokenHoldersCollectionResponse'
+    GenericSuccessResponse_TokenHoldersCountResponse_:
+      title: GenericSuccessResponse[TokenHoldersCountResponse]
+      required:
+        - meta
+        - data
+      type: object
+      properties:
+        meta:
+          title: Meta
+          allOf:
+            - $ref: '#/components/schemas/Success200MetaModel'
+          example:
+            code: 200
+            message: OK
+        data:
+          $ref: '#/components/schemas/TokenHoldersCountResponse'
+    GenericSuccessResponse_TokenHoldersResponse_:
+      title: GenericSuccessResponse[TokenHoldersResponse]
+      required:
+        - meta
+        - data
+      type: object
+      properties:
+        meta:
+          title: Meta
+          allOf:
+            - $ref: '#/components/schemas/Success200MetaModel'
+          example:
+            code: 200
+            message: OK
+        data:
+          $ref: '#/components/schemas/TokenHoldersResponse'
+    GenericSuccessResponse_TokenStatusResponse_:
+      title: GenericSuccessResponse[TokenStatusResponse]
+      required:
+        - meta
+        - data
+      type: object
+      properties:
+        meta:
+          title: Meta
+          allOf:
+            - $ref: '#/components/schemas/Success200MetaModel'
+          example:
+            code: 200
+            message: OK
+        data:
+          $ref: '#/components/schemas/TokenStatusResponse'
+    GenericSuccessResponse_TransactionCountResponse_:
+      title: GenericSuccessResponse[TransactionCountResponse]
+      required:
+        - meta
+        - data
+      type: object
+      properties:
+        meta:
+          title: Meta
+          allOf:
+            - $ref: '#/components/schemas/Success200MetaModel'
+          example:
+            code: 200
+            message: OK
+        data:
+          $ref: '#/components/schemas/TransactionCountResponse'
     GenericSuccessResponse_TransferApprovalHistoriesResponse_:
       title: GenericSuccessResponse[TransferApprovalHistoriesResponse]
       required:
@@ -4738,8 +4840,8 @@ components:
             message: OK
         data:
           $ref: '#/components/schemas/TransferHistoriesResponse'
-    GenericSuccessResponse_WaitForTransactionReceiptResult_:
-      title: GenericSuccessResponse[WaitForTransactionReceiptResult]
+    GenericSuccessResponse_WaitForTransactionReceiptResponse_:
+      title: GenericSuccessResponse[WaitForTransactionReceiptResponse]
       required:
         - meta
         - data
@@ -4753,10 +4855,9 @@ components:
             code: 200
             message: OK
         data:
-          $ref: '#/components/schemas/WaitForTransactionReceiptResult'
-    GenericSuccessResponse_app.model.schema.dex_order_list.OrderListResponse_app.model.schema.dex_order_list.TokenAddress__:
-      title: >-
-        GenericSuccessResponse[app.model.schema.dex_order_list.OrderListResponse[app.model.schema.dex_order_list.TokenAddress]]
+          $ref: '#/components/schemas/WaitForTransactionReceiptResponse'
+    GenericSuccessResponse_app.model.schema.dex_order_list.ListAllOrderListResponse_app.model.schema.dex_order_list.TokenAddress__:
+      title: GenericSuccessResponse[app.model.schema.dex_order_list.ListAllOrderListResponse[app.model.schema.dex_order_list.TokenAddress]]
       required:
         - meta
         - data
@@ -4770,10 +4871,9 @@ components:
             code: 200
             message: OK
         data:
-          $ref: '#/components/schemas/OrderListResponse'
-    GenericSuccessResponse_app.model.schema.dex_order_list.OrderListResponse_app.model.schema.token_bond.StraightBondToken__:
-      title: >-
-        GenericSuccessResponse[app.model.schema.dex_order_list.OrderListResponse[app.model.schema.token_bond.StraightBondToken]]
+          $ref: '#/components/schemas/ListAllOrderListResponse'
+    GenericSuccessResponse_app.model.schema.dex_order_list.ListAllOrderListResponse_app.model.schema.token_bond.RetrieveStraightBondTokenResponse__:
+      title: GenericSuccessResponse[app.model.schema.dex_order_list.ListAllOrderListResponse[app.model.schema.token_bond.RetrieveStraightBondTokenResponse]]
       required:
         - meta
         - data
@@ -4787,10 +4887,9 @@ components:
             code: 200
             message: OK
         data:
-          $ref: '#/components/schemas/OrderListResponse'
-    GenericSuccessResponse_app.model.schema.dex_order_list.OrderListResponse_app.model.schema.token_coupon.CouponToken__:
-      title: >-
-        GenericSuccessResponse[app.model.schema.dex_order_list.OrderListResponse[app.model.schema.token_coupon.CouponToken]]
+          $ref: '#/components/schemas/ListAllOrderListResponse'
+    GenericSuccessResponse_app.model.schema.dex_order_list.ListAllOrderListResponse_app.model.schema.token_coupon.RetrieveCouponTokenResponse__:
+      title: GenericSuccessResponse[app.model.schema.dex_order_list.ListAllOrderListResponse[app.model.schema.token_coupon.RetrieveCouponTokenResponse]]
       required:
         - meta
         - data
@@ -4804,10 +4903,9 @@ components:
             code: 200
             message: OK
         data:
-          $ref: '#/components/schemas/OrderListResponse'
-    GenericSuccessResponse_app.model.schema.dex_order_list.OrderListResponse_app.model.schema.token_membership.MembershipToken__:
-      title: >-
-        GenericSuccessResponse[app.model.schema.dex_order_list.OrderListResponse[app.model.schema.token_membership.MembershipToken]]
+          $ref: '#/components/schemas/ListAllOrderListResponse'
+    GenericSuccessResponse_app.model.schema.dex_order_list.ListAllOrderListResponse_app.model.schema.token_membership.RetrieveMembershipTokenResponse__:
+      title: GenericSuccessResponse[app.model.schema.dex_order_list.ListAllOrderListResponse[app.model.schema.token_membership.RetrieveMembershipTokenResponse]]
       required:
         - meta
         - data
@@ -4821,10 +4919,9 @@ components:
             code: 200
             message: OK
         data:
-          $ref: '#/components/schemas/OrderListResponse'
-    GenericSuccessResponse_app.model.schema.dex_order_list.OrderListResponse_app.model.schema.token_share.ShareToken__:
-      title: >-
-        GenericSuccessResponse[app.model.schema.dex_order_list.OrderListResponse[app.model.schema.token_share.ShareToken]]
+          $ref: '#/components/schemas/ListAllOrderListResponse'
+    GenericSuccessResponse_app.model.schema.dex_order_list.ListAllOrderListResponse_app.model.schema.token_share.RetrieveShareTokenResponse__:
+      title: GenericSuccessResponse[app.model.schema.dex_order_list.ListAllOrderListResponse[app.model.schema.token_share.RetrieveShareTokenResponse]]
       required:
         - meta
         - data
@@ -4838,27 +4935,9 @@ components:
             code: 200
             message: OK
         data:
-          $ref: '#/components/schemas/OrderListResponse'
-    GenericSuccessResponse_app.model.schema.position.GenericSecurityTokenPositionsResponse_app.model.schema.token_bond.StraightBondToken__:
-      title: >-
-        GenericSuccessResponse[app.model.schema.position.GenericSecurityTokenPositionsResponse[app.model.schema.token_bond.StraightBondToken]]
-      required:
-        - meta
-        - data
-      type: object
-      properties:
-        meta:
-          title: Meta
-          allOf:
-            - $ref: '#/components/schemas/Success200MetaModel'
-          example:
-            code: 200
-            message: OK
-        data:
-          $ref: '#/components/schemas/GenericSecurityTokenPositionsResponse'
-    GenericSuccessResponse_app.model.schema.position.GenericSecurityTokenPositionsResponse_app.model.schema.token_share.ShareToken__:
-      title: >-
-        GenericSuccessResponse[app.model.schema.position.GenericSecurityTokenPositionsResponse[app.model.schema.token_share.ShareToken]]
+          $ref: '#/components/schemas/ListAllOrderListResponse'
+    GenericSuccessResponse_app.model.schema.position.GenericSecurityTokenPositionsResponse_app.model.schema.token_bond.RetrieveStraightBondTokenResponse__:
+      title: GenericSuccessResponse[app.model.schema.position.GenericSecurityTokenPositionsResponse[app.model.schema.token_bond.RetrieveStraightBondTokenResponse]]
       required:
         - meta
         - data
@@ -4873,9 +4952,24 @@ components:
             message: OK
         data:
           $ref: '#/components/schemas/GenericSecurityTokenPositionsResponse'
-    GenericSuccessResponse_app.model.schema.position.SecurityTokenPositionWithDetail_app.model.schema.token_bond.StraightBondToken__:
-      title: >-
-        GenericSuccessResponse[app.model.schema.position.SecurityTokenPositionWithDetail[app.model.schema.token_bond.StraightBondToken]]
+    GenericSuccessResponse_app.model.schema.position.GenericSecurityTokenPositionsResponse_app.model.schema.token_share.RetrieveShareTokenResponse__:
+      title: GenericSuccessResponse[app.model.schema.position.GenericSecurityTokenPositionsResponse[app.model.schema.token_share.RetrieveShareTokenResponse]]
+      required:
+        - meta
+        - data
+      type: object
+      properties:
+        meta:
+          title: Meta
+          allOf:
+            - $ref: '#/components/schemas/Success200MetaModel'
+          example:
+            code: 200
+            message: OK
+        data:
+          $ref: '#/components/schemas/GenericSecurityTokenPositionsResponse'
+    GenericSuccessResponse_app.model.schema.position.SecurityTokenPositionWithDetail_app.model.schema.token_bond.RetrieveStraightBondTokenResponse__:
+      title: GenericSuccessResponse[app.model.schema.position.SecurityTokenPositionWithDetail[app.model.schema.token_bond.RetrieveStraightBondTokenResponse]]
       required:
         - meta
         - data
@@ -4890,9 +4984,8 @@ components:
             message: OK
         data:
           $ref: '#/components/schemas/SecurityTokenPositionWithDetail'
-    GenericSuccessResponse_app.model.schema.position.SecurityTokenPositionWithDetail_app.model.schema.token_share.ShareToken__:
-      title: >-
-        GenericSuccessResponse[app.model.schema.position.SecurityTokenPositionWithDetail[app.model.schema.token_share.ShareToken]]
+    GenericSuccessResponse_app.model.schema.position.SecurityTokenPositionWithDetail_app.model.schema.token_share.RetrieveShareTokenResponse__:
+      title: GenericSuccessResponse[app.model.schema.position.SecurityTokenPositionWithDetail[app.model.schema.token_share.RetrieveShareTokenResponse]]
       required:
         - meta
         - data
@@ -4907,206 +5000,94 @@ components:
             message: OK
         data:
           $ref: '#/components/schemas/SecurityTokenPositionWithDetail'
-    GenericSuccessResponse_list_Union_app.model.schema.token_bond.StraightBondToken__app.model.schema.token_share.ShareToken__app.model.schema.token_membership.MembershipToken__app.model.schema.token_coupon.CouponToken___:
-      title: >-
-        GenericSuccessResponse[list[Union[app.model.schema.token_bond.StraightBondToken,
-        app.model.schema.token_share.ShareToken,
-        app.model.schema.token_membership.MembershipToken,
-        app.model.schema.token_coupon.CouponToken]]]
+    GetAdminTokenTypeResponse:
+      title: GetAdminTokenTypeResponse
       required:
-        - meta
-        - data
+        - IbetStraightBond
+        - IbetShare
+        - IbetMembership
+        - IbetCoupon
       type: object
       properties:
-        meta:
-          title: Meta
-          allOf:
-            - $ref: '#/components/schemas/Success200MetaModel'
-          example:
-            code: 200
-            message: OK
-        data:
-          title: Data
-          type: array
-          items:
-            anyOf:
-              - $ref: '#/components/schemas/StraightBondToken'
-              - $ref: '#/components/schemas/ShareToken'
-              - $ref: '#/components/schemas/MembershipToken'
-              - $ref: '#/components/schemas/CouponToken'
-    GenericSuccessResponse_list_app.model.schema.admin.AdminToken__:
-      title: GenericSuccessResponse[list[app.model.schema.admin.AdminToken]]
+        IbetStraightBond:
+          title: Ibetstraightbond
+          type: boolean
+        IbetShare:
+          title: Ibetshare
+          type: boolean
+        IbetMembership:
+          title: Ibetmembership
+          type: boolean
+        IbetCoupon:
+          title: Ibetcoupon
+          type: boolean
+    GetBlockSyncStatusResponse:
+      title: GetBlockSyncStatusResponse
       required:
-        - meta
-        - data
+        - is_synced
+        - latest_block_number
       type: object
       properties:
-        meta:
-          title: Meta
-          allOf:
-            - $ref: '#/components/schemas/Success200MetaModel'
-          example:
-            code: 200
-            message: OK
-        data:
-          title: Data
-          type: array
-          items:
-            $ref: '#/components/schemas/AdminToken'
-    GenericSuccessResponse_list_app.model.schema.company_info.CompanyInfo__:
-      title: GenericSuccessResponse[list[app.model.schema.company_info.CompanyInfo]]
-      required:
-        - meta
-        - data
+        is_synced:
+          title: Is Synced
+          type: boolean
+          description: block sync status
+        latest_block_number:
+          title: Latest Block Number
+          type: integer
+          description: latest block number (returns null if is_synced is false)
+    GetNodeInfoResponse:
+      title: GetNodeInfoResponse
       type: object
       properties:
-        meta:
-          title: Meta
-          allOf:
-            - $ref: '#/components/schemas/Success200MetaModel'
-          example:
-            code: 200
-            message: OK
-        data:
-          title: Data
-          type: array
-          items:
-            $ref: '#/components/schemas/CompanyInfo'
-    GenericSuccessResponse_list_app.model.schema.dex_market.LastPrice__:
-      title: GenericSuccessResponse[list[app.model.schema.dex_market.LastPrice]]
-      required:
-        - meta
-        - data
-      type: object
-      properties:
-        meta:
-          title: Meta
-          allOf:
-            - $ref: '#/components/schemas/Success200MetaModel'
-          example:
-            code: 200
-            message: OK
-        data:
-          title: Data
-          type: array
-          items:
-            $ref: '#/components/schemas/LastPrice'
-    GenericSuccessResponse_list_app.model.schema.dex_market.OrderBookItem__:
-      title: GenericSuccessResponse[list[app.model.schema.dex_market.OrderBookItem]]
-      required:
-        - meta
-        - data
-      type: object
-      properties:
-        meta:
-          title: Meta
-          allOf:
-            - $ref: '#/components/schemas/Success200MetaModel'
-          example:
-            code: 200
-            message: OK
-        data:
-          title: Data
-          type: array
-          items:
-            $ref: '#/components/schemas/OrderBookItem'
-    GenericSuccessResponse_list_app.model.schema.dex_market.TicksResponse__:
-      title: GenericSuccessResponse[list[app.model.schema.dex_market.TicksResponse]]
-      required:
-        - meta
-        - data
-      type: object
-      properties:
-        meta:
-          title: Meta
-          allOf:
-            - $ref: '#/components/schemas/Success200MetaModel'
-          example:
-            code: 200
-            message: OK
-        data:
-          title: Data
-          type: array
-          items:
-            $ref: '#/components/schemas/TicksResponse'
-    GenericSuccessResponse_list_app.model.schema.eth.SendRawTransactionNoWaitResult__:
-      title: >-
-        GenericSuccessResponse[list[app.model.schema.eth.SendRawTransactionNoWaitResult]]
-      required:
-        - meta
-        - data
-      type: object
-      properties:
-        meta:
-          title: Meta
-          allOf:
-            - $ref: '#/components/schemas/Success200MetaModel'
-          example:
-            code: 200
-            message: OK
-        data:
-          title: Data
-          type: array
-          items:
-            $ref: '#/components/schemas/SendRawTransactionNoWaitResult'
-    GenericSuccessResponse_list_app.model.schema.eth.SendRawTransactionResult__:
-      title: >-
-        GenericSuccessResponse[list[app.model.schema.eth.SendRawTransactionResult]]
-      required:
-        - meta
-        - data
-      type: object
-      properties:
-        meta:
-          title: Meta
-          allOf:
-            - $ref: '#/components/schemas/Success200MetaModel'
-          example:
-            code: 200
-            message: OK
-        data:
-          title: Data
-          type: array
-          items:
-            $ref: '#/components/schemas/SendRawTransactionResult'
-    GenericSuccessResponse_list_app.model.schema.events.Event__:
-      title: GenericSuccessResponse[list[app.model.schema.events.Event]]
-      required:
-        - meta
-        - data
-      type: object
-      properties:
-        meta:
-          title: Meta
-          allOf:
-            - $ref: '#/components/schemas/Success200MetaModel'
-          example:
-            code: 200
-            message: OK
-        data:
-          title: Data
-          type: array
-          items:
-            $ref: '#/components/schemas/Event'
-    GenericSuccessResponse_list_app.model.schema.token.TokenHolder__:
-      title: GenericSuccessResponse[list[app.model.schema.token.TokenHolder]]
-      required:
-        - meta
-        - data
-      type: object
-      properties:
-        meta:
-          title: Meta
-          allOf:
-            - $ref: '#/components/schemas/Success200MetaModel'
-          example:
-            code: 200
-            message: OK
-        data:
-          title: Data
-          type: array
-          items:
-            $ref: '#/components/schemas/TokenHolder'
+        payment_gateway_address:
+          title: Payment Gateway Address
+          type: string
+        payment_gateway_abi:
+          title: Payment Gateway Abi
+        personal_info_address:
+          title: Personal Info Address
+          type: string
+        personal_info_abi:
+          title: Personal Info Abi
+        ibet_straightbond_exchange_address:
+          title: Ibet Straightbond Exchange Address
+          type: string
+        ibet_straightbond_exchange_abi:
+          title: Ibet Straightbond Exchange Abi
+        ibet_membership_exchange_address:
+          title: Ibet Membership Exchange Address
+          type: string
+        ibet_membership_exchange_abi:
+          title: Ibet Membership Exchange Abi
+        ibet_coupon_exchange_address:
+          title: Ibet Coupon Exchange Address
+          type: string
+        ibet_coupon_exchange_abi:
+          title: Ibet Coupon Exchange Abi
+        ibet_share_exchange_address:
+          title: Ibet Share Exchange Address
+          type: string
+        ibet_share_exchange_abi:
+          title: Ibet Share Exchange Abi
+        ibet_escrow_address:
+          title: Ibet Escrow Address
+          type: string
+        ibet_escrow_abi:
+          title: Ibet Escrow Abi
+        ibet_security_token_escrow_address:
+          title: Ibet Security Token Escrow Address
+          type: string
+        ibet_security_token_escrow_abi:
+          title: Ibet Security Token Escrow Abi
+        e2e_messaging_address:
+          title: E2E Messaging Address
+          type: string
+        e2e_messaging_abi:
+          title: E2E Messaging Abi
+        agent_address:
+          title: Agent Address
+          type: string
     HTTPValidationError:
       title: HTTPValidationError
       type: object
@@ -5155,11 +5136,6 @@ components:
           title: Message
           type: string
           example: Invalid Parameter
-        description:
-          title: Description
-          anyOf:
-            - type: string
-            - type: object
     InvalidParameterErrorResponse:
       title: InvalidParameterErrorResponse
       required:
@@ -5171,11 +5147,6 @@ components:
         details:
           title: Details
           type: object
-      meta:
-        code:
-          example: 88
-        message:
-          example: Invalid Parameter
     LastPrice:
       title: LastPrice
       required:
@@ -5189,8 +5160,60 @@ components:
         last_price:
           title: Last Price
           type: integer
-    LastPriceRequest:
-      title: LastPriceRequest
+    ListAllAdminTokensResponse:
+      title: ListAllAdminTokensResponse
+      type: array
+      items:
+        $ref: '#/components/schemas/RetrieveAdminTokenResponse'
+    ListAllCompanyInfoResponse:
+      title: ListAllCompanyInfoResponse
+      type: array
+      items:
+        $ref: '#/components/schemas/RetrieveCompanyInfoResponse'
+    ListAllCompanyTokensResponse:
+      title: ListAllCompanyTokensResponse
+      type: array
+      items:
+        anyOf:
+          - $ref: '#/components/schemas/RetrieveStraightBondTokenResponse'
+          - $ref: '#/components/schemas/RetrieveShareTokenResponse'
+          - $ref: '#/components/schemas/RetrieveMembershipTokenResponse'
+          - $ref: '#/components/schemas/RetrieveCouponTokenResponse'
+    ListAllCouponTokenAddressesResponse:
+      title: ListAllCouponTokenAddressesResponse
+      required:
+        - result_set
+        - address_list
+      type: object
+      properties:
+        result_set:
+          $ref: '#/components/schemas/ResultSet'
+        address_list:
+          title: Address List
+          type: array
+          items:
+            type: string
+    ListAllCouponTokensResponse:
+      title: ListAllCouponTokensResponse
+      required:
+        - result_set
+        - tokens
+      type: object
+      properties:
+        result_set:
+          $ref: '#/components/schemas/ResultSet'
+        tokens:
+          title: Tokens
+          type: array
+          items:
+            $ref: '#/components/schemas/RetrieveCouponTokenResponse'
+    ListAllEventsResponse:
+      title: ListAllEventsResponse
+      type: array
+      items:
+        $ref: '#/components/schemas/Event'
+    ListAllLastPriceRequest:
+      title: ListAllLastPriceRequest
       required:
         - address_list
       type: object
@@ -5201,6 +5224,175 @@ components:
           items:
             type: string
           description: Token address list
+    ListAllLastPriceResponse:
+      title: ListAllLastPriceResponse
+      type: array
+      items:
+        $ref: '#/components/schemas/LastPrice'
+    ListAllMembershipTokenAddressesResponse:
+      title: ListAllMembershipTokenAddressesResponse
+      required:
+        - result_set
+        - address_list
+      type: object
+      properties:
+        result_set:
+          $ref: '#/components/schemas/ResultSet'
+        address_list:
+          title: Address List
+          type: array
+          items:
+            type: string
+    ListAllMembershipTokensResponse:
+      title: ListAllMembershipTokensResponse
+      required:
+        - result_set
+        - tokens
+      type: object
+      properties:
+        result_set:
+          $ref: '#/components/schemas/ResultSet'
+        tokens:
+          title: Tokens
+          type: array
+          items:
+            $ref: '#/components/schemas/RetrieveMembershipTokenResponse'
+    ListAllOrderBookItemResponse:
+      title: ListAllOrderBookItemResponse
+      type: array
+      items:
+        $ref: '#/components/schemas/OrderBookItem'
+    ListAllOrderBookRequest:
+      title: ListAllOrderBookRequest
+      required:
+        - token_address
+        - order_type
+      type: object
+      properties:
+        account_address:
+          title: Account Address
+          type: string
+          description: Orderer's account address. Orders from the given address will not be included in the response.
+        token_address:
+          title: Token Address
+          type: string
+          description: Token address
+        order_type:
+          allOf:
+            - $ref: '#/components/schemas/OrderType'
+          description: Order type to be executed by the Orderer. If "buy" is selected, the sell order book will be returned.
+    ListAllOrderListRequest:
+      title: ListAllOrderListRequest
+      required:
+        - account_address_list
+      type: object
+      properties:
+        account_address_list:
+          title: Account Address List
+          type: array
+          items:
+            type: string
+          description: Account address list
+        include_canceled_items:
+          title: Include Canceled Items
+          type: boolean
+          description: Whether to include canceled orders or canceled agreements.
+    ListAllOrderListResponse:
+      title: ListAllOrderListResponse
+      required:
+        - order_list
+        - settlement_list
+        - complete_list
+      type: object
+      properties:
+        order_list:
+          title: Order List
+          type: array
+          items:
+            $ref: '#/components/schemas/OrderSet'
+        settlement_list:
+          title: Settlement List
+          type: array
+          items:
+            $ref: '#/components/schemas/AgreementSet'
+        complete_list:
+          title: Complete List
+          type: array
+          items:
+            $ref: '#/components/schemas/CompleteAgreementSet'
+    ListAllShareTokenAddressesResponse:
+      title: ListAllShareTokenAddressesResponse
+      required:
+        - result_set
+        - address_list
+      type: object
+      properties:
+        result_set:
+          $ref: '#/components/schemas/ResultSet'
+        address_list:
+          title: Address List
+          type: array
+          items:
+            type: string
+    ListAllShareTokensResponse:
+      title: ListAllShareTokensResponse
+      required:
+        - result_set
+        - tokens
+      type: object
+      properties:
+        result_set:
+          $ref: '#/components/schemas/ResultSet'
+        tokens:
+          title: Tokens
+          type: array
+          items:
+            $ref: '#/components/schemas/RetrieveShareTokenResponse'
+    ListAllStraightBondTokenAddressesResponse:
+      title: ListAllStraightBondTokenAddressesResponse
+      required:
+        - result_set
+        - address_list
+      type: object
+      properties:
+        result_set:
+          $ref: '#/components/schemas/ResultSet'
+        address_list:
+          title: Address List
+          type: array
+          items:
+            type: string
+    ListAllStraightBondTokensResponse:
+      title: ListAllStraightBondTokensResponse
+      required:
+        - result_set
+        - tokens
+      type: object
+      properties:
+        result_set:
+          $ref: '#/components/schemas/ResultSet'
+        tokens:
+          title: Tokens
+          type: array
+          items:
+            $ref: '#/components/schemas/RetrieveStraightBondTokenResponse'
+    ListAllTickRequest:
+      title: ListAllTickRequest
+      required:
+        - address_list
+      type: object
+      properties:
+        address_list:
+          title: Address List
+          type: array
+          items:
+            type: string
+          description: Token address list
+    ListAllTicksResponse:
+      title: ListAllTicksResponse
+      type: array
+      items:
+        $ref: '#/components/schemas/Ticks'
     MembershipImage:
       title: MembershipImage
       required:
@@ -5257,7 +5449,7 @@ components:
         token:
           title: Token
           allOf:
-            - $ref: '#/components/schemas/MembershipToken'
+            - $ref: '#/components/schemas/RetrieveMembershipTokenResponse'
           description: set when include_token_details=false or null
     MembershipPositionsResponse:
       title: MembershipPositionsResponse
@@ -5277,127 +5469,6 @@ components:
             - type: array
               items:
                 $ref: '#/components/schemas/MembershipPositionWithAddress'
-    MembershipToken:
-      title: MembershipToken
-      required:
-        - token_address
-        - token_template
-        - owner_address
-        - company_name
-        - rsa_publickey
-        - name
-        - symbol
-        - total_supply
-        - tradable_exchange
-        - contact_information
-        - privacy_policy
-        - status
-        - details
-        - return_details
-        - expiration_date
-        - memo
-        - transferable
-        - initial_offering_status
-        - image_url
-      type: object
-      properties:
-        token_address:
-          title: Token Address
-          type: string
-        token_template:
-          title: Token Template
-          type: string
-          example: IbetMembership
-        owner_address:
-          title: Owner Address
-          type: string
-          description: issuer address
-        company_name:
-          title: Company Name
-          type: string
-        rsa_publickey:
-          title: Rsa Publickey
-          type: string
-        name:
-          title: Name
-          type: string
-          description: token name
-        symbol:
-          title: Symbol
-          type: string
-          description: token symbol
-        total_supply:
-          title: Total Supply
-          type: integer
-        tradable_exchange:
-          title: Tradable Exchange
-          type: string
-        contact_information:
-          title: Contact Information
-          type: string
-        privacy_policy:
-          title: Privacy Policy
-          type: string
-        status:
-          title: Status
-          type: boolean
-        max_holding_quantity:
-          title: Max Holding Quantity
-          type: integer
-        max_sell_amount:
-          title: Max Sell Amount
-          type: integer
-        details:
-          title: Details
-          type: string
-        return_details:
-          title: Return Details
-          type: string
-        expiration_date:
-          title: Expiration Date
-          type: string
-        memo:
-          title: Memo
-          type: string
-        transferable:
-          title: Transferable
-          type: boolean
-        initial_offering_status:
-          title: Initial Offering Status
-          type: boolean
-        image_url:
-          title: Image Url
-          type: array
-          items:
-            $ref: '#/components/schemas/MembershipImage'
-    MembershipTokenAddressesResponse:
-      title: MembershipTokenAddressesResponse
-      required:
-        - result_set
-        - address_list
-      type: object
-      properties:
-        result_set:
-          $ref: '#/components/schemas/ResultSet'
-        address_list:
-          title: Address List
-          type: array
-          items:
-            type: string
-    MembershipTokensResponse:
-      title: MembershipTokensResponse
-      required:
-        - result_set
-        - tokens
-      type: object
-      properties:
-        result_set:
-          $ref: '#/components/schemas/ResultSet'
-        tokens:
-          title: Tokens
-          type: array
-          items:
-            $ref: '#/components/schemas/MembershipToken'
     MembershipTokensSortItem:
       title: MembershipTokensSortItem
       enum:
@@ -5414,58 +5485,6 @@ components:
         - created
       type: string
       description: An enumeration.
-    NodeInfo:
-      title: NodeInfo
-      type: object
-      properties:
-        payment_gateway_address:
-          title: Payment Gateway Address
-          type: string
-        payment_gateway_abi:
-          title: Payment Gateway Abi
-        personal_info_address:
-          title: Personal Info Address
-          type: string
-        personal_info_abi:
-          title: Personal Info Abi
-        ibet_straightbond_exchange_address:
-          title: Ibet Straightbond Exchange Address
-          type: string
-        ibet_straightbond_exchange_abi:
-          title: Ibet Straightbond Exchange Abi
-        ibet_membership_exchange_address:
-          title: Ibet Membership Exchange Address
-          type: string
-        ibet_membership_exchange_abi:
-          title: Ibet Membership Exchange Abi
-        ibet_coupon_exchange_address:
-          title: Ibet Coupon Exchange Address
-          type: string
-        ibet_coupon_exchange_abi:
-          title: Ibet Coupon Exchange Abi
-        ibet_share_exchange_address:
-          title: Ibet Share Exchange Address
-          type: string
-        ibet_share_exchange_abi:
-          title: Ibet Share Exchange Abi
-        ibet_escrow_address:
-          title: Ibet Escrow Address
-          type: string
-        ibet_escrow_abi:
-          title: Ibet Escrow Abi
-        ibet_security_token_escrow_address:
-          title: Ibet Security Token Escrow Address
-          type: string
-        ibet_security_token_escrow_abi:
-          title: Ibet Security Token Escrow Abi
-        e2e_messaging_address:
-          title: E2E Messaging Address
-          type: string
-        e2e_messaging_abi:
-          title: E2E Messaging Abi
-        agent_address:
-          title: Agent Address
-          type: string
     NotSupportedErrorMetainfo:
       title: NotSupportedErrorMetainfo
       required:
@@ -5481,11 +5500,6 @@ components:
           title: Message
           type: string
           example: Not Supported
-        description:
-          title: Description
-          anyOf:
-            - type: string
-            - type: object
     NotSupportedErrorResponse:
       title: NotSupportedErrorResponse
       required:
@@ -5497,11 +5511,6 @@ components:
         details:
           title: Details
           type: object
-      meta:
-        code:
-          example: 10
-        message:
-          example: Not Supported
     Notification:
       title: Notification
       required:
@@ -5767,68 +5776,6 @@ components:
           title: Account Address
           type: string
           description: An orderrer of each order book
-    OrderBookRequest:
-      title: OrderBookRequest
-      required:
-        - token_address
-        - order_type
-      type: object
-      properties:
-        account_address:
-          title: Account Address
-          type: string
-          description: >-
-            Orderer's account address. Orders from the given address will not be
-            included in the response.
-        token_address:
-          title: Token Address
-          type: string
-          description: Token address
-        order_type:
-          allOf:
-            - $ref: '#/components/schemas/OrderType'
-          description: >-
-            Order type to be executed by the Orderer. If "buy" is selected, the
-            sell order book will be returned.
-    OrderListRequest:
-      title: OrderListRequest
-      required:
-        - account_address_list
-      type: object
-      properties:
-        account_address_list:
-          title: Account Address List
-          type: array
-          items:
-            type: string
-          description: Account address list
-        include_canceled_items:
-          title: Include Canceled Items
-          type: boolean
-          description: Whether to include canceled orders or canceled agreements.
-    OrderListResponse:
-      title: OrderListResponse
-      required:
-        - order_list
-        - settlement_list
-        - complete_list
-      type: object
-      properties:
-        order_list:
-          title: Order List
-          type: array
-          items:
-            $ref: '#/components/schemas/OrderSet'
-        settlement_list:
-          title: Settlement List
-          type: array
-          items:
-            $ref: '#/components/schemas/AgreementSet'
-        complete_list:
-          title: Complete List
-          type: array
-          items:
-            $ref: '#/components/schemas/CompleteAgreementSet'
     OrderSet:
       title: OrderSet
       required:
@@ -5840,12 +5787,11 @@ components:
         token:
           title: Token
           anyOf:
-            - $ref: '#/components/schemas/StraightBondToken'
-            - $ref: '#/components/schemas/ShareToken'
-            - $ref: '#/components/schemas/MembershipToken'
-            - $ref: '#/components/schemas/CouponToken'
-            - $ref: >-
-                #/components/schemas/app__model__schema__dex_order_list__TokenAddress
+            - $ref: '#/components/schemas/RetrieveStraightBondTokenResponse'
+            - $ref: '#/components/schemas/RetrieveShareTokenResponse'
+            - $ref: '#/components/schemas/RetrieveMembershipTokenResponse'
+            - $ref: '#/components/schemas/RetrieveCouponTokenResponse'
+            - $ref: '#/components/schemas/app__model__schema__dex_order_list__TokenAddress'
         order:
           $ref: '#/components/schemas/Order'
         sort_id:
@@ -5858,44 +5804,8 @@ components:
         - sell
       type: string
       description: An enumeration.
-    PaymentAccountRegistrationStatus:
-      title: PaymentAccountRegistrationStatus
-      required:
-        - account_address
-        - agent_address
-        - approval_status
-      type: object
-      properties:
-        account_address:
-          title: Account Address
-          type: string
-        agent_address:
-          title: Agent Address
-          type: string
-        approval_status:
-          allOf:
-            - $ref: '#/components/schemas/ApprovalStatus'
-          description: approval status (NONE(0)/NG(1)/OK(2)/WARN(3)/BAN(4))
-    PersonalInfoRegistrationStatus:
-      title: PersonalInfoRegistrationStatus
-      required:
-        - account_address
-        - owner_address
-        - registered
-      type: object
-      properties:
-        account_address:
-          title: Account Address
-          type: string
-        owner_address:
-          title: Owner Address
-          type: string
-          description: link address
-        registered:
-          title: Registered
-          type: boolean
-    RegisterAdminTokensRequest:
-      title: RegisterAdminTokensRequest
+    RegisterAdminTokenRequest:
+      title: RegisterAdminTokenRequest
       required:
         - contract_address
         - is_public
@@ -5997,129 +5907,333 @@ components:
           title: Total
           type: integer
       description: result set for pagination
-    SecurityTokenPositionWithAddress:
-      title: SecurityTokenPositionWithAddress
+    RetrieveAdminTokenResponse:
+      title: RetrieveAdminTokenResponse
       required:
-        - balance
-        - pending_transfer
-        - exchange_balance
-        - exchange_commitment
+        - id
         - token_address
+        - is_public
+        - owner_address
+        - created
       type: object
       properties:
-        balance:
-          title: Balance
-          type: integer
-        pending_transfer:
-          title: Pending Transfer
-          type: integer
-        exchange_balance:
-          title: Exchange Balance
-          type: integer
-        exchange_commitment:
-          title: Exchange Commitment
+        id:
+          title: Id
           type: integer
         token_address:
           title: Token Address
           type: string
-          description: set when include_token_details=true
-    SecurityTokenPositionWithDetail:
-      title: SecurityTokenPositionWithDetail
+        is_public:
+          title: Is Public
+          type: boolean
+        max_holding_quantity:
+          title: Max Holding Quantity
+          type: integer
+        max_sell_amount:
+          title: Max Sell Amount
+          type: integer
+        owner_address:
+          title: Owner Address
+          type: string
+        created:
+          title: Created
+          type: string
+          description: Create Datetime (JST)
+    RetrieveAgreementDetailResponse:
+      title: RetrieveAgreementDetailResponse
       required:
-        - balance
-        - pending_transfer
-        - exchange_balance
-        - exchange_commitment
-        - token
+        - token_address
+        - counterpart
+        - buyer_address
+        - seller_address
+        - amount
+        - price
+        - canceled
+        - paid
+        - expiry
       type: object
       properties:
-        balance:
-          title: Balance
+        token_address:
+          title: Token Address
+          type: string
+          description: token address
+        counterpart:
+          title: Counterpart
+          type: string
+          description: taker account address
+        buyer_address:
+          title: Buyer Address
+          type: string
+          description: buyer account address
+        seller_address:
+          title: Seller Address
+          type: string
+          description: seller account address
+        amount:
+          title: Amount
           type: integer
-        pending_transfer:
-          title: Pending Transfer
+          description: agreement token amount
+        price:
+          title: Price
           type: integer
-        exchange_balance:
-          title: Exchange Balance
-          type: integer
-        exchange_commitment:
-          title: Exchange Commitment
-          type: integer
-        token:
-          title: Token
-          anyOf:
-            - {}
-            - $ref: '#/components/schemas/app__model__schema__position__TokenAddress'
-          description: set when include_token_details=false or null
-    SendRawTransactionNoWaitResult:
-      title: SendRawTransactionNoWaitResult
+          description: agreement price
+        canceled:
+          title: Canceled
+          type: boolean
+          description: agreement canceled status
+        paid:
+          title: Paid
+          type: boolean
+          description: agreement payment status
+        expiry:
+          title: Expiry
+          type: string
+          description: expiry (unixtime)
+    RetrieveCompanyInfoResponse:
+      title: RetrieveCompanyInfoResponse
       required:
-        - id
+        - address
+        - corporate_name
+        - rsa_publickey
+        - homepage
+      type: object
+      properties:
+        address:
+          title: Address
+          type: string
+        corporate_name:
+          title: Corporate Name
+          type: string
+        rsa_publickey:
+          title: Rsa Publickey
+          type: string
+        homepage:
+          title: Homepage
+          type: string
+    RetrieveCouponTokenResponse:
+      title: RetrieveCouponTokenResponse
+      required:
+        - token_address
+        - token_template
+        - owner_address
+        - company_name
+        - rsa_publickey
+        - name
+        - symbol
+        - total_supply
+        - tradable_exchange
+        - contact_information
+        - privacy_policy
         - status
+        - details
+        - return_details
+        - expiration_date
+        - memo
+        - transferable
+        - initial_offering_status
+        - image_url
       type: object
       properties:
-        id:
-          title: Id
+        token_address:
+          title: Token Address
+          type: string
+        token_template:
+          title: Token Template
+          type: string
+          example: IbetCoupon
+        owner_address:
+          title: Owner Address
+          type: string
+          description: issuer address
+        company_name:
+          title: Company Name
+          type: string
+        rsa_publickey:
+          title: Rsa Publickey
+          type: string
+        name:
+          title: Name
+          type: string
+          description: token name
+        symbol:
+          title: Symbol
+          type: string
+          description: token symbol
+        total_supply:
+          title: Total Supply
           type: integer
-          description: transaction send order
-          example: 1
+        tradable_exchange:
+          title: Tradable Exchange
+          type: string
+        contact_information:
+          title: Contact Information
+          type: string
+        privacy_policy:
+          title: Privacy Policy
+          type: string
         status:
           title: Status
+          type: boolean
+        max_holding_quantity:
+          title: Max Holding Quantity
           type: integer
-          description: execution failure:0, execution success:1
-          example: 1
-        transaction_hash:
-          title: Transaction Hash
+        max_sell_amount:
+          title: Max Sell Amount
+          type: integer
+        details:
+          title: Details
           type: string
-          description: transaction hash
-    SendRawTransactionRequest:
-      title: SendRawTransactionRequest
-      required:
-        - raw_tx_hex_list
-      type: object
-      properties:
-        raw_tx_hex_list:
-          title: Raw Tx Hex List
-          minItems: 1
+        return_details:
+          title: Return Details
+          type: string
+        expiration_date:
+          title: Expiration Date
+          type: string
+        memo:
+          title: Memo
+          type: string
+        transferable:
+          title: Transferable
+          type: boolean
+        initial_offering_status:
+          title: Initial Offering Status
+          type: boolean
+        image_url:
+          title: Image Url
           type: array
           items:
-            type: string
-          description: Signed transaction list
-    SendRawTransactionResult:
-      title: SendRawTransactionResult
+            $ref: '#/components/schemas/CouponImage'
+    RetrieveMembershipTokenResponse:
+      title: RetrieveMembershipTokenResponse
       required:
-        - id
+        - token_address
+        - token_template
+        - owner_address
+        - company_name
+        - rsa_publickey
+        - name
+        - symbol
+        - total_supply
+        - tradable_exchange
+        - contact_information
+        - privacy_policy
         - status
+        - details
+        - return_details
+        - expiration_date
+        - memo
+        - transferable
+        - initial_offering_status
+        - image_url
       type: object
       properties:
-        id:
-          title: Id
+        token_address:
+          title: Token Address
+          type: string
+        token_template:
+          title: Token Template
+          type: string
+          example: IbetMembership
+        owner_address:
+          title: Owner Address
+          type: string
+          description: issuer address
+        company_name:
+          title: Company Name
+          type: string
+        rsa_publickey:
+          title: Rsa Publickey
+          type: string
+        name:
+          title: Name
+          type: string
+          description: token name
+        symbol:
+          title: Symbol
+          type: string
+          description: token symbol
+        total_supply:
+          title: Total Supply
           type: integer
-          description: transaction send order
-          example: 1
+        tradable_exchange:
+          title: Tradable Exchange
+          type: string
+        contact_information:
+          title: Contact Information
+          type: string
+        privacy_policy:
+          title: Privacy Policy
+          type: string
         status:
           title: Status
+          type: boolean
+        max_holding_quantity:
+          title: Max Holding Quantity
           type: integer
-          description: >-
-            execution failure:0, execution success:1, execution success(pending
-            transaction):2
-          example: 1
-        transaction_hash:
-          title: Transaction Hash
-          type: string
-          description: transaction hash
-        error_code:
-          title: Error Code
+        max_sell_amount:
+          title: Max Sell Amount
           type: integer
-          description: error code thrown from contract
-          example: 240202
-        error_msg:
-          title: Error Msg
+        details:
+          title: Details
           type: string
-          description: error msg
-          example: Message sender is not token owner.
-    ShareToken:
-      title: ShareToken
+        return_details:
+          title: Return Details
+          type: string
+        expiration_date:
+          title: Expiration Date
+          type: string
+        memo:
+          title: Memo
+          type: string
+        transferable:
+          title: Transferable
+          type: boolean
+        initial_offering_status:
+          title: Initial Offering Status
+          type: boolean
+        image_url:
+          title: Image Url
+          type: array
+          items:
+            $ref: '#/components/schemas/MembershipImage'
+    RetrievePaymentAccountRegistrationStatusResponse:
+      title: RetrievePaymentAccountRegistrationStatusResponse
+      required:
+        - account_address
+        - agent_address
+        - approval_status
+      type: object
+      properties:
+        account_address:
+          title: Account Address
+          type: string
+        agent_address:
+          title: Agent Address
+          type: string
+        approval_status:
+          allOf:
+            - $ref: '#/components/schemas/ApprovalStatus'
+          description: approval status (NONE(0)/NG(1)/OK(2)/WARN(3)/BAN(4))
+    RetrievePersonalInfoRegistrationStatusResponse:
+      title: RetrievePersonalInfoRegistrationStatusResponse
+      required:
+        - account_address
+        - owner_address
+        - registered
+      type: object
+      properties:
+        account_address:
+          title: Account Address
+          type: string
+        owner_address:
+          title: Owner Address
+          type: string
+          description: link address
+        registered:
+          title: Registered
+          type: boolean
+    RetrieveShareTokenResponse:
+      title: RetrieveShareTokenResponse
       required:
         - token_address
         - token_template
@@ -6220,61 +6334,8 @@ components:
           type: boolean
         dividend_information:
           $ref: '#/components/schemas/DividendInformation'
-    ShareTokenAddressesResponse:
-      title: ShareTokenAddressesResponse
-      required:
-        - result_set
-        - address_list
-      type: object
-      properties:
-        result_set:
-          $ref: '#/components/schemas/ResultSet'
-        address_list:
-          title: Address List
-          type: array
-          items:
-            type: string
-    ShareTokensResponse:
-      title: ShareTokensResponse
-      required:
-        - result_set
-        - tokens
-      type: object
-      properties:
-        result_set:
-          $ref: '#/components/schemas/ResultSet'
-        tokens:
-          title: Tokens
-          type: array
-          items:
-            $ref: '#/components/schemas/ShareToken'
-    ShareTokensSortItem:
-      title: ShareTokensSortItem
-      enum:
-        - token_address
-        - owner_address
-        - name
-        - symbol
-        - company_name
-        - tradable_exchange
-        - status
-        - personal_info_address
-        - transferable
-        - is_offering
-        - transfer_approval_required
-        - is_canceled
-        - created
-      type: string
-      description: An enumeration.
-    SortOrder:
-      title: SortOrder
-      enum:
-        - 0
-        - 1
-      type: integer
-      description: An enumeration.
-    StraightBondToken:
-      title: StraightBondToken
+    RetrieveStraightBondTokenResponse:
+      title: RetrieveStraightBondTokenResponse
       required:
         - token_address
         - token_template
@@ -6424,34 +6485,160 @@ components:
         is_redeemed:
           title: Is Redeemed
           type: boolean
-    StraightBondTokenAddressesResponse:
-      title: StraightBondTokenAddressesResponse
+    SecurityTokenPositionWithAddress:
+      title: SecurityTokenPositionWithAddress
       required:
-        - result_set
-        - address_list
+        - balance
+        - pending_transfer
+        - exchange_balance
+        - exchange_commitment
+        - token_address
       type: object
       properties:
-        result_set:
-          $ref: '#/components/schemas/ResultSet'
-        address_list:
-          title: Address List
+        balance:
+          title: Balance
+          type: integer
+        pending_transfer:
+          title: Pending Transfer
+          type: integer
+        exchange_balance:
+          title: Exchange Balance
+          type: integer
+        exchange_commitment:
+          title: Exchange Commitment
+          type: integer
+        token_address:
+          title: Token Address
+          type: string
+          description: set when include_token_details=true
+    SecurityTokenPositionWithDetail:
+      title: SecurityTokenPositionWithDetail
+      required:
+        - balance
+        - pending_transfer
+        - exchange_balance
+        - exchange_commitment
+        - token
+      type: object
+      properties:
+        balance:
+          title: Balance
+          type: integer
+        pending_transfer:
+          title: Pending Transfer
+          type: integer
+        exchange_balance:
+          title: Exchange Balance
+          type: integer
+        exchange_commitment:
+          title: Exchange Commitment
+          type: integer
+        token:
+          title: Token
+          anyOf:
+            - {}
+            - $ref: '#/components/schemas/app__model__schema__position__TokenAddress'
+          description: set when include_token_details=false or null
+    SendRawTransactionNoWaitResponse:
+      title: SendRawTransactionNoWaitResponse
+      required:
+        - id
+        - status
+      type: object
+      properties:
+        id:
+          title: Id
+          type: integer
+          description: transaction send order
+          example: 1
+        status:
+          title: Status
+          type: integer
+          description: execution failure:0, execution success:1
+          example: 1
+        transaction_hash:
+          title: Transaction Hash
+          type: string
+          description: transaction hash
+    SendRawTransactionRequest:
+      title: SendRawTransactionRequest
+      required:
+        - raw_tx_hex_list
+      type: object
+      properties:
+        raw_tx_hex_list:
+          title: Raw Tx Hex List
+          minItems: 1
           type: array
           items:
             type: string
-    StraightBondTokensResponse:
-      title: StraightBondTokensResponse
+          description: Signed transaction list
+    SendRawTransactionResponse:
+      title: SendRawTransactionResponse
       required:
-        - result_set
-        - tokens
+        - id
+        - status
       type: object
       properties:
-        result_set:
-          $ref: '#/components/schemas/ResultSet'
-        tokens:
-          title: Tokens
-          type: array
-          items:
-            $ref: '#/components/schemas/StraightBondToken'
+        id:
+          title: Id
+          type: integer
+          description: transaction send order
+          example: 1
+        status:
+          title: Status
+          type: integer
+          description: execution failure:0, execution success:1, execution success(pending transaction):2
+          example: 1
+        transaction_hash:
+          title: Transaction Hash
+          type: string
+          description: transaction hash
+        error_code:
+          title: Error Code
+          type: integer
+          description: error code thrown from contract
+          example: 240202
+        error_msg:
+          title: Error Msg
+          type: string
+          description: error msg
+          example: Message sender is not token owner.
+    SendRawTransactionsNoWaitResponse:
+      title: SendRawTransactionsNoWaitResponse
+      type: array
+      items:
+        $ref: '#/components/schemas/SendRawTransactionNoWaitResponse'
+    SendRawTransactionsResponse:
+      title: SendRawTransactionsResponse
+      type: array
+      items:
+        $ref: '#/components/schemas/SendRawTransactionResponse'
+    ShareTokensSortItem:
+      title: ShareTokensSortItem
+      enum:
+        - token_address
+        - owner_address
+        - name
+        - symbol
+        - company_name
+        - tradable_exchange
+        - status
+        - personal_info_address
+        - transferable
+        - is_offering
+        - transfer_approval_required
+        - is_canceled
+        - created
+      type: string
+      description: An enumeration.
+    SortOrder:
+      title: SortOrder
+      enum:
+        - 0
+        - 1
+      type: integer
+      description: An enumeration.
     StraightBondTokensSortItem:
       title: StraightBondTokensSortItem
       enum:
@@ -6517,11 +6704,6 @@ components:
           title: Message
           type: string
           example: Suspended Token
-        description:
-          title: Description
-          anyOf:
-            - type: string
-            - type: object
     SuspendedTokenErrorResponse:
       title: SuspendedTokenErrorResponse
       required:
@@ -6533,11 +6715,6 @@ components:
         details:
           title: Details
           type: object
-      meta:
-        code:
-          example: 20
-        message:
-          example: Suspended Token
     Tick:
       title: Tick
       required:
@@ -6572,20 +6749,8 @@ components:
         amount:
           title: Amount
           type: integer
-    TickRequest:
-      title: TickRequest
-      required:
-        - address_list
-      type: object
-      properties:
-        address_list:
-          title: Address List
-          type: array
-          items:
-            type: string
-          description: Token address list
-    TicksResponse:
-      title: TicksResponse
+    Ticks:
+      title: Ticks
       required:
         - token_address
         - tick
@@ -6628,21 +6793,6 @@ components:
           title: Exchange Commitment
           type: integer
           default: 0
-    TokenHoldersCollection:
-      title: TokenHoldersCollection
-      required:
-        - status
-        - holders
-      type: object
-      properties:
-        status:
-          $ref: '#/components/schemas/TokenHoldersCollectionBatchStatus'
-        holders:
-          title: Holders
-          type: array
-          items:
-            $ref: '#/components/schemas/TokenHoldersCollectionHolder'
-          description: Token holder list.This list is excluding token owner address.
     TokenHoldersCollectionBatchStatus:
       title: TokenHoldersCollectionBatchStatus
       enum:
@@ -6665,11 +6815,24 @@ components:
         hold_balance:
           title: Hold Balance
           type: integer
-          description: >-
-            Amount of balance.This includes
-            balance/pending_transfer/exchange_balance/exchange_commitment.
-    TokenHoldersCount:
-      title: TokenHoldersCount
+          description: Amount of balance.This includes balance/pending_transfer/exchange_balance/exchange_commitment.
+    TokenHoldersCollectionResponse:
+      title: TokenHoldersCollectionResponse
+      required:
+        - status
+        - holders
+      type: object
+      properties:
+        status:
+          $ref: '#/components/schemas/TokenHoldersCollectionBatchStatus'
+        holders:
+          title: Holders
+          type: array
+          items:
+            $ref: '#/components/schemas/TokenHoldersCollectionHolder'
+          description: Token holder list.This list is excluding token owner address.
+    TokenHoldersCountResponse:
+      title: TokenHoldersCountResponse
       required:
         - count
       type: object
@@ -6677,8 +6840,13 @@ components:
         count:
           title: Count
           type: integer
-    TokenStatus:
-      title: TokenStatus
+    TokenHoldersResponse:
+      title: TokenHoldersResponse
+      type: array
+      items:
+        $ref: '#/components/schemas/TokenHolder'
+    TokenStatusResponse:
+      title: TokenStatusResponse
       required:
         - token_template
         - status
@@ -6704,8 +6872,8 @@ components:
         - IbetCoupon
       type: string
       description: An enumeration.
-    TransactionCount:
-      title: TransactionCount
+    TransactionCountResponse:
+      title: TransactionCountResponse
       required:
         - nonce
         - gasprice
@@ -6921,8 +7089,8 @@ components:
           type: integer
           description: Timeout value
           default: 5
-    WaitForTransactionReceiptResult:
-      title: WaitForTransactionReceiptResult
+    WaitForTransactionReceiptResponse:
+      title: WaitForTransactionReceiptResponse
       required:
         - status
       type: object
@@ -6961,7 +7129,6 @@ components:
           title: Token Address
           type: string
 tags:
-  - name: Root
   - name: Admin
     description: System administration
   - name: NodeInfo

--- a/tests/app/dex_market_GetAgreement_test.py
+++ b/tests/app/dex_market_GetAgreement_test.py
@@ -400,7 +400,7 @@ class TestDEXMarketGetAgreement:
             "code": 88,
             "description": [
                 {
-                    "loc": ["query", "exchange_address"],
+                    "loc": ["exchange_address"],
                     "msg": "owner_address is not a valid address",
                     "type": "value_error"
                 }

--- a/tests/app/events_E2EMessagingEvents_test.py
+++ b/tests/app/events_E2EMessagingEvents_test.py
@@ -556,7 +556,7 @@ class TestEventsE2EMessaging:
             "code": 88,
             "description": [
                 {
-                    "loc": ["query", "__root__"],
+                    "loc": ["__root__"],
                     "msg": "to_block must be greater than or equal to the from_block",
                     "type": "value_error"
                 }

--- a/tests/app/events_IbetEscrowEvents_test.py
+++ b/tests/app/events_IbetEscrowEvents_test.py
@@ -671,7 +671,7 @@ class TestEventsIbetEscrow:
             "code": 88,
             "description": [
                 {
-                    "loc": ["query", "__root__"],
+                    "loc": ["__root__"],
                     "msg": "to_block must be greater than or equal to the "
                            "from_block",
                     "type": "value_error"

--- a/tests/app/events_IbetSecurityTokenEscrowEvents_test.py
+++ b/tests/app/events_IbetSecurityTokenEscrowEvents_test.py
@@ -1419,7 +1419,7 @@ class TestEventsIbetSecurityTokenEscrow:
             "code": 88,
             "description": [
                 {
-                    "loc": ["query", "__root__"],
+                    "loc": ["__root__"],
                     "msg": "to_block must be greater than or equal to the from_block",
                     "type": "value_error"
                 }

--- a/tests/app/notification_NotificationsCount_test.py
+++ b/tests/app/notification_NotificationsCount_test.py
@@ -169,7 +169,7 @@ class TestNotificationCount:
             "code": 88,
             "description": [
                 {
-                    "loc": ["query", "address"],
+                    "loc": ["address"],
                     "msg": "address is not a valid address",
                     "type": "value_error"
                 }

--- a/tests/app/notification_Notifications_GET_test.py
+++ b/tests/app/notification_Notifications_GET_test.py
@@ -682,7 +682,7 @@ class TestNotificationsGet:
             "code": 88,
             "description": [
                 {
-                    "loc": ["query", "address"],
+                    "loc": ["address"],
                     "msg": "address is not a valid address",
                     "type": "value_error"
                 }

--- a/tests/app/token_TransferApprovalHistory_test.py
+++ b/tests/app/token_TransferApprovalHistory_test.py
@@ -570,7 +570,8 @@ class TestTokenTransferApprovalHistory:
 
         assert resp.status_code == 400
         assert resp.json()['meta'] == {
-            'code': 88,'description': [
+            'code': 88,
+            'description': [
                 {
                     'ctx': {'limit_value': 0},
                     'loc': ['query', 'offset'],

--- a/tests/app/token_bond_StraightBondTokenAddresses_test.py
+++ b/tests/app/token_bond_StraightBondTokenAddresses_test.py
@@ -614,7 +614,7 @@ class TestTokenStraightBondTokenAddresses:
         processor.process()
 
         query_string = ""
-        resp: _ResultBase = client.get(self.apiurl, params=query_string)
+        resp = client.get(self.apiurl, params=query_string)
 
         assert resp.status_code == 404
         assert resp.json()["meta"] == {

--- a/tests/app/token_coupon_CouponTokenAddresses_test.py
+++ b/tests/app/token_coupon_CouponTokenAddresses_test.py
@@ -586,7 +586,7 @@ class TestTokenCouponTokenAddresses:
         processor.process()
 
         query_string = ""
-        resp: _ResultBase = client.get(self.apiurl, params=query_string)
+        resp = client.get(self.apiurl, params=query_string)
 
         assert resp.status_code == 404
         assert resp.json()["meta"] == {

--- a/tests/app/userinfo_PaymentAccount_test.py
+++ b/tests/app/userinfo_PaymentAccount_test.py
@@ -145,7 +145,7 @@ class TestUserInfoPaymentAccount:
             "code": 88,
             "description": [
                 {
-                    "loc": ["query", "account_address"],
+                    "loc": ["account_address"],
                     "msg": "account_address is not a valid address",
                     "type": "value_error"
                 }
@@ -194,7 +194,7 @@ class TestUserInfoPaymentAccount:
             "code": 88,
             "description": [
                 {
-                    "loc": ["query", "agent_address"],
+                    "loc": ["agent_address"],
                     "msg": "agent_address is not a valid address",
                     "type": "value_error"
                 }

--- a/tests/app/userinfo_PersonalInfo_test.py
+++ b/tests/app/userinfo_PersonalInfo_test.py
@@ -185,7 +185,7 @@ class TestUserInfoPersonalInfo:
             "code": 88,
             "description": [
                 {
-                    "loc": ["query", "account_address"],
+                    "loc": ["account_address"],
                     "msg": "account_address is not a valid address",
                     "type": "value_error"
                 }
@@ -209,7 +209,7 @@ class TestUserInfoPersonalInfo:
             "code": 88,
             "description": [
                 {
-                    "loc": ["query", "owner_address"],
+                    "loc": ["owner_address"],
                     "msg": "owner_address is not a valid address",
                     "type": "value_error"
                 }


### PR DESCRIPTION
Close: #1223 

## Changes
- Fixed query parameter model so that parameter description is shown in openapi docs.
  - Changed to use `pydantic.dataclasses.dataclass` as query parameter definition.
- Fixed a problem that an errors were displayed when the openapi document is load by the following official editor.
  - https://editor.swagger.io/

**Changes on display(<-Before / After->)**
![スクリーンショット 2022-10-06 17 11 54](https://user-images.githubusercontent.com/15183665/194264687-4798692b-1830-4b12-bc1c-4b24866b07bc.png)
