### PR TITLE
feat: bump package versions

### DIFF
--- a/requirements.lock
+++ b/requirements.lock
@@ -49,7 +49,7 @@ requests==2.28.1
 rlp==2.0.1
 six==1.16.0
 sniffio==1.3.0
-SQLAlchemy==1.4.44
+SQLAlchemy==1.4.45
 sqlalchemy-migrate==0.13.0
 sqlparse==0.4.3
 starlette==0.20.4


### PR DESCRIPTION
- Update lockfile
  - SQLAlchemy 1.4.44 -> [1.4.45](https://github.com/sqlalchemy/sqlalchemy/releases/tag/rel_1_4_45)