### PR TITLE
feat: Localize datetime and return it in API response

### DIFF
--- a/ENV_LIST.md
+++ b/ENV_LIST.md
@@ -15,6 +15,7 @@ The list of environment variables that can be set for this system is as follows.
 | TEST_DATABASE_URL       | False    | Test database URL (for development use)  | postgresql://xxxx:xxxx@yyyy:5432/zzzz    | postgresql://ethuser:ethpass@localhost:5432/ethcache_test |
 | APP_LOGFILE             | False    | Output location for application logs     | /some/directory                          | /dev/stdout (standard output)                             |
 | ACCESS_LOGFILE          | False    | Output location for access logs          | /some/directory                          | /dev/stdout (standard output)                             |
+| TZ                      | False    | Time Zone                                | Europe/Berlin                            | Asia/Tokyo                                                |
 
 
 ## API Server Settings

--- a/app/api/routers/position.py
+++ b/app/api/routers/position.py
@@ -21,6 +21,7 @@ from datetime import (
     timezone
 )
 from decimal import Decimal
+from zoneinfo import ZoneInfo
 from eth_utils import to_checksum_address
 from fastapi import (
     APIRouter,
@@ -49,6 +50,7 @@ from web3 import Web3
 
 from app import config
 from app import log
+from app.config import TZ
 from app.contracts import Contract
 from app.database import db_session
 from app.errors import (
@@ -108,13 +110,12 @@ from app.utils.fastapi import json_response
 LOG = log.get_logger()
 
 UTC = timezone(timedelta(hours=0), "UTC")
-JST = timezone(timedelta(hours=+9), "JST")
+local_tz = ZoneInfo(TZ)
 
 router = APIRouter(
     prefix="/Position",
     tags=["user_position"]
 )
-
 
 
 class ListAllLock:
@@ -297,7 +298,7 @@ class ListAllLockEvent:
                 "recipient_address": lock_event[5],
                 "value": lock_event[6],
                 "data": lock_event[7],
-                "block_timestamp": lock_event[8].replace(tzinfo=UTC).astimezone(JST)
+                "block_timestamp": lock_event[8].replace(tzinfo=UTC).astimezone(local_tz)
             })
 
         data = {

--- a/app/config.py
+++ b/app/config.py
@@ -50,6 +50,9 @@ COMPANY_LIST_URL = os.environ.get("COMPANY_LIST_URL")
 COMPANY_LIST_LOCAL_MODE = True if os.environ.get("COMPANY_LIST_LOCAL_MODE") == "1" else False
 COMPANY_LIST_SLEEP_INTERVAL = int(os.environ.get("COMPANY_LIST_SLEEP_INTERVAL")) if os.environ.get("COMPANY_LIST_SLEEP_INTERVAL") else 3600
 
+# System timezone for REST API
+TZ = os.environ.get("TZ") or "Asia/Tokyo"
+
 ####################################################
 # Server settings
 ####################################################

--- a/app/model/db/idx_lock_unlock.py
+++ b/app/model/db/idx_lock_unlock.py
@@ -22,6 +22,7 @@ from datetime import (
     timezone,
     timedelta
 )
+from zoneinfo import ZoneInfo
 from sqlalchemy import (
     Column,
     String,
@@ -29,11 +30,11 @@ from sqlalchemy import (
     JSON,
     DateTime
 )
-
+from app.config import TZ
 from app.model.db import Base
 
 UTC = timezone(timedelta(hours=0), "UTC")
-JST = timezone(timedelta(hours=+9), "JST")
+local_tz = ZoneInfo(TZ)
 
 
 class IDXLock(Base):
@@ -73,11 +74,15 @@ class IDXLock(Base):
     FIELDS.update(Base.FIELDS)
 
     @staticmethod
-    def replace_to_JST(_datetime: datetime) -> datetime | None:
+    def replace_to_local_tz(_datetime: datetime) -> datetime | None:
+        """Convert timestamp from UTC to local timezone
+        :param _datetime:
+        :return: datetime | None
+        """
         if _datetime is None:
             return None
-        datetime_jp = _datetime.replace(tzinfo=UTC).astimezone(JST)
-        return datetime_jp
+        datetime_local = _datetime.replace(tzinfo=UTC).astimezone(local_tz)
+        return datetime_local
 
     def json(self):
         return {
@@ -89,7 +94,7 @@ class IDXLock(Base):
             "account_address": self.account_address,
             "value": self.value,
             "data": self.data,
-            "block_timestamp": self.replace_to_JST(self.block_timestamp)
+            "block_timestamp": self.replace_to_local_tz(self.block_timestamp)
         }
 
 
@@ -133,11 +138,15 @@ class IDXUnlock(Base):
     FIELDS.update(Base.FIELDS)
 
     @staticmethod
-    def replace_to_JST(_datetime: datetime) -> datetime | None:
+    def replace_to_local_tz(_datetime: datetime) -> datetime | None:
+        """Convert timestamp from UTC to local timezone
+        :param _datetime:
+        :return: datetime | None
+        """
         if _datetime is None:
             return None
-        datetime_jp = _datetime.replace(tzinfo=UTC).astimezone(JST)
-        return datetime_jp
+        datetime_local = _datetime.replace(tzinfo=UTC).astimezone(local_tz)
+        return datetime_local
 
     def json(self):
         return {
@@ -150,5 +159,5 @@ class IDXUnlock(Base):
             "recipient_address": self.recipient_address,
             "value": self.value,
             "data": self.data,
-            "block_timestamp": self.replace_to_JST(self.block_timestamp)
+            "block_timestamp": self.replace_to_local_tz(self.block_timestamp)
         }

--- a/app/model/db/idx_transfer.py
+++ b/app/model/db/idx_transfer.py
@@ -17,6 +17,7 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 from enum import Enum
+from zoneinfo import ZoneInfo
 from sqlalchemy import (
     Column,
     String,
@@ -28,11 +29,11 @@ from datetime import (
     timedelta,
     timezone
 )
-
+from app.config import TZ
 from app.model.db import Base
 
 UTC = timezone(timedelta(hours=0), "UTC")
-JST = timezone(timedelta(hours=+9), "JST")
+local_tz = ZoneInfo(TZ)
 
 
 class IDXTransferSourceEventType(str, Enum):
@@ -64,14 +65,14 @@ class IDXTransfer(Base):
 
     @staticmethod
     def format_timestamp(_datetime: datetime) -> str:
-        """UTCからJSTへ変換
+        """Convert timestamp from UTC to local timezone str
         :param _datetime:
-        :return:
+        :return: str
         """
         if _datetime is None:
             return ""
-        datetime_jp = _datetime.replace(tzinfo=UTC).astimezone(JST)
-        return datetime_jp.strftime("%Y/%m/%d %H:%M:%S")
+        datetime_local = _datetime.replace(tzinfo=UTC).astimezone(local_tz)
+        return datetime_local.strftime("%Y/%m/%d %H:%M:%S")
 
     def json(self):
         return {

--- a/app/model/db/idx_transfer_approval.py
+++ b/app/model/db/idx_transfer_approval.py
@@ -21,7 +21,7 @@ from datetime import (
     timezone,
     timedelta
 )
-
+from zoneinfo import ZoneInfo
 from sqlalchemy import (
     Column,
     String,
@@ -29,12 +29,12 @@ from sqlalchemy import (
     DateTime,
     Boolean
 )
-
+from app.config import TZ
 from app.model.db import Base
 from app.utils import alchemy
 
 UTC = timezone(timedelta(hours=0), "UTC")
-JST = timezone(timedelta(hours=+9), "JST")
+local_tz = ZoneInfo(TZ)
 
 
 class IDXTransferApproval(Base):
@@ -72,10 +72,14 @@ class IDXTransferApproval(Base):
 
     @staticmethod
     def format_datetime(_datetime: datetime) -> str:
+        """Convert timestamp from UTC to local timezone str
+        :param _datetime:
+        :return: str
+        """
         if _datetime is None:
             return ""
-        _datetime = _datetime.replace(tzinfo=UTC).astimezone(JST)
-        return _datetime.strftime("%Y/%m/%d %H:%M:%S.%f")
+        datetime_local = _datetime.replace(tzinfo=UTC).astimezone(local_tz)
+        return datetime_local.strftime("%Y/%m/%d %H:%M:%S")
 
     def json(self):
         return {

--- a/app/model/db/listing.py
+++ b/app/model/db/listing.py
@@ -17,15 +17,24 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
-from datetime import datetime, timedelta, timezone
-
+from datetime import (
+    datetime,
+    timedelta,
+    timezone
+)
+from zoneinfo import ZoneInfo
 from sqlalchemy import Column
-from sqlalchemy import String, BigInteger, Boolean
+from sqlalchemy import (
+    String,
+    BigInteger,
+    Boolean
+)
 
+from app.config import TZ
 from app.model.db import Base
 
 UTC = timezone(timedelta(hours=0), "UTC")
-JST = timezone(timedelta(hours=+9), "JST")
+local_tz = ZoneInfo(TZ)
 
 
 class Listing(Base):
@@ -45,14 +54,14 @@ class Listing(Base):
 
     @staticmethod
     def format_timestamp(_datetime: datetime) -> str:
-        """UTCからJSTへ変換
+        """Convert timestamp from UTC to local timezone str
         :param _datetime:
-        :return:
+        :return: str
         """
         if _datetime is None:
             return ""
-        datetime_jp = _datetime.replace(tzinfo=UTC).astimezone(JST)
-        return datetime_jp.strftime("%Y/%m/%d %H:%M:%S")
+        datetime_local = _datetime.replace(tzinfo=UTC).astimezone(local_tz)
+        return datetime_local.strftime("%Y/%m/%d %H:%M:%S")
 
     def json(self):
         return {

--- a/app/model/schema/admin.py
+++ b/app/model/schema/admin.py
@@ -72,7 +72,7 @@ class RetrieveAdminTokenResponse(BaseModel):
     max_holding_quantity: Optional[int]
     max_sell_amount: Optional[int]
     owner_address: str = Field(...)
-    created: str = Field(..., description="Create Datetime (JST)")
+    created: str = Field(..., description="Create Datetime (local timezone)")
 
 
 class ListAllAdminTokensResponse(BaseModel):

--- a/app/model/schema/position.py
+++ b/app/model/schema/position.py
@@ -117,7 +117,7 @@ class LockEvent(BaseModel):
     recipient_address: Optional[str] = Field(default=None, description="Recipient address")
     value: int = Field(description="Transfer quantity")
     data: dict = Field(description="Data")
-    block_timestamp: datetime = Field(description="block_timestamp when Lock log was emitted (JST)")
+    block_timestamp: datetime = Field(description="block_timestamp when Lock log was emitted (local_timezone)")
 
 
 ############################

--- a/app/model/schema/token.py
+++ b/app/model/schema/token.py
@@ -139,7 +139,7 @@ class TransferHistory(BaseModel):
     value: int = Field(description="Transfer quantity")
     source_event: TransferSourceEvent = Field(description="Source Event")
     data: dict | None = Field(description="Event data")
-    created: str = Field(description="block_timestamp when Transfer log was emitted (JST)")
+    created: str = Field(description="block_timestamp when Transfer log was emitted (local timezone)")
 
 
 class TransferHistoriesResponse(BaseModel):
@@ -154,10 +154,10 @@ class TransferApprovalHistory(BaseModel):
     from_address: str = Field(description="Account address of transfer source")
     to_address: str = Field(description="Account address of transfer destination")
     value: int = Field(description="Transfer quantity")
-    application_datetime: str = Field(description="application datetime (JST)")
-    application_blocktimestamp: str = Field(description="application blocktimestamp (JST)")
-    approval_datetime: Optional[str] = Field(description="approval datetime (JST)")
-    approval_blocktimestamp: Optional[str] = Field(description="approval blocktimestamp (JST)")
+    application_datetime: str = Field(description="application datetime (local timezone)")
+    application_blocktimestamp: str = Field(description="application blocktimestamp (local timezone)")
+    approval_datetime: Optional[str] = Field(description="approval datetime (local timezone)")
+    approval_blocktimestamp: Optional[str] = Field(description="approval blocktimestamp (local timezone)")
     cancelled: Optional[bool] = Field(description="Cancellation status")
     transfer_approved: Optional[bool] = Field(description="transfer approval status")
 

--- a/batch/indexer_Consume_Coupon.py
+++ b/batch/indexer_Consume_Coupon.py
@@ -19,11 +19,8 @@ SPDX-License-Identifier: Apache-2.0
 import os
 import sys
 import time
-from datetime import (
-    datetime,
-    timezone,
-    timedelta
-)
+from datetime import datetime
+from zoneinfo import ZoneInfo
 
 from eth_utils import to_checksum_address
 from sqlalchemy import create_engine
@@ -37,7 +34,8 @@ sys.path.append(path)
 from app.config import (
     DATABASE_URL,
     TOKEN_LIST_CONTRACT_ADDRESS,
-    ZERO_ADDRESS
+    ZERO_ADDRESS,
+    TZ
 )
 from app.contracts import Contract
 from app.errors import ServiceUnavailable
@@ -48,7 +46,7 @@ from app.model.db import (
 from app.utils.web3_utils import Web3Wrapper
 import log
 
-JST = timezone(timedelta(hours=+9), "JST")
+local_tz = ZoneInfo(TZ)
 
 process_name = "INDEXER-CONSUME-COUPON"
 LOG = log.get_logger(process_name=process_name)
@@ -172,7 +170,7 @@ class Processor:
                     transaction_hash = event["transactionHash"].hex()
                     block_timestamp = datetime.fromtimestamp(
                         web3.eth.get_block(event["blockNumber"])["timestamp"],
-                        JST
+                        local_tz
                     )
                     amount = args.get("value", 0)
                     consumer = args.get("consumer", ZERO_ADDRESS)

--- a/batch/indexer_DEX.py
+++ b/batch/indexer_DEX.py
@@ -24,6 +24,7 @@ from datetime import (
     timezone,
     timedelta
 )
+from zoneinfo import ZoneInfo
 
 from sqlalchemy import create_engine
 from sqlalchemy.exc import SQLAlchemyError
@@ -36,7 +37,8 @@ sys.path.append(path)
 from app.config import (
     DATABASE_URL,
     IBET_MEMBERSHIP_EXCHANGE_CONTRACT_ADDRESS,
-    IBET_COUPON_EXCHANGE_CONTRACT_ADDRESS
+    IBET_COUPON_EXCHANGE_CONTRACT_ADDRESS,
+    TZ
 )
 from app.contracts import Contract
 from app.errors import ServiceUnavailable
@@ -49,7 +51,7 @@ from app.model.db import (
 from app.utils.web3_utils import Web3Wrapper
 import log
 
-JST = timezone(timedelta(hours=+9), "JST")
+local_tz = ZoneInfo(TZ)
 
 process_name = "INDEXER-DEX"
 LOG = log.get_logger(process_name=process_name)
@@ -172,7 +174,7 @@ class Processor:
                         transaction_hash = event["transactionHash"].hex()
                         order_timestamp = datetime.fromtimestamp(
                             web3.eth.get_block(event["blockNumber"])["timestamp"],
-                            JST
+                            local_tz
                         )
                         if available_token is not None:
                             account_address = args["accountAddress"]
@@ -263,7 +265,7 @@ class Processor:
                         transaction_hash = event["transactionHash"].hex()
                         agreement_timestamp = datetime.fromtimestamp(
                             web3.eth.get_block(event["blockNumber"])["timestamp"],
-                            JST
+                            local_tz
                         )
                         self.__sink_on_agree(
                             db_session=db_session,
@@ -294,7 +296,7 @@ class Processor:
                     args = event["args"]
                     settlement_timestamp = datetime.fromtimestamp(
                         web3.eth.get_block(event["blockNumber"])["timestamp"],
-                        JST
+                        local_tz
                     )
                     self.__sink_on_settlement_ok(
                         db_session=db_session,

--- a/batch/processor_Notifications_Coupon_Exchange.py
+++ b/batch/processor_Notifications_Coupon_Exchange.py
@@ -20,11 +20,8 @@ import os
 import sys
 from concurrent.futures import ThreadPoolExecutor
 import time
-from datetime import (
-    datetime,
-    timezone,
-    timedelta
-)
+from datetime import datetime
+from zoneinfo import ZoneInfo
 
 from sqlalchemy import create_engine
 from sqlalchemy.exc import SQLAlchemyError
@@ -38,7 +35,8 @@ from app.config import (
     WORKER_COUNT,
     NOTIFICATION_PROCESS_INTERVAL,
     TOKEN_LIST_CONTRACT_ADDRESS,
-    IBET_COUPON_EXCHANGE_CONTRACT_ADDRESS
+    IBET_COUPON_EXCHANGE_CONTRACT_ADDRESS,
+    TZ
 )
 from app.contracts import Contract
 from app.errors import ServiceUnavailable
@@ -54,7 +52,7 @@ from batch.lib.token_list import TokenList
 from batch.lib.misc import wait_all_futures
 import log
 
-JST = timezone(timedelta(hours=+9), "JST")
+local_tz = ZoneInfo(TZ)
 LOG = log.get_logger(process_name="PROCESSOR-NOTIFICATIONS-COUPON-EXCHANGE")
 
 WORKER_COUNT = int(WORKER_COUNT)
@@ -100,7 +98,7 @@ class Watcher:
 
     @staticmethod
     def _gen_block_timestamp(entry):
-        return datetime.fromtimestamp(web3.eth.get_block(entry["blockNumber"])["timestamp"], JST)
+        return datetime.fromtimestamp(web3.eth.get_block(entry["blockNumber"])["timestamp"], local_tz)
 
     def watch(self, db_session: Session, entries):
         pass

--- a/batch/processor_Notifications_Membership_Exchange.py
+++ b/batch/processor_Notifications_Membership_Exchange.py
@@ -20,11 +20,8 @@ import os
 import sys
 from concurrent.futures import ThreadPoolExecutor
 import time
-from datetime import (
-    datetime,
-    timezone,
-    timedelta
-)
+from datetime import datetime
+from zoneinfo import ZoneInfo
 
 from sqlalchemy import create_engine
 from sqlalchemy.exc import SQLAlchemyError
@@ -38,7 +35,8 @@ from app.config import (
     WORKER_COUNT,
     NOTIFICATION_PROCESS_INTERVAL,
     IBET_MEMBERSHIP_EXCHANGE_CONTRACT_ADDRESS,
-    TOKEN_LIST_CONTRACT_ADDRESS
+    TOKEN_LIST_CONTRACT_ADDRESS,
+    TZ
 )
 from app.contracts import Contract
 from app.errors import ServiceUnavailable
@@ -54,7 +52,7 @@ from batch.lib.token_list import TokenList
 from batch.lib.misc import wait_all_futures
 import log
 
-JST = timezone(timedelta(hours=+9), "JST")
+local_tz = ZoneInfo(TZ)
 LOG = log.get_logger(process_name="PROCESSOR-NOTIFICATIONS-MEMBERSHIP-EXCHANGE")
 
 WORKER_COUNT = int(WORKER_COUNT)
@@ -100,7 +98,7 @@ class Watcher:
 
     @staticmethod
     def _gen_block_timestamp(entry):
-        return datetime.fromtimestamp(web3.eth.get_block(entry["blockNumber"])["timestamp"], JST)
+        return datetime.fromtimestamp(web3.eth.get_block(entry["blockNumber"])["timestamp"], local_tz)
 
     def watch(self, db_session: Session, entries):
         pass

--- a/batch/processor_Notifications_Token.py
+++ b/batch/processor_Notifications_Token.py
@@ -20,11 +20,8 @@ import os
 import sys
 from concurrent.futures import ThreadPoolExecutor
 import time
-from datetime import (
-    datetime,
-    timezone,
-    timedelta
-)
+from datetime import datetime
+from zoneinfo import ZoneInfo
 
 from sqlalchemy import create_engine, and_
 from sqlalchemy.exc import SQLAlchemyError
@@ -39,7 +36,8 @@ from app.config import (
     DATABASE_URL,
     WORKER_COUNT,
     NOTIFICATION_PROCESS_INTERVAL,
-    TOKEN_LIST_CONTRACT_ADDRESS
+    TOKEN_LIST_CONTRACT_ADDRESS,
+    TZ
 )
 from app.contracts import Contract
 from app.errors import ServiceUnavailable
@@ -56,7 +54,7 @@ from batch.lib.token_list import TokenList
 from batch.lib.misc import wait_all_futures
 import log
 
-JST = timezone(timedelta(hours=+9), "JST")
+local_tz = ZoneInfo(TZ)
 LOG = log.get_logger(process_name="PROCESSOR-NOTIFICATIONS-TOKEN")
 
 WORKER_COUNT = int(WORKER_COUNT)
@@ -94,7 +92,7 @@ class Watcher:
 
     @staticmethod
     def _gen_block_timestamp(entry):
-        return datetime.fromtimestamp(web3.eth.get_block(entry["blockNumber"])["timestamp"], JST)
+        return datetime.fromtimestamp(web3.eth.get_block(entry["blockNumber"])["timestamp"], local_tz)
 
     @staticmethod
     def _get_token_all_list(db_session: Session):

--- a/tests/app/notification_NotificationsId_POST_test.py
+++ b/tests/app/notification_NotificationsId_POST_test.py
@@ -16,13 +16,11 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 """
-from datetime import datetime, timedelta, timezone
+from datetime import datetime
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
 from app.model.db import Notification, NotificationType
-
-JST = timezone(timedelta(hours=+9), "JST")
 
 
 class TestNotificationsIdPOST:

--- a/tests/app/notification_NotificationsRead_test.py
+++ b/tests/app/notification_NotificationsRead_test.py
@@ -16,13 +16,15 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 """
-from datetime import datetime, timedelta, timezone
+from datetime import datetime
+from zoneinfo import ZoneInfo
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
+from app.config import TZ
 
 from app.model.db import Notification
 
-JST = timezone(timedelta(hours=+9), "JST")
+local_tz = ZoneInfo(TZ)
 
 
 class TestNotificationsRead:
@@ -47,7 +49,7 @@ class TestNotificationsRead:
         n.is_flagged = False
         n.is_deleted = False
         n.deleted_at = None
-        n.block_timestamp = datetime(2017, 6, 10, 10, 0, 0).replace(tzinfo=JST)  # JST時間として保存する
+        n.block_timestamp = datetime(2017, 6, 10, 10, 0, 0).replace(tzinfo=local_tz)  # ローカルタイムゾーンとして保存する
         n.args = {
             "hoge": "fuga",
         }
@@ -65,7 +67,7 @@ class TestNotificationsRead:
         n.is_flagged = False
         n.is_deleted = True
         n.deleted_at = None
-        n.block_timestamp = datetime(2017, 5, 10, 10, 0, 0).replace(tzinfo=JST)
+        n.block_timestamp = datetime(2017, 5, 10, 10, 0, 0).replace(tzinfo=local_tz)
         n.args = {
             "hoge": "fuga",
         }
@@ -81,7 +83,7 @@ class TestNotificationsRead:
         n.is_flagged = True
         n.is_deleted = False
         n.deleted_at = None
-        n.block_timestamp = datetime(2017, 4, 10, 10, 0, 0).replace(tzinfo=JST)
+        n.block_timestamp = datetime(2017, 4, 10, 10, 0, 0).replace(tzinfo=local_tz)
         n.args = {
             "hoge": "fuga",
         }
@@ -97,7 +99,7 @@ class TestNotificationsRead:
         n.is_flagged = False
         n.is_deleted = False
         n.deleted_at = None
-        n.block_timestamp = datetime(2017, 3, 10, 10, 0, 0).replace(tzinfo=JST)
+        n.block_timestamp = datetime(2017, 3, 10, 10, 0, 0).replace(tzinfo=local_tz)
         n.args = {
             "hoge": "fuga",
         }
@@ -113,7 +115,7 @@ class TestNotificationsRead:
         n.is_flagged = False
         n.is_deleted = False
         n.deleted_at = None
-        n.block_timestamp = datetime(2017, 2, 10, 10, 0, 0).replace(tzinfo=JST)
+        n.block_timestamp = datetime(2017, 2, 10, 10, 0, 0).replace(tzinfo=local_tz)
         n.args = {
             "hoge": "fuga",
         }

--- a/tests/app/token_TransferApprovalHistory_test.py
+++ b/tests/app/token_TransferApprovalHistory_test.py
@@ -22,8 +22,10 @@ from datetime import (
     timezone,
     timedelta
 )
+from zoneinfo import ZoneInfo
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
+from app.config import TZ
 
 from app.model.db import (
     Listing,
@@ -31,7 +33,7 @@ from app.model.db import (
 )
 
 UTC = timezone(timedelta(hours=0), "UTC")
-JST = timezone(timedelta(hours=+9), "JST")
+local_tz = ZoneInfo(TZ)
 
 
 class TestTokenTransferApprovalHistory:
@@ -120,7 +122,7 @@ class TestTokenTransferApprovalHistory:
 
         before_datetime = datetime.utcnow().\
             replace(tzinfo=UTC).\
-            astimezone(JST).\
+            astimezone(local_tz).\
             strftime("%Y/%m/%d %H:%M:%S.%f")
         time.sleep(1)
 
@@ -146,7 +148,7 @@ class TestTokenTransferApprovalHistory:
         time.sleep(1)
         after_datetime = datetime.utcnow().\
             replace(tzinfo=UTC).\
-            astimezone(JST).\
+            astimezone(local_tz).\
             strftime("%Y/%m/%d %H:%M:%S.%f")
 
         # request target API
@@ -191,7 +193,7 @@ class TestTokenTransferApprovalHistory:
 
         before_datetime = datetime.utcnow().\
             replace(tzinfo=UTC).\
-            astimezone(JST).\
+            astimezone(local_tz).\
             strftime("%Y/%m/%d %H:%M:%S.%f")
         time.sleep(1)
 
@@ -218,7 +220,7 @@ class TestTokenTransferApprovalHistory:
         time.sleep(1)
         after_datetime = datetime.utcnow().\
             replace(tzinfo=UTC).\
-            astimezone(JST).\
+            astimezone(local_tz).\
             strftime("%Y/%m/%d %H:%M:%S.%f")
 
         # request target API
@@ -263,7 +265,7 @@ class TestTokenTransferApprovalHistory:
 
         before_datetime = datetime.utcnow(). \
             replace(tzinfo=UTC). \
-            astimezone(JST). \
+            astimezone(local_tz). \
             strftime("%Y/%m/%d %H:%M:%S.%f")
         time.sleep(1)
 
@@ -289,7 +291,7 @@ class TestTokenTransferApprovalHistory:
         time.sleep(1)
         after_datetime = datetime.utcnow(). \
             replace(tzinfo=UTC). \
-            astimezone(JST). \
+            astimezone(local_tz). \
             strftime("%Y/%m/%d %H:%M:%S.%f")
 
         # request target API
@@ -333,7 +335,7 @@ class TestTokenTransferApprovalHistory:
 
         before_datetime = datetime.utcnow(). \
             replace(tzinfo=UTC). \
-            astimezone(JST). \
+            astimezone(local_tz). \
             strftime("%Y/%m/%d %H:%M:%S.%f")
         time.sleep(1)
 
@@ -359,7 +361,7 @@ class TestTokenTransferApprovalHistory:
         time.sleep(1)
         after_datetime = datetime.utcnow(). \
             replace(tzinfo=UTC). \
-            astimezone(JST). \
+            astimezone(local_tz). \
             strftime("%Y/%m/%d %H:%M:%S.%f")
 
         # request target API
@@ -402,7 +404,7 @@ class TestTokenTransferApprovalHistory:
 
         before_datetime = datetime.utcnow(). \
             replace(tzinfo=UTC). \
-            astimezone(JST). \
+            astimezone(local_tz). \
             strftime("%Y/%m/%d %H:%M:%S.%f")
         time.sleep(1)
 
@@ -428,7 +430,7 @@ class TestTokenTransferApprovalHistory:
         time.sleep(1)
         after_datetime = datetime.utcnow(). \
             replace(tzinfo=UTC). \
-            astimezone(JST). \
+            astimezone(local_tz). \
             strftime("%Y/%m/%d %H:%M:%S.%f")
 
         # request target API


### PR DESCRIPTION
Close: # 

### Changes
- Replaced all `JST` definition to `local timezone`.
  - Local timezone can be set via config.
  - [ZoneInfo](https://www.python.jp/pages/python3.9.html#zoneinfo%E3%83%A2%E3%82%B8%E3%83%A5%E3%83%BC%E3%83%AB) is used.