### PR TITLE
hotfix: change message level about web3 in GET endpoint

### DIFF
--- a/app/api/routers/position.py
+++ b/app/api/routers/position.py
@@ -43,7 +43,8 @@ from app.database import db_session
 from app.errors import (
     InvalidParameterError,
     DataNotExistsError,
-    NotSupportedError
+    NotSupportedError,
+    ServiceUnavailable
 )
 from app.model.db import (
     Listing,
@@ -350,6 +351,9 @@ class BasePosition:
                 else:
                     position["token_address"] = token_address
                 return position
+        except ServiceUnavailable as e:
+            LOG.warning(e)
+            return None
         except Exception as e:
             LOG.error(e)
             return None
@@ -447,6 +451,9 @@ class BasePositionShare(BasePosition):
                 else:
                     position["token_address"] = token_address
                 return position
+        except ServiceUnavailable as e:
+            LOG.warning(e)
+            return None
         except Exception as e:
             LOG.error(e)
             return None
@@ -520,6 +527,9 @@ class BasePositionStraightBond(BasePosition):
                 else:
                     position["token_address"] = token_address
                 return position
+        except ServiceUnavailable as e:
+            LOG.warning(e)
+            return None
         except Exception as e:
             LOG.error(e)
             return None
@@ -746,6 +756,9 @@ class BasePositionCoupon(BasePosition):
                 else:
                     position["token_address"] = token_address
                 return position
+        except ServiceUnavailable as e:
+            LOG.warning(e)
+            return None
         except Exception as e:
             LOG.error(e)
             return None

--- a/app/api/routers/token.py
+++ b/app/api/routers/token.py
@@ -36,7 +36,8 @@ from app import log
 from app.database import db_session
 from app.errors import (
     InvalidParameterError,
-    DataNotExistsError
+    DataNotExistsError,
+    ServiceUnavailable
 )
 from app import config
 from app.contracts import Contract
@@ -132,6 +133,9 @@ def get_token_status(
             function_name="transferable",
             args=()
         )
+    except ServiceUnavailable as e:
+        LOG.warning(e)
+        raise DataNotExistsError('contract_address: %s' % contract_address)
     except Exception as e:
         LOG.error(e)
         raise DataNotExistsError('contract_address: %s' % contract_address)

--- a/app/api/routers/token_bond.py
+++ b/app/api/routers/token_bond.py
@@ -33,7 +33,8 @@ from app.database import db_session
 from app.errors import (
     InvalidParameterError,
     NotSupportedError,
-    DataNotExistsError
+    DataNotExistsError,
+    ServiceUnavailable
 )
 from app import config
 from app.model.blockchain import BondToken
@@ -313,6 +314,9 @@ def retrieve_straight_bond_token(
     try:
         token_detail = BondToken.get(session=session, token_address=token_address)
 
+    except ServiceUnavailable as e:
+        LOG.warning(e)
+        raise DataNotExistsError('contract_address: %s' % contract_address) from None
     except Exception as e:
         LOG.error(e)
         raise DataNotExistsError('contract_address: %s' % contract_address) from None

--- a/app/api/routers/token_coupon.py
+++ b/app/api/routers/token_coupon.py
@@ -33,7 +33,8 @@ from app.database import db_session
 from app.errors import (
     InvalidParameterError,
     NotSupportedError, 
-    DataNotExistsError
+    DataNotExistsError,
+    ServiceUnavailable
 )
 from app import config
 from app.model.blockchain import CouponToken
@@ -296,6 +297,9 @@ def retrieve_coupon_token(
 
     try:
         token_detail = CouponToken.get(session=session, token_address=token_address)
+    except ServiceUnavailable as e:
+        LOG.warning(e)
+        raise DataNotExistsError('contract_address: %s' % contract_address) from None
     except Exception as e:
         LOG.error(e)
         raise DataNotExistsError('contract_address: %s' % contract_address) from None

--- a/app/api/routers/token_membership.py
+++ b/app/api/routers/token_membership.py
@@ -33,7 +33,8 @@ from app.database import db_session
 from app.errors import (
     InvalidParameterError,
     NotSupportedError,
-    DataNotExistsError
+    DataNotExistsError,
+    ServiceUnavailable
 )
 from app import config
 from app.model.blockchain import MembershipToken
@@ -296,6 +297,9 @@ def retrieve_membership_token(
 
     try:
         token_detail = MembershipToken.get(session=session, token_address=token_address)
+    except ServiceUnavailable as e:
+        LOG.warning(e)
+        raise DataNotExistsError('contract_address: %s' % contract_address) from None
     except Exception as e:
         LOG.error(e)
         raise DataNotExistsError('contract_address: %s' % contract_address) from None

--- a/app/api/routers/token_share.py
+++ b/app/api/routers/token_share.py
@@ -33,7 +33,8 @@ from app.database import db_session
 from app.errors import (
     InvalidParameterError,
     NotSupportedError,
-    DataNotExistsError
+    DataNotExistsError,
+    ServiceUnavailable
 )
 from app import config
 from app.model.blockchain import ShareToken
@@ -313,6 +314,9 @@ def retrieve_share_token(
 
     try:
         token_detail = ShareToken.get(session=session, token_address=token_address)
+    except ServiceUnavailable as e:
+        LOG.warning(e)
+        raise DataNotExistsError('contract_address: %s' % contract_address) from None
     except Exception as e:
         LOG.error(e)
         raise DataNotExistsError('contract_address: %s' % contract_address) from None


### PR DESCRIPTION
- From past release, if the connection to quorum is broken during an API endpoint request, a `Block Synchronisation down` message is displayed as an error. 
- Considering the frequency with this, it would be preferable to make it  as warning.
- So changed message level about web3 exception in GET endpoints.