### PR TITLE
Bump FastAPI to 0.91.0

### DIFF
--- a/requirements.lock
+++ b/requirements.lock
@@ -5,9 +5,9 @@ asn1crypto==1.5.1
 async-timeout==4.0.2
 attrs==22.2.0
 base58==2.1.1
-bitarray==2.6.2
-boto3==1.26.59
-botocore==1.29.60
+bitarray==2.7.0
+boto3==1.26.68
+botocore==1.29.68
 certifi==2022.12.7
 cffi==1.15.1
 charset-normalizer==2.1.1
@@ -25,7 +25,7 @@ eth-keys==0.3.4
 eth-rlp==0.2.1
 eth-typing==2.3.0
 eth-utils==1.10.0
-fastapi==0.88.0
+fastapi==0.91.0
 frozenlist==1.3.3
 gevent==22.10.2
 greenlet==2.0.2
@@ -40,7 +40,7 @@ lru-dict==1.1.8
 multiaddr==0.0.9
 multidict==6.0.4
 netaddr==0.8.0
-orjson==3.8.3
+orjson==3.8.6
 parsimonious==0.8.1
 pbr==5.11.1
 protobuf==3.19.5
@@ -59,7 +59,7 @@ sniffio==1.3.0
 SQLAlchemy==1.4.46
 sqlalchemy-migrate==0.13.0
 sqlparse==0.4.3
-starlette==0.22.0
+starlette==0.24.0
 Tempita==0.5.2
 toolz==0.12.0
 typing_extensions==4.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
-boto3== 1.26.59
+boto3== 1.26.68
 coincurve==18.0.0
 eth-keyfile==0.5.1
 eth-utils==1.10.0
-fastapi==0.88.0
+fastapi==0.91.0
 gunicorn==20.1.0
 gevent==22.10.2
 hexbytes==0.3.0
-orjson==3.8.3
+orjson==3.8.6
 PyMySQL==1.0.2
 psycopg2-binary==2.9.5
 pydantic[email]==1.10.4

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,4 @@
-pytest==7.2.0
+pytest==7.2.1
 pytest-cov==4.0.0
 locustio==0.9.0
-httpx==0.23.1
+httpx==0.23.3


### PR DESCRIPTION
Upgrade packages.

- FastAPI etc.

### Release notes: FastAPI
- https://github.com/tiangolo/fastapi/releases/tag/0.89.0
- https://github.com/tiangolo/fastapi/releases/tag/0.89.1
- https://github.com/tiangolo/fastapi/releases/tag/0.90.0
- https://github.com/tiangolo/fastapi/releases/tag/0.90.1
- https://github.com/tiangolo/fastapi/releases/tag/0.91.0