### PR TITLE
fix: timeout/cache/limit parameters in BC Explorer

### DIFF
--- a/cmd/explorer/src/connector/__init__.py
+++ b/cmd/explorer/src/connector/__init__.py
@@ -47,7 +47,8 @@ async def health_check(url: str, session: ClientSession) -> None:
         await resp.json()
 
 
-async def get_node_info(url: str, session: ClientSession) -> GetBlockSyncStatusResponse:
+@AsyncTTL(time_to_live=10, skip_args=1)
+async def get_node_info(session: ClientSession, url: str) -> GetBlockSyncStatusResponse:
     async with session.get(url=f"{url}/NodeInfo/BlockSyncStatus") as resp:
         data = await resp.json()
         return GetBlockSyncStatusResponse.parse_obj(data.get("data"))

--- a/cmd/explorer/src/gui/explorer.css
+++ b/cmd/explorer/src/gui/explorer.css
@@ -45,6 +45,10 @@ DataTable:focus {
     height: 1;
     background: $accent-darken-3;
 }
+#tx_list_header {
+    height: 1;
+    background: $accent-darken-3;
+}
 .menubutton {
     color: $text;
     width: 30;

--- a/cmd/explorer/src/gui/screen/block.py
+++ b/cmd/explorer/src/gui/screen/block.py
@@ -111,7 +111,7 @@ class BlockScreen(TuiScreen):
     async def background_execution(self, refresh_rate: float):
         self.background_lock = Event()
         block_number = None
-        async with TCPConnector(limit=1, keepalive_timeout=60) as tcp_connector:
+        async with TCPConnector(limit=2, keepalive_timeout=0) as tcp_connector:
             async with ClientSession(connector=tcp_connector, timeout=ClientTimeout(30)) as session:
                 while self.is_running:
                     start = time.time()
@@ -163,11 +163,11 @@ class BlockScreen(TuiScreen):
         async with self.lock_reload_block:
             if self.current_block_number == 0:
                 return
-            async with TCPConnector(limit=1) as tcp_connector:
+            async with TCPConnector(limit=1, keepalive_timeout=0) as tcp_connector:
                 async with ClientSession(connector=tcp_connector, timeout=ClientTimeout(30)) as session:
                     query = ListBlockDataQuery()
                     query.to_block_number = self.current_block_number
-                    query.limit = 100
+                    query.from_block_number = self.current_block_number - 100
                     query.sort_order = SortOrder.DESC
                     try:
                         block_data_list: BlockDataListResponse = await connector.list_block_data(
@@ -212,7 +212,7 @@ class BlockScreen(TuiScreen):
         if selected_row is None:
             return
         block_number = selected_row_data[0]
-        async with TCPConnector(limit=1) as tcp_connector:
+        async with TCPConnector(limit=1, keepalive_timeout=0) as tcp_connector:
             async with ClientSession(connector=tcp_connector, timeout=ClientTimeout(30)) as session:
                 try:
                     block_detail: BlockDataDetail = await connector.get_block_data(

--- a/cmd/explorer/src/gui/screen/transaction.py
+++ b/cmd/explorer/src/gui/screen/transaction.py
@@ -50,7 +50,7 @@ class TransactionScreen(TuiScreen):
                     Label(Text.from_markup(" [bold]ibet-Wallet-API BC Explorer[/bold]")),
                     Label(" | "),
                     Label(f"Selected block: -", id=ID.TX_SELECTED_BLOCK_NUMBER),
-                    id="header",
+                    id="tx_list_header",
                 ),
                 Horizontal(TxListView(classes="column"), TxDetailView(classes="column")),
                 classes="column",

--- a/cmd/explorer/src/gui/screen/transaction.py
+++ b/cmd/explorer/src/gui/screen/transaction.py
@@ -73,7 +73,7 @@ class TransactionScreen(TuiScreen):
 
         tx_hash = selected_row[0]
         async with TCPConnector(limit=1) as tcp_connector:
-            async with ClientSession(connector=tcp_connector, timeout=ClientTimeout(10)) as session:
+            async with ClientSession(connector=tcp_connector, timeout=ClientTimeout(30)) as session:
                 tx_detail: TxDataDetail = await connector.get_tx_data(
                     session,
                     self.tui.url,
@@ -87,7 +87,7 @@ class TransactionScreen(TuiScreen):
     async def on_screen_resume(self):
         if self.tui.state.tx_query is not None:
             async with TCPConnector(limit=1) as tcp_connector:
-                async with ClientSession(connector=tcp_connector, timeout=ClientTimeout(10)) as session:
+                async with ClientSession(connector=tcp_connector, timeout=ClientTimeout(30)) as session:
                     tx_list = await connector.list_tx_data(
                         session=session, url=self.tui.url, query=self.tui.state.tx_query
                     )

--- a/cmd/explorer/src/gui/screen/transaction.py
+++ b/cmd/explorer/src/gui/screen/transaction.py
@@ -72,7 +72,7 @@ class TransactionScreen(TuiScreen):
             return
 
         tx_hash = selected_row[0]
-        async with TCPConnector(limit=1) as tcp_connector:
+        async with TCPConnector(limit=1, keepalive_timeout=0) as tcp_connector:
             async with ClientSession(connector=tcp_connector, timeout=ClientTimeout(30)) as session:
                 tx_detail: TxDataDetail = await connector.get_tx_data(
                     session,
@@ -86,7 +86,7 @@ class TransactionScreen(TuiScreen):
 
     async def on_screen_resume(self):
         if self.tui.state.tx_query is not None:
-            async with TCPConnector(limit=1) as tcp_connector:
+            async with TCPConnector(limit=1, keepalive_timeout=0) as tcp_connector:
                 async with ClientSession(connector=tcp_connector, timeout=ClientTimeout(30)) as session:
                     tx_list = await connector.list_tx_data(
                         session=session, url=self.tui.url, query=self.tui.state.tx_query


### PR DESCRIPTION
Fix: #1320

### Changes

- Change client timeout from 10 sec to 30 sec.
- Added client cache.
- Reduce the number of blocks initially fetched from 300 to 100.