### PR TITLE
Remove PytestRemovedIn8Warning

### DIFF
--- a/tests/app/config_test.py
+++ b/tests/app/config_test.py
@@ -24,7 +24,7 @@ from unittest import mock
 class TestTransactionWaitPollLatency:
     # テスト対象: TRANSACTION_WAIT_POLL_LATENCY
 
-    def teardown(self):
+    def teardown_method(self):
         from app import config
 
         reload(config)

--- a/tests/app/dex_market_CouponOrderBook_test.py
+++ b/tests/app/dex_market_CouponOrderBook_test.py
@@ -33,7 +33,7 @@ class TestDEXMarketCouponOrderBook:
     # テスト対象API
     apiurl = "/DEX/Market/OrderBook/Coupon"
 
-    def setup(self):
+    def setup_method(self):
         # 環境変数設定
         config.AGENT_ADDRESS = eth_account["agent"]["account_address"]
 

--- a/tests/app/dex_market_MembershipOrderBook_test.py
+++ b/tests/app/dex_market_MembershipOrderBook_test.py
@@ -33,7 +33,7 @@ class TestDEXMarketMembershipOrderBook:
     # テスト対象API
     apiurl = "/DEX/Market/OrderBook/Membership"
 
-    def setup(self):
+    def setup_method(self):
         # 環境変数設定
         config.AGENT_ADDRESS = eth_account["agent"]["account_address"]
 

--- a/tests/app/eth_SendRawTransactionNowait_test.py
+++ b/tests/app/eth_SendRawTransactionNowait_test.py
@@ -128,7 +128,7 @@ class TestEthSendRawTransactionNoWait:
         tx["nonce"] = web3.eth.get_transaction_count(
             to_checksum_address(local_account_1.address)
         )
-        signed_tx_1 = web3.eth.account.sign_transaction(tx, local_account_1.privateKey)
+        signed_tx_1 = web3.eth.account.sign_transaction(tx, local_account_1.key)
 
         request_params = {"raw_tx_hex_list": [signed_tx_1.rawTransaction.hex()]}
         headers = {"Content-Type": "application/json"}
@@ -220,7 +220,7 @@ class TestEthSendRawTransactionNoWait:
         tx["nonce"] = web3.eth.get_transaction_count(
             to_checksum_address(local_account_1.address)
         )
-        signed_tx_1 = web3.eth.account.sign_transaction(tx, local_account_1.privateKey)
+        signed_tx_1 = web3.eth.account.sign_transaction(tx, local_account_1.key)
 
         token_contract_2 = web3.eth.contract(
             address=to_checksum_address(coupontoken_2["address"]),
@@ -252,7 +252,7 @@ class TestEthSendRawTransactionNoWait:
         tx["nonce"] = web3.eth.get_transaction_count(
             to_checksum_address(local_account_2.address)
         )
-        signed_tx_2 = web3.eth.account.sign_transaction(tx, local_account_2.privateKey)
+        signed_tx_2 = web3.eth.account.sign_transaction(tx, local_account_2.key)
 
         request_params = {
             "raw_tx_hex_list": [
@@ -481,7 +481,7 @@ class TestEthSendRawTransactionNoWait:
         tx["nonce"] = web3.eth.get_transaction_count(
             to_checksum_address(local_account_1.address)
         )
-        signed_tx_1 = web3.eth.account.sign_transaction(tx, local_account_1.privateKey)
+        signed_tx_1 = web3.eth.account.sign_transaction(tx, local_account_1.key)
 
         request_params = {"raw_tx_hex_list": [signed_tx_1.rawTransaction.hex()]}
         headers = {"Content-Type": "application/json"}
@@ -539,7 +539,7 @@ class TestEthSendRawTransactionNoWait:
         tx["nonce"] = web3.eth.get_transaction_count(
             to_checksum_address(local_account_1.address)
         )
-        signed_tx_1 = web3.eth.account.sign_transaction(tx, local_account_1.privateKey)
+        signed_tx_1 = web3.eth.account.sign_transaction(tx, local_account_1.key)
 
         request_params = {"raw_tx_hex_list": [signed_tx_1.rawTransaction.hex()]}
         headers = {"Content-Type": "application/json"}
@@ -596,7 +596,7 @@ class TestEthSendRawTransactionNoWait:
         tx["nonce"] = web3.eth.get_transaction_count(
             to_checksum_address(local_account_1.address)
         )
-        signed_tx_1 = web3.eth.account.sign_transaction(tx, local_account_1.privateKey)
+        signed_tx_1 = web3.eth.account.sign_transaction(tx, local_account_1.key)
 
         request_params = {"raw_tx_hex_list": [signed_tx_1.rawTransaction.hex()]}
         headers = {"Content-Type": "application/json"}

--- a/tests/batch/processor_Notifications_Token_test.py
+++ b/tests/batch/processor_Notifications_Token_test.py
@@ -38,7 +38,7 @@ from app.model.db import (
     NotificationType,
 )
 from tests.account_config import eth_account
-from tests.conftest import DeployedContract, SharedContract, TestAccount
+from tests.conftest import DeployedContract, SharedContract, UnitTestAccount
 from tests.contract_modules import (
     coupon_register_list,
     coupon_transfer_to_exchange,
@@ -83,7 +83,7 @@ def watcher_factory(
 
 
 def prepare_coupon_token(
-    issuer: TestAccount,
+    issuer: UnitTestAccount,
     exchange: DeployedContract,
     token_list: DeployedContract,
     session: Session,
@@ -118,7 +118,7 @@ def prepare_coupon_token(
 
 
 def prepare_share_token(
-    issuer: TestAccount,
+    issuer: UnitTestAccount,
     exchange: DeployedContract,
     token_list: DeployedContract,
     personal_info: DeployedContract,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,7 +64,7 @@ class SharedContract(TypedDict):
     IbetSecurityTokenEscrow: Web3Contract
 
 
-class TestAccount(TypedDict):
+class UnitTestAccount(TypedDict):
     account_address: ChecksumAddress
     password: str
 

--- a/tests/contract_modules.py
+++ b/tests/contract_modules.py
@@ -26,7 +26,7 @@ from web3.middleware import geth_poa_middleware
 from app import config
 from app.contracts import Contract
 from tests.account_config import eth_account
-from tests.conftest import DeployedContract, TestAccount
+from tests.conftest import DeployedContract, UnitTestAccount
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
 web3.middleware_onion.inject(geth_poa_middleware, layer=0)
@@ -188,7 +188,7 @@ def bond_transfer_to_exchange(invoker, bond_exchange, bond_token, amount):
 
 # 債券トークンの移転
 def transfer_bond_token(
-    invoker: TestAccount, to: TestAccount, token: DeployedContract, amount: int
+    invoker: UnitTestAccount, to: UnitTestAccount, token: DeployedContract, amount: int
 ):
     web3.eth.default_account = invoker["account_address"]
     TokenContract = Contract.get_contract("IbetStraightBond", token["address"])
@@ -438,7 +438,7 @@ def share_transfer_to_exchange(invoker, exchange, token, amount):
 
 # 株式トークンの移転
 def transfer_share_token(
-    invoker: TestAccount, to: TestAccount, token: DeployedContract, amount: int
+    invoker: UnitTestAccount, to: UnitTestAccount, token: DeployedContract, amount: int
 ):
     web3.eth.default_account = invoker["account_address"]
     TokenContract = Contract.get_contract("IbetShare", token["address"])


### PR DESCRIPTION
close #1368 

- Fixed unit test code to remove `PytestRemovedIn8Warning`.
- Relatedly, I've also removed other warnings that occur when running unit tests.