### PR TITLE
feat: store source event data as idx_transfer

### DIFF
--- a/app/model/db/__init__.py
+++ b/app/model/db/__init__.py
@@ -27,7 +27,8 @@ from .listing import Listing
 from .executable_contract import ExecutableContract
 from .idx_transfer import (
     IDXTransfer,
-    IDXTransferBlockNumber
+    IDXTransferBlockNumber,
+    IDXTransferSourceEventType
 )
 from .idx_transfer_approval import (
     IDXTransferApproval,

--- a/app/model/db/idx_lock_unlock.py
+++ b/app/model/db/idx_lock_unlock.py
@@ -35,6 +35,7 @@ from app.model.db import Base
 UTC = timezone(timedelta(hours=0), "UTC")
 JST = timezone(timedelta(hours=+9), "JST")
 
+
 class IDXLock(Base):
     """Token Lock Event (INDEX)"""
     __tablename__ = "lock"

--- a/app/model/db/idx_transfer.py
+++ b/app/model/db/idx_transfer.py
@@ -16,10 +16,12 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 """
+from enum import Enum
 from sqlalchemy import (
     Column,
     String,
-    BigInteger
+    BigInteger,
+    JSON
 )
 from datetime import (
     datetime,
@@ -31,6 +33,12 @@ from app.model.db import Base
 
 UTC = timezone(timedelta(hours=0), "UTC")
 JST = timezone(timedelta(hours=+9), "JST")
+
+
+class IDXTransferSourceEventType(str, Enum):
+    """Transfer source event type"""
+    TRANSFER = "Transfer"
+    UNLOCK = "Unlock"
 
 
 class IDXTransfer(Base):
@@ -49,6 +57,10 @@ class IDXTransfer(Base):
     to_address = Column(String(42))
     # Transfer Amount
     value = Column(BigInteger)
+    # Source Event (IDXTransferSourceEventType)
+    source_event = Column(String(50), nullable=False)
+    # Data
+    data = Column(JSON)
 
     @staticmethod
     def format_timestamp(_datetime: datetime) -> str:
@@ -68,6 +80,8 @@ class IDXTransfer(Base):
             "from_address": self.from_address,
             "to_address": self.to_address,
             "value": self.value,
+            "source_event": self.source_event,
+            "data": self.data,
             "created": self.format_timestamp(self.created),
         }
 
@@ -78,6 +92,8 @@ class IDXTransfer(Base):
         "from_address": str,
         "to_address": str,
         "value": int,
+        "source_event": str,
+        "data": dict
     }
     FIELDS.update(Base.FIELDS)
 

--- a/app/model/schema/__init__.py
+++ b/app/model/schema/__init__.py
@@ -112,6 +112,7 @@ from .token import (
     CreateTokenHoldersCollectionRequest,
     RetrieveTokenHoldersCountQuery,
     ListAllTokenHoldersQuery,
+    ListAllTransferHistoryQuery,
     # Response
     TokenStatusResponse,
     TokenHoldersResponse,

--- a/app/model/schema/bc_explorer.py
+++ b/app/model/schema/bc_explorer.py
@@ -44,6 +44,7 @@ class BlockData(BaseModel):
     gas_used: int
     size: NonNegativeInt
 
+
 class BlockDataDetail(BaseModel):
     number: NonNegativeInt = Field(description="Block number")
     parent_hash: str

--- a/app/model/schema/token.py
+++ b/app/model/schema/token.py
@@ -24,6 +24,7 @@ from uuid import UUID
 from pydantic import (
     BaseModel,
     Field,
+    NonNegativeInt
 )
 
 from app.model.schema.base import (
@@ -40,6 +41,11 @@ class TokenType(str, Enum):
     IbetShare = "IbetShare"
     IbetMembership = "IbetMembership"
     IbetCoupon = "IbetCoupon"
+
+
+class TransferSourceEvent(str, Enum):
+    Transfer = "Transfer"
+    Unlock = "Unlock"
 
 
 ############################
@@ -61,6 +67,14 @@ class ListAllTokenHoldersQuery:
 @dataclass
 class RetrieveTokenHoldersCountQuery:
     exclude_owner: Optional[bool] = Query(default=False, description="exclude owner")
+
+
+@dataclass
+class ListAllTransferHistoryQuery:
+    offset: Optional[NonNegativeInt] = Query(default=None, description="start position")
+    limit: Optional[NonNegativeInt] = Query(default=None, description="number of set")
+    source_event: Optional[TransferSourceEvent] = Query(default=None, description="source event of transfer")
+    data: Optional[str] = Query(default=None, description="source event data")
 
 
 ############################
@@ -123,6 +137,8 @@ class TransferHistory(BaseModel):
     from_address: str = Field(description="Account address of transfer source")
     to_address: str = Field(description="Account address of transfer destination")
     value: int = Field(description="Transfer quantity")
+    source_event: TransferSourceEvent = Field(description="Source Event")
+    data: dict | None = Field(description="Event data")
     created: str = Field(description="block_timestamp when Transfer log was emitted (JST)")
 
 

--- a/docs/ibet_wallet_api.yaml
+++ b/docs/ibet_wallet_api.yaml
@@ -2457,6 +2457,22 @@ paths:
             description: number of set
           name: limit
           in: query
+        - description: source event of transfer
+          required: false
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/TransferSourceEvent'
+            description: source event of transfer
+          name: source_event
+          in: query
+        - description: source event data
+          required: false
+          schema:
+            title: Data
+            type: string
+            description: source event data
+          name: data
+          in: query
       responses:
         '200':
           description: Successful Response
@@ -8025,6 +8041,7 @@ components:
         - from_address
         - to_address
         - value
+        - source_event
         - created
       type: object
       properties:
@@ -8048,10 +8065,25 @@ components:
           title: Value
           type: integer
           description: Transfer quantity
+        source_event:
+          allOf:
+            - $ref: '#/components/schemas/TransferSourceEvent'
+          description: Source Event
+        data:
+          title: Data
+          type: object
+          description: Event data
         created:
           title: Created
           type: string
           description: block_timestamp when Transfer log was emitted (JST)
+    TransferSourceEvent:
+      title: TransferSourceEvent
+      enum:
+        - Transfer
+        - Unlock
+      type: string
+      description: An enumeration.
     TxData:
       title: TxData
       required:

--- a/migrations/versions/051_alter_transfer.py
+++ b/migrations/versions/051_alter_transfer.py
@@ -1,0 +1,55 @@
+"""
+Copyright BOOSTRY Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+from sqlalchemy import *
+from sqlalchemy.exc import ProgrammingError
+from migrate import *
+from migrations.log import LOG
+
+meta = MetaData()
+
+
+def upgrade(migrate_engine):
+    meta.bind = migrate_engine
+
+    try:
+        # NOTE: カラム追加
+        transfer = Table("transfer", meta, autoload=True)
+        Column("data", JSON).create(transfer)
+        Column("source_event", String(50), nullable=False, server_default="Transfer").create(transfer)
+
+        # NOTE: 新規レコード登録時のデフォルト値設定の削除
+        meta.clear()
+        transfer = Table("transfer", meta, autoload=True)
+        transfer.c.source_event.alter(String(50), nullable=False, server_default=None)
+
+    except sqlalchemy.exc.ProgrammingError as err:
+        LOG.warning(err.orig)
+
+
+def downgrade(migrate_engine):
+    meta.bind = migrate_engine
+
+    try:
+        transfer = Table("transfer", meta, autoload=True)
+        Column("data").drop(transfer)
+        Column("source_event").drop(transfer)
+
+    except sqlalchemy.exc.ProgrammingError as err:
+        LOG.warning(err.orig)

--- a/tests/app/position_PositionCouponContractAddress_test.py
+++ b/tests/app/position_PositionCouponContractAddress_test.py
@@ -27,7 +27,8 @@ from app import config
 from app.contracts import Contract
 from app.model.db import (
     Listing,
-    IDXTransfer
+    IDXTransfer,
+    IDXTransferSourceEventType
 )
 from tests.account_config import eth_account
 from tests.contract_modules import (
@@ -203,6 +204,7 @@ class TestPositionCouponContractAddress:
         idx_transfer.from_address = self.issuer["account_address"]
         idx_transfer.to_address = self.account_1["account_address"]
         idx_transfer.value = 100000
+        idx_transfer.source_event = IDXTransferSourceEventType.TRANSFER.value
         session.add(idx_transfer)
         token_non = self.create_non_balance_data(
             self.account_1, self.account_2, {"address": config.ZERO_ADDRESS}, token_list_contract)
@@ -302,6 +304,7 @@ class TestPositionCouponContractAddress:
         idx_transfer.from_address = self.issuer["account_address"]
         idx_transfer.to_address = self.account_1["account_address"]
         idx_transfer.value = 100000
+        idx_transfer.source_event = IDXTransferSourceEventType.TRANSFER.value
         session.add(idx_transfer)
         token_non = self.create_non_balance_data(
             self.account_1, self.account_2, {"address": config.ZERO_ADDRESS}, token_list_contract)
@@ -401,6 +404,7 @@ class TestPositionCouponContractAddress:
         idx_transfer.from_address = self.issuer["account_address"]
         idx_transfer.to_address = self.account_1["account_address"]
         idx_transfer.value = 100000
+        idx_transfer.source_event = IDXTransferSourceEventType.TRANSFER.value
         session.add(idx_transfer)
         token_non = self.create_non_balance_data(
             self.account_1, self.account_2, {"address": config.ZERO_ADDRESS}, token_list_contract)
@@ -500,6 +504,7 @@ class TestPositionCouponContractAddress:
         idx_transfer.from_address = self.issuer["account_address"]
         idx_transfer.to_address = self.account_1["account_address"]
         idx_transfer.value = 100000
+        idx_transfer.source_event = IDXTransferSourceEventType.TRANSFER.value
         session.add(idx_transfer)
         token_non = self.create_non_balance_data(
             self.account_1, self.account_2, {"address": config.ZERO_ADDRESS}, token_list_contract)
@@ -599,6 +604,7 @@ class TestPositionCouponContractAddress:
         idx_transfer.from_address = self.issuer["account_address"]
         idx_transfer.to_address = self.account_1["account_address"]
         idx_transfer.value = 100000
+        idx_transfer.source_event = IDXTransferSourceEventType.TRANSFER.value
         session.add(idx_transfer)
         token_non = self.create_non_balance_data(
             self.account_1, self.account_2, {"address": config.ZERO_ADDRESS}, token_list_contract)
@@ -698,6 +704,7 @@ class TestPositionCouponContractAddress:
         idx_transfer.from_address = self.issuer["account_address"]
         idx_transfer.to_address = self.account_1["account_address"]
         idx_transfer.value = 100000
+        idx_transfer.source_event = IDXTransferSourceEventType.TRANSFER.value
         session.add(idx_transfer)
         token_non = self.create_non_balance_data(
             self.account_1, self.account_2, {"address": config.ZERO_ADDRESS}, token_list_contract)

--- a/tests/app/position_PositionCoupon_test.py
+++ b/tests/app/position_PositionCoupon_test.py
@@ -30,7 +30,8 @@ from app.model.db import (
     IDXTransfer,
     IDXPosition,
     IDXCouponToken,
-    IDXConsumeCoupon
+    IDXConsumeCoupon,
+    IDXTransferSourceEventType
 )
 from tests.account_config import eth_account
 from tests.contract_modules import (
@@ -271,6 +272,7 @@ class TestPositionAccountAddressCoupon:
         idx_transfer.from_address = self.issuer["account_address"]
         idx_transfer.to_address = self.account_1["account_address"]
         idx_transfer.value = 100000
+        idx_transfer.source_event = IDXTransferSourceEventType.TRANSFER.value
         session.add(idx_transfer)
         token_non = self.create_non_balance_data(
             self.account_1, self.account_2, {"address": config.ZERO_ADDRESS}, token_list_contract)
@@ -397,6 +399,7 @@ class TestPositionAccountAddressCoupon:
         idx_transfer.from_address = self.issuer["account_address"]
         idx_transfer.to_address = self.account_1["account_address"]
         idx_transfer.value = 100000
+        idx_transfer.source_event = IDXTransferSourceEventType.TRANSFER.value
         session.add(idx_transfer)
         token_non = self.create_non_balance_data(
             self.account_1, self.account_2, {"address": config.ZERO_ADDRESS}, token_list_contract)
@@ -605,6 +608,7 @@ class TestPositionAccountAddressCoupon:
         idx_transfer.from_address = self.issuer["account_address"]
         idx_transfer.to_address = self.account_1["account_address"]
         idx_transfer.value = 100000
+        idx_transfer.source_event = IDXTransferSourceEventType.TRANSFER.value
         session.add(idx_transfer)
 
         token_non = self.create_non_balance_data(
@@ -786,6 +790,7 @@ class TestPositionAccountAddressCoupon:
         idx_transfer.from_address = self.issuer["account_address"]
         idx_transfer.to_address = self.account_1["account_address"]
         idx_transfer.value = 100000
+        idx_transfer.source_event = IDXTransferSourceEventType.TRANSFER.value
         session.add(idx_transfer)
 
         token_non = self.create_non_balance_data(

--- a/tests/batch/indexer_Transfer_test.py
+++ b/tests/batch/indexer_Transfer_test.py
@@ -16,6 +16,7 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 """
+import json
 import logging
 from datetime import datetime
 import pytest
@@ -34,7 +35,8 @@ from app.errors import ServiceUnavailable
 from app.model.db import (
     Listing,
     IDXTransfer,
-    IDXTransferBlockNumber
+    IDXTransferBlockNumber,
+    IDXTransferSourceEventType
 )
 from batch import indexer_Transfer
 from batch.indexer_Transfer import LOG, UTC
@@ -253,7 +255,8 @@ class TestProcessor:
             share_token,
             self.trader["account_address"],
             self.trader2["account_address"],
-            50000
+            50000,
+            json.dumps({"message": "unlock"})
         )
         block_number_2 = web3.eth.block_number
 
@@ -272,6 +275,8 @@ class TestProcessor:
         assert idx_transfer.from_address == self.issuer["account_address"]
         assert idx_transfer.to_address == self.trader["account_address"]
         assert idx_transfer.value == 100000
+        assert idx_transfer.source_event == IDXTransferSourceEventType.TRANSFER.value
+        assert idx_transfer.data is None
         assert idx_transfer.created is not None
         assert idx_transfer.modified is not None
 
@@ -283,6 +288,8 @@ class TestProcessor:
         assert idx_transfer.from_address == self.trader["account_address"]
         assert idx_transfer.to_address == self.trader2["account_address"]
         assert idx_transfer.value == 50000
+        assert idx_transfer.source_event == IDXTransferSourceEventType.UNLOCK.value
+        assert idx_transfer.data == {"message": "unlock"}
         assert idx_transfer.created is not None
         assert idx_transfer.modified is not None
 
@@ -398,7 +405,8 @@ class TestProcessor:
             share_token,
             self.trader["account_address"],
             self.trader2["account_address"],
-            50000
+            50000,
+            json.dumps({"message": "unlock"})
         )
         block_number_3 = web3.eth.block_number
 
@@ -407,7 +415,8 @@ class TestProcessor:
             share_token,
             self.trader["account_address"],
             self.trader2["account_address"],
-            50000
+            50000,
+            json.dumps({"message": "unlock"})
         )
         block_number_4 = web3.eth.block_number
 
@@ -426,6 +435,8 @@ class TestProcessor:
         assert idx_transfer.from_address == self.issuer["account_address"]
         assert idx_transfer.to_address == self.trader["account_address"]
         assert idx_transfer.value == 100000
+        assert idx_transfer.source_event == IDXTransferSourceEventType.TRANSFER.value
+        assert idx_transfer.data is None
         assert idx_transfer.created is not None
         assert idx_transfer.modified is not None
 
@@ -437,6 +448,8 @@ class TestProcessor:
         assert idx_transfer.from_address == self.issuer["account_address"]
         assert idx_transfer.to_address == self.trader2["account_address"]
         assert idx_transfer.value == 200000
+        assert idx_transfer.source_event == IDXTransferSourceEventType.TRANSFER.value
+        assert idx_transfer.data is None
         assert idx_transfer.created is not None
         assert idx_transfer.modified is not None
 
@@ -448,6 +461,8 @@ class TestProcessor:
         assert idx_transfer.from_address == self.trader["account_address"]
         assert idx_transfer.to_address == self.trader2["account_address"]
         assert idx_transfer.value == 50000
+        assert idx_transfer.source_event == IDXTransferSourceEventType.UNLOCK.value
+        assert idx_transfer.data == {"message": "unlock"}
         assert idx_transfer.created is not None
         assert idx_transfer.modified is not None
 
@@ -459,6 +474,8 @@ class TestProcessor:
         assert idx_transfer.from_address == self.trader["account_address"]
         assert idx_transfer.to_address == self.trader2["account_address"]
         assert idx_transfer.value == 50000
+        assert idx_transfer.source_event == IDXTransferSourceEventType.UNLOCK.value
+        assert idx_transfer.data == {"message": "unlock"}
         assert idx_transfer.created is not None
         assert idx_transfer.modified is not None
 
@@ -538,6 +555,8 @@ class TestProcessor:
         assert idx_transfer.from_address == self.issuer["account_address"]
         assert idx_transfer.to_address == self.trader["account_address"]
         assert idx_transfer.value == 100000
+        assert idx_transfer.source_event == IDXTransferSourceEventType.TRANSFER.value
+        assert idx_transfer.data is None
         assert idx_transfer.created is not None
         assert idx_transfer.modified is not None
 
@@ -549,6 +568,8 @@ class TestProcessor:
         assert idx_transfer.from_address == self.issuer["account_address"]
         assert idx_transfer.to_address == self.trader["account_address"]
         assert idx_transfer.value == 200000
+        assert idx_transfer.source_event == IDXTransferSourceEventType.TRANSFER.value
+        assert idx_transfer.data is None
         assert idx_transfer.created is not None
         assert idx_transfer.modified is not None
 
@@ -560,6 +581,8 @@ class TestProcessor:
         assert idx_transfer.from_address == self.issuer["account_address"]
         assert idx_transfer.to_address == self.trader["account_address"]
         assert idx_transfer.value == 300000
+        assert idx_transfer.source_event == IDXTransferSourceEventType.TRANSFER.value
+        assert idx_transfer.data is None
         assert idx_transfer.created is not None
         assert idx_transfer.modified is not None
 
@@ -624,6 +647,8 @@ class TestProcessor:
         assert _transfer.from_address == self.issuer["account_address"]
         assert _transfer.to_address == self.trader["account_address"]
         assert _transfer.value == 100000
+        assert _transfer.source_event == IDXTransferSourceEventType.TRANSFER.value
+        assert _transfer.data is None
         assert _transfer.created is not None
         assert _transfer.modified is not None
 
@@ -703,6 +728,8 @@ class TestProcessor:
         assert _transfer.from_address == self.issuer["account_address"]
         assert _transfer.to_address == self.trader["account_address"]
         assert _transfer.value == 100000
+        assert _transfer.source_event == IDXTransferSourceEventType.TRANSFER.value
+        assert _transfer.data is None
         assert _transfer.created is not None
         assert _transfer.modified is not None
 
@@ -785,6 +812,8 @@ class TestProcessor:
         assert _transfer.from_address == self.issuer["account_address"]
         assert _transfer.to_address == self.trader["account_address"]
         assert _transfer.value == 100000
+        assert _transfer.source_event == IDXTransferSourceEventType.TRANSFER.value
+        assert _transfer.data is None
         assert _transfer.created is not None
         assert _transfer.modified is not None
 
@@ -863,6 +892,7 @@ class TestProcessor:
         idx_transfer.from_address = self.issuer["account_address"]
         idx_transfer.to_address = self.issuer["account_address"]
         idx_transfer.value = 100000
+        idx_transfer.source_event = IDXTransferSourceEventType.TRANSFER.value
         idx_transfer.token_address = share_token["address"]
         idx_transfer.created = datetime.fromtimestamp(block["timestamp"], UTC)
         session.merge(idx_transfer)

--- a/tests/contract_modules.py
+++ b/tests/contract_modules.py
@@ -281,11 +281,11 @@ def bond_lock(invoker, token, lock_address: str, amount: int):
 
 
 # トークン資産アンロック
-def bond_unlock(invoker, token, target: str, recipient: str, amount: int):
+def bond_unlock(invoker, token, target: str, recipient: str, amount: int, data_str: str = ""):
     web3.eth.default_account = invoker['account_address']
 
     TokenContract = Contract.get_contract('IbetStraightBond', token['address'])
-    tx_hash = TokenContract.functions.unlock(target, recipient, amount, ""). \
+    tx_hash = TokenContract.functions.unlock(target, recipient, amount, data_str). \
         transact({'from': invoker['account_address'], 'gas': 4000000})
     web3.eth.wait_for_transaction_receipt(tx_hash)
 
@@ -482,11 +482,11 @@ def share_lock(invoker, token, lock_address: str, amount: int):
 
 
 # トークン資産アンロック
-def share_unlock(invoker, token, target: str, recipient: str, amount: int):
+def share_unlock(invoker, token, target: str, recipient: str, amount: int, data_str: str = ""):
     web3.eth.default_account = invoker['account_address']
 
     TokenContract = Contract.get_contract('IbetShare', token['address'])
-    tx_hash = TokenContract.functions.unlock(target, recipient, amount, ""). \
+    tx_hash = TokenContract.functions.unlock(target, recipient, amount, data_str). \
         transact({'from': invoker['account_address'], 'gas': 4000000})
     web3.eth.wait_for_transaction_receipt(tx_hash)
 


### PR DESCRIPTION
Close #1303 

### Changes

- Added new columns about source event data to `IDXTransfer`
- Added some logic to batch `indexer_Transfer` so that source event data is stored.
- Added some query param to `/Token/{token_address}/TransferHistory`

### Check List

- [x] Migrations about server_default value for existing record
- [x] API document updates
- [x] Unit tests coverages