### PR TITLE
feat: cleanup unused setuptools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,8 +53,7 @@ RUN . ~/.bash_profile \
 
 # install poetry
 RUN . ~/.bash_profile \
- && curl -sSL https://install.python-poetry.org | POETRY_VERSION=1.4.0 python - \
- && echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~apl/.bash_profile
+ && python -m pip install poetry==1.4.0
 RUN . ~/.bash_profile \
  && poetry config virtualenvs.create false
 


### PR DESCRIPTION
Close: #1349 

---

- Changed poetry installation way from [official installer](https://python-poetry.org/docs/#installing-with-the-official-installer) to [manual](https://python-poetry.org/docs/#installing-manually) so as not to create poetry python environment