### PR TITLE
Fix: migration fails after isort

### DIFF
--- a/app/model/db/__init__.py
+++ b/app/model/db/__init__.py
@@ -16,7 +16,6 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 """
-from .base import Base
 from .company import Company
 from .executable_contract import ExecutableContract
 from .idx_agreement import AgreementStatus, IDXAgreement

--- a/app/model/db/company.py
+++ b/app/model/db/company.py
@@ -18,7 +18,7 @@ SPDX-License-Identifier: Apache-2.0
 """
 from sqlalchemy import Column, String, Text
 
-from app.model.db import Base
+from app.model.db.base import Base
 
 
 class Company(Base):

--- a/app/model/db/executable_contract.py
+++ b/app/model/db/executable_contract.py
@@ -19,7 +19,7 @@ SPDX-License-Identifier: Apache-2.0
 
 from sqlalchemy import BigInteger, Column, String
 
-from app.model.db import Base
+from app.model.db.base import Base
 
 
 class ExecutableContract(Base):

--- a/app/model/db/idx_agreement.py
+++ b/app/model/db/idx_agreement.py
@@ -20,7 +20,7 @@ from enum import Enum
 
 from sqlalchemy import BigInteger, Column, DateTime, Integer, String
 
-from app.model.db import Base
+from app.model.db.base import Base
 from app.utils import alchemy
 
 

--- a/app/model/db/idx_block_data.py
+++ b/app/model/db/idx_block_data.py
@@ -18,7 +18,7 @@ SPDX-License-Identifier: Apache-2.0
 """
 from sqlalchemy import JSON, BigInteger, Column, Integer, String, Text
 
-from app.model.db import Base
+from app.model.db.base import Base
 
 
 class IDXBlockData(Base):

--- a/app/model/db/idx_consume_coupon.py
+++ b/app/model/db/idx_consume_coupon.py
@@ -18,7 +18,7 @@ SPDX-License-Identifier: Apache-2.0
 """
 from sqlalchemy import BigInteger, Column, DateTime, String
 
-from app.model.db import Base
+from app.model.db.base import Base
 
 
 class IDXConsumeCoupon(Base):

--- a/app/model/db/idx_lock_unlock.py
+++ b/app/model/db/idx_lock_unlock.py
@@ -23,7 +23,7 @@ from zoneinfo import ZoneInfo
 from sqlalchemy import JSON, BigInteger, Column, DateTime, String
 
 from app.config import TZ
-from app.model.db import Base
+from app.model.db.base import Base
 
 UTC = timezone(timedelta(hours=0), "UTC")
 local_tz = ZoneInfo(TZ)

--- a/app/model/db/idx_order.py
+++ b/app/model/db/idx_order.py
@@ -18,7 +18,7 @@ SPDX-License-Identifier: Apache-2.0
 """
 from sqlalchemy import BigInteger, Boolean, Column, DateTime, String
 
-from app.model.db import Base
+from app.model.db.base import Base
 from app.utils import alchemy
 
 

--- a/app/model/db/idx_position.py
+++ b/app/model/db/idx_position.py
@@ -18,7 +18,7 @@ SPDX-License-Identifier: Apache-2.0
 """
 from sqlalchemy import BigInteger, Column, String
 
-from app.model.db import Base
+from app.model.db.base import Base
 
 
 class IDXPosition(Base):

--- a/app/model/db/idx_token.py
+++ b/app/model/db/idx_token.py
@@ -20,7 +20,7 @@ from typing import Type, Union
 
 from sqlalchemy import JSON, BigInteger, Boolean, Column, DateTime, Float, String, Text
 
-from app.model.db import Base
+from app.model.db.base import Base
 
 
 class TokenBase(Base):

--- a/app/model/db/idx_token_list.py
+++ b/app/model/db/idx_token_list.py
@@ -18,7 +18,7 @@ SPDX-License-Identifier: Apache-2.0
 """
 from sqlalchemy import BigInteger, Column, String
 
-from app.model.db import Base
+from app.model.db.base import Base
 
 
 class IDXTokenListItem(Base):

--- a/app/model/db/idx_transfer.py
+++ b/app/model/db/idx_transfer.py
@@ -23,7 +23,7 @@ from zoneinfo import ZoneInfo
 from sqlalchemy import JSON, BigInteger, Column, String
 
 from app.config import TZ
-from app.model.db import Base
+from app.model.db.base import Base
 
 UTC = timezone(timedelta(hours=0), "UTC")
 local_tz = ZoneInfo(TZ)

--- a/app/model/db/idx_transfer_approval.py
+++ b/app/model/db/idx_transfer_approval.py
@@ -22,7 +22,7 @@ from zoneinfo import ZoneInfo
 from sqlalchemy import BigInteger, Boolean, Column, DateTime, String
 
 from app.config import TZ
-from app.model.db import Base
+from app.model.db.base import Base
 from app.utils import alchemy
 
 UTC = timezone(timedelta(hours=0), "UTC")

--- a/app/model/db/idx_tx_data.py
+++ b/app/model/db/idx_tx_data.py
@@ -18,7 +18,7 @@ SPDX-License-Identifier: Apache-2.0
 """
 from sqlalchemy import BigInteger, Column, Integer, String, Text
 
-from app.model.db import Base
+from app.model.db.base import Base
 
 
 class IDXTxData(Base):

--- a/app/model/db/listing.py
+++ b/app/model/db/listing.py
@@ -23,7 +23,7 @@ from zoneinfo import ZoneInfo
 from sqlalchemy import BigInteger, Boolean, Column, String
 
 from app.config import TZ
-from app.model.db import Base
+from app.model.db.base import Base
 
 UTC = timezone(timedelta(hours=0), "UTC")
 local_tz = ZoneInfo(TZ)

--- a/app/model/db/mail.py
+++ b/app/model/db/mail.py
@@ -18,7 +18,7 @@ SPDX-License-Identifier: Apache-2.0
 """
 from sqlalchemy import BigInteger, Column, String, Text
 
-from app.model.db import Base
+from app.model.db.base import Base
 
 
 class Mail(Base):

--- a/app/model/db/node.py
+++ b/app/model/db/node.py
@@ -19,7 +19,7 @@ SPDX-License-Identifier: Apache-2.0
 
 from sqlalchemy import BigInteger, Boolean, Column, Integer, String
 
-from app.model.db import Base
+from app.model.db.base import Base
 
 
 class Node(Base):

--- a/app/model/db/notification.py
+++ b/app/model/db/notification.py
@@ -35,7 +35,7 @@ from sqlalchemy import (
 )
 
 from app import config
-from app.model.db import Base
+from app.model.db.base import Base
 
 URI = config.DATABASE_URL
 engine = create_engine(URI, echo=False)

--- a/app/model/db/tokenholders.py
+++ b/app/model/db/tokenholders.py
@@ -20,7 +20,7 @@ from enum import Enum
 
 from sqlalchemy import BigInteger, Column, String
 
-from app.model.db import Base
+from app.model.db.base import Base
 
 
 class TokenHoldersList(Base):

--- a/migrations/versions/001_create_agreement.py
+++ b/migrations/versions/001_create_agreement.py
@@ -19,9 +19,9 @@ SPDX-License-Identifier: Apache-2.0
 
 from datetime import datetime
 
-from migrate import *
 from sqlalchemy import *
 from sqlalchemy.exc import ProgrammingError
+from migrate import *
 
 from migrations.log import LOG
 

--- a/migrations/versions/002_create_consume_coupon.py
+++ b/migrations/versions/002_create_consume_coupon.py
@@ -19,9 +19,9 @@ SPDX-License-Identifier: Apache-2.0
 
 from datetime import datetime
 
-from migrate import *
 from sqlalchemy import *
 from sqlalchemy.exc import ProgrammingError
+from migrate import *
 
 from migrations.log import LOG
 

--- a/migrations/versions/003_create_executable_contract.py
+++ b/migrations/versions/003_create_executable_contract.py
@@ -19,9 +19,9 @@ SPDX-License-Identifier: Apache-2.0
 
 from datetime import datetime
 
-from migrate import *
 from sqlalchemy import *
 from sqlalchemy.exc import ProgrammingError
+from migrate import *
 
 from migrations.log import LOG
 

--- a/migrations/versions/004_create_listing.py
+++ b/migrations/versions/004_create_listing.py
@@ -19,9 +19,9 @@ SPDX-License-Identifier: Apache-2.0
 
 from datetime import datetime
 
-from migrate import *
 from sqlalchemy import *
 from sqlalchemy.exc import ProgrammingError
+from migrate import *
 
 from migrations.log import LOG
 

--- a/migrations/versions/005_create_notification.py
+++ b/migrations/versions/005_create_notification.py
@@ -19,9 +19,9 @@ SPDX-License-Identifier: Apache-2.0
 
 from datetime import datetime
 
-from migrate import *
 from sqlalchemy import *
 from sqlalchemy.exc import ProgrammingError
+from migrate import *
 
 from migrations.log import LOG
 

--- a/migrations/versions/006_create_order.py
+++ b/migrations/versions/006_create_order.py
@@ -19,9 +19,9 @@ SPDX-License-Identifier: Apache-2.0
 
 from datetime import datetime
 
-from migrate import *
 from sqlalchemy import *
 from sqlalchemy.exc import ProgrammingError
+from migrate import *
 
 from migrations.log import LOG
 

--- a/migrations/versions/007_create_position.py
+++ b/migrations/versions/007_create_position.py
@@ -19,9 +19,9 @@ SPDX-License-Identifier: Apache-2.0
 
 from datetime import datetime
 
-from migrate import *
 from sqlalchemy import *
 from sqlalchemy.exc import ProgrammingError
+from migrate import *
 
 from migrations.log import LOG
 

--- a/migrations/versions/008_create_private_listing.py
+++ b/migrations/versions/008_create_private_listing.py
@@ -19,9 +19,9 @@ SPDX-License-Identifier: Apache-2.0
 
 from datetime import datetime
 
-from migrate import *
 from sqlalchemy import *
 from sqlalchemy.exc import ProgrammingError
+from migrate import *
 
 from migrations.log import LOG
 

--- a/migrations/versions/009_alter_listing_and_private_listing.py
+++ b/migrations/versions/009_alter_listing_and_private_listing.py
@@ -17,9 +17,9 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
-from migrate import *
 from sqlalchemy import *
 from sqlalchemy.exc import ProgrammingError
+from migrate import *
 
 from migrations.log import LOG
 

--- a/migrations/versions/010_alter_notification.py
+++ b/migrations/versions/010_alter_notification.py
@@ -20,9 +20,9 @@ SPDX-License-Identifier: Apache-2.0
 import sys
 
 import pymysql
-from migrate import *
 from sqlalchemy import *
 from sqlalchemy.exc import ProgrammingError
+from migrate import *
 
 from app import config
 from migrations.log import LOG

--- a/migrations/versions/011_create_transfer.py
+++ b/migrations/versions/011_create_transfer.py
@@ -19,9 +19,9 @@ SPDX-License-Identifier: Apache-2.0
 
 from datetime import datetime
 
-from migrate import *
 from sqlalchemy import *
 from sqlalchemy.exc import ProgrammingError
+from migrate import *
 
 from migrations.log import LOG
 

--- a/migrations/versions/012_alter_order.py
+++ b/migrations/versions/012_alter_order.py
@@ -17,9 +17,9 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
-from migrate import *
 from sqlalchemy import *
 from sqlalchemy.exc import ProgrammingError
+from migrate import *
 
 from migrations.log import LOG
 

--- a/migrations/versions/013_alter_agreement.py
+++ b/migrations/versions/013_alter_agreement.py
@@ -17,9 +17,9 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
-from migrate import *
 from sqlalchemy import *
 from sqlalchemy.exc import ProgrammingError
+from migrate import *
 
 from migrations.log import LOG
 

--- a/migrations/versions/014_alter_order.py
+++ b/migrations/versions/014_alter_order.py
@@ -17,9 +17,9 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
-from migrate import *
 from sqlalchemy import *
 from sqlalchemy.exc import ProgrammingError
+from migrate import *
 
 from migrations.log import LOG
 

--- a/migrations/versions/015_alter_listing.py
+++ b/migrations/versions/015_alter_listing.py
@@ -17,9 +17,9 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
-from migrate import *
 from sqlalchemy import *
 from sqlalchemy.exc import ProgrammingError
+from migrate import *
 
 from migrations.log import LOG
 

--- a/migrations/versions/016_alter_private_listing.py
+++ b/migrations/versions/016_alter_private_listing.py
@@ -17,9 +17,9 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
-from migrate import *
 from sqlalchemy import *
 from sqlalchemy.exc import ProgrammingError
+from migrate import *
 
 from migrations.log import LOG
 

--- a/migrations/versions/017_drop_private_listing.py
+++ b/migrations/versions/017_drop_private_listing.py
@@ -19,9 +19,9 @@ SPDX-License-Identifier: Apache-2.0
 
 from datetime import datetime
 
-from migrate import *
 from sqlalchemy import *
 from sqlalchemy.exc import ProgrammingError
+from migrate import *
 
 from migrations.log import LOG
 

--- a/migrations/versions/018_alter_listing.py
+++ b/migrations/versions/018_alter_listing.py
@@ -17,9 +17,9 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
-from migrate import *
 from sqlalchemy import *
 from sqlalchemy.exc import ProgrammingError
+from migrate import *
 
 from migrations.log import LOG
 

--- a/migrations/versions/020_alter_position.py
+++ b/migrations/versions/020_alter_position.py
@@ -16,9 +16,9 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 """
-from migrate import *
 from sqlalchemy import *
 from sqlalchemy.exc import ProgrammingError
+from migrate import *
 
 from migrations.log import LOG
 

--- a/migrations/versions/021_create_transfer_approval.py
+++ b/migrations/versions/021_create_transfer_approval.py
@@ -18,9 +18,9 @@ SPDX-License-Identifier: Apache-2.0
 """
 from datetime import datetime
 
-from migrate import *
 from sqlalchemy import *
 from sqlalchemy.exc import ProgrammingError
+from migrate import *
 
 from migrations.log import LOG
 

--- a/migrations/versions/022_alter_node.py
+++ b/migrations/versions/022_alter_node.py
@@ -16,9 +16,9 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 """
-from migrate import *
 from sqlalchemy import *
 from sqlalchemy.exc import ProgrammingError
+from migrate import *
 
 from migrations.log import LOG
 

--- a/migrations/versions/024_alter_transfer_approval.py
+++ b/migrations/versions/024_alter_transfer_approval.py
@@ -16,9 +16,9 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 """
-from migrate import *
 from sqlalchemy import *
 from sqlalchemy.exc import ProgrammingError
+from migrate import *
 
 from migrations.log import LOG
 

--- a/migrations/versions/025_alter_position.py
+++ b/migrations/versions/025_alter_position.py
@@ -16,8 +16,8 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 """
-from migrate import *
 from sqlalchemy import *
+from migrate import *
 
 from migrations.log import LOG
 

--- a/migrations/versions/026_alter_transfer_approval.py
+++ b/migrations/versions/026_alter_transfer_approval.py
@@ -16,9 +16,9 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 """
-from migrate import *
 from sqlalchemy import *
 from sqlalchemy.exc import ProgrammingError
+from migrate import *
 
 from migrations.log import LOG
 

--- a/migrations/versions/027_alter_transfer_approval.py
+++ b/migrations/versions/027_alter_transfer_approval.py
@@ -16,9 +16,9 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 """
-from migrate import *
 from sqlalchemy import *
 from sqlalchemy.exc import ProgrammingError
+from migrate import *
 
 from migrations.log import LOG
 

--- a/migrations/versions/028_create_token_holders_list.py
+++ b/migrations/versions/028_create_token_holders_list.py
@@ -19,9 +19,9 @@ SPDX-License-Identifier: Apache-2.0
 import logging
 from datetime import datetime
 
-from migrate import *
 from sqlalchemy import *
 from sqlalchemy.exc import ProgrammingError
+from migrate import *
 
 meta = MetaData()
 

--- a/migrations/versions/029_create_token_holder.py
+++ b/migrations/versions/029_create_token_holder.py
@@ -19,9 +19,9 @@ SPDX-License-Identifier: Apache-2.0
 import logging
 from datetime import datetime
 
-from migrate import *
 from sqlalchemy import *
 from sqlalchemy.exc import ProgrammingError
+from migrate import *
 
 meta = MetaData()
 

--- a/migrations/versions/030_create_idx_position_bond_block_number.py
+++ b/migrations/versions/030_create_idx_position_bond_block_number.py
@@ -19,9 +19,9 @@ SPDX-License-Identifier: Apache-2.0
 import logging
 from datetime import datetime
 
-from migrate import *
 from sqlalchemy import *
 from sqlalchemy.exc import ProgrammingError
+from migrate import *
 
 meta = MetaData()
 

--- a/migrations/versions/031_create_idx_position_share_block_number.py
+++ b/migrations/versions/031_create_idx_position_share_block_number.py
@@ -19,9 +19,9 @@ SPDX-License-Identifier: Apache-2.0
 import logging
 from datetime import datetime
 
-from migrate import *
 from sqlalchemy import *
 from sqlalchemy.exc import ProgrammingError
+from migrate import *
 
 meta = MetaData()
 

--- a/migrations/versions/032_create_idx_position_membership_block_number.py
+++ b/migrations/versions/032_create_idx_position_membership_block_number.py
@@ -19,9 +19,9 @@ SPDX-License-Identifier: Apache-2.0
 import logging
 from datetime import datetime
 
-from migrate import *
 from sqlalchemy import *
 from sqlalchemy.exc import ProgrammingError
+from migrate import *
 
 meta = MetaData()
 

--- a/migrations/versions/033_create_idx_position_coupon_block_number.py
+++ b/migrations/versions/033_create_idx_position_coupon_block_number.py
@@ -19,9 +19,9 @@ SPDX-License-Identifier: Apache-2.0
 import logging
 from datetime import datetime
 
-from migrate import *
 from sqlalchemy import *
 from sqlalchemy.exc import ProgrammingError
+from migrate import *
 
 meta = MetaData()
 

--- a/migrations/versions/034_create_idx_transfer_approval_block_number.py
+++ b/migrations/versions/034_create_idx_transfer_approval_block_number.py
@@ -19,9 +19,9 @@ SPDX-License-Identifier: Apache-2.0
 import logging
 from datetime import datetime
 
-from migrate import *
 from sqlalchemy import *
 from sqlalchemy.exc import ProgrammingError
+from migrate import *
 
 meta = MetaData()
 

--- a/migrations/versions/035_create_bond_token.py
+++ b/migrations/versions/035_create_bond_token.py
@@ -19,9 +19,9 @@ SPDX-License-Identifier: Apache-2.0
 import logging
 from datetime import datetime
 
-from migrate import *
 from sqlalchemy import *
 from sqlalchemy.exc import ProgrammingError
+from migrate import *
 
 meta = MetaData()
 

--- a/migrations/versions/036_create_share_token.py
+++ b/migrations/versions/036_create_share_token.py
@@ -19,9 +19,9 @@ SPDX-License-Identifier: Apache-2.0
 import logging
 from datetime import datetime
 
-from migrate import *
 from sqlalchemy import *
 from sqlalchemy.exc import ProgrammingError
+from migrate import *
 
 meta = MetaData()
 

--- a/migrations/versions/037_create_membership_token.py
+++ b/migrations/versions/037_create_membership_token.py
@@ -19,9 +19,9 @@ SPDX-License-Identifier: Apache-2.0
 import logging
 from datetime import datetime
 
-from migrate import *
 from sqlalchemy import *
 from sqlalchemy.exc import ProgrammingError
+from migrate import *
 
 meta = MetaData()
 

--- a/migrations/versions/038_create_coupon_token.py
+++ b/migrations/versions/038_create_coupon_token.py
@@ -19,9 +19,9 @@ SPDX-License-Identifier: Apache-2.0
 import logging
 from datetime import datetime
 
-from migrate import *
 from sqlalchemy import *
 from sqlalchemy.exc import ProgrammingError
+from migrate import *
 
 meta = MetaData()
 

--- a/migrations/versions/039_create_token_list.py
+++ b/migrations/versions/039_create_token_list.py
@@ -19,9 +19,9 @@ SPDX-License-Identifier: Apache-2.0
 import logging
 from datetime import datetime
 
-from migrate import *
 from sqlalchemy import *
 from sqlalchemy.exc import ProgrammingError
+from migrate import *
 
 meta = MetaData()
 

--- a/migrations/versions/040_create_idx_token_list_block_number.py
+++ b/migrations/versions/040_create_idx_token_list_block_number.py
@@ -19,9 +19,9 @@ SPDX-License-Identifier: Apache-2.0
 import logging
 from datetime import datetime
 
-from migrate import *
 from sqlalchemy import *
 from sqlalchemy.exc import ProgrammingError
+from migrate import *
 
 meta = MetaData()
 

--- a/migrations/versions/041_create_idx_transfer_block_number.py
+++ b/migrations/versions/041_create_idx_transfer_block_number.py
@@ -19,9 +19,9 @@ SPDX-License-Identifier: Apache-2.0
 import logging
 from datetime import datetime
 
-from migrate import *
 from sqlalchemy import *
 from sqlalchemy.exc import ProgrammingError
+from migrate import *
 
 meta = MetaData()
 

--- a/migrations/versions/042_create_notification_block_number.py
+++ b/migrations/versions/042_create_notification_block_number.py
@@ -19,9 +19,9 @@ SPDX-License-Identifier: Apache-2.0
 import logging
 from datetime import datetime
 
-from migrate import *
 from sqlalchemy import *
 from sqlalchemy.exc import ProgrammingError
+from migrate import *
 
 meta = MetaData()
 

--- a/migrations/versions/043_create_block_data.py
+++ b/migrations/versions/043_create_block_data.py
@@ -19,9 +19,9 @@ SPDX-License-Identifier: Apache-2.0
 import logging
 from datetime import datetime
 
-from migrate import *
 from sqlalchemy import *
 from sqlalchemy.exc import ProgrammingError
+from migrate import *
 
 meta = MetaData()
 

--- a/migrations/versions/044_create_idx_block_data_block_number.py
+++ b/migrations/versions/044_create_idx_block_data_block_number.py
@@ -19,9 +19,9 @@ SPDX-License-Identifier: Apache-2.0
 import logging
 from datetime import datetime
 
-from migrate import *
 from sqlalchemy import *
 from sqlalchemy.exc import ProgrammingError
+from migrate import *
 
 meta = MetaData()
 

--- a/migrations/versions/045_create_tx_data.py
+++ b/migrations/versions/045_create_tx_data.py
@@ -19,9 +19,9 @@ SPDX-License-Identifier: Apache-2.0
 import logging
 from datetime import datetime
 
-from migrate import *
 from sqlalchemy import *
 from sqlalchemy.exc import ProgrammingError
+from migrate import *
 
 meta = MetaData()
 

--- a/migrations/versions/046_alter_bond_token.py
+++ b/migrations/versions/046_alter_bond_token.py
@@ -17,9 +17,9 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
-from migrate import *
 from sqlalchemy import *
 from sqlalchemy.exc import ProgrammingError
+from migrate import *
 
 from migrations.log import LOG
 

--- a/migrations/versions/047_alter_share_token.py
+++ b/migrations/versions/047_alter_share_token.py
@@ -17,9 +17,9 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
-from migrate import *
 from sqlalchemy import *
 from sqlalchemy.exc import ProgrammingError
+from migrate import *
 
 from migrations.log import LOG
 

--- a/migrations/versions/048_create_locked_position.py
+++ b/migrations/versions/048_create_locked_position.py
@@ -19,9 +19,9 @@ SPDX-License-Identifier: Apache-2.0
 import logging
 from datetime import datetime
 
-from migrate import *
 from sqlalchemy import *
 from sqlalchemy.exc import ProgrammingError
+from migrate import *
 
 meta = MetaData()
 

--- a/migrations/versions/049_create_lock.py
+++ b/migrations/versions/049_create_lock.py
@@ -19,9 +19,9 @@ SPDX-License-Identifier: Apache-2.0
 import logging
 from datetime import datetime
 
-from migrate import *
 from sqlalchemy import *
 from sqlalchemy.exc import ProgrammingError
+from migrate import *
 
 meta = MetaData()
 

--- a/migrations/versions/050_create_unlock.py
+++ b/migrations/versions/050_create_unlock.py
@@ -19,9 +19,9 @@ SPDX-License-Identifier: Apache-2.0
 import logging
 from datetime import datetime
 
-from migrate import *
 from sqlalchemy import *
 from sqlalchemy.exc import ProgrammingError
+from migrate import *
 
 meta = MetaData()
 

--- a/migrations/versions/051_alter_transfer.py
+++ b/migrations/versions/051_alter_transfer.py
@@ -17,9 +17,9 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
-from migrate import *
 from sqlalchemy import *
 from sqlalchemy.exc import ProgrammingError
+from migrate import *
 
 from migrations.log import LOG
 

--- a/migrations/versions/052_create_mail.py
+++ b/migrations/versions/052_create_mail.py
@@ -19,9 +19,9 @@ SPDX-License-Identifier: Apache-2.0
 import logging
 from datetime import datetime
 
-from migrate import *
 from sqlalchemy import *
 from sqlalchemy.exc import ProgrammingError
+from migrate import *
 
 meta = MetaData()
 

--- a/migrations/versions/053_alter_token_holder.py
+++ b/migrations/versions/053_alter_token_holder.py
@@ -17,9 +17,9 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
-from migrate import *
 from sqlalchemy import *
 from sqlalchemy.exc import ProgrammingError
+from migrate import *
 
 from migrations.log import LOG
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,9 @@ ibet-explorer = [
     "aiohttp"
 ]
 
+[tool.isort]
+skip_glob = ["migrations/*"]
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -234,7 +234,7 @@ def db(request):
     app.dependency_overrides[db_session] = override_inject_db_session
 
     # Create DB tables
-    from app.model.db import Base
+    from app.model.db.base import Base
 
     Base.metadata.create_all(engine)
 


### PR DESCRIPTION
Related to: #1351 

We have detected that migration fails after linting by `isort`. 
This is because the priority order of `sqlalchemy.PrimaryKeyConstraint` and `migrate.PrimaryKeyConstraint` changed due to a change in the import order in the migration script.

The change in the Class used caused problems with the behavior of the scripts.