### PR TITLE
feat: add Position API that does not include the token type in the API path

### DIFF
--- a/app/api/routers/position.py
+++ b/app/api/routers/position.py
@@ -1536,7 +1536,7 @@ def retrieve_membership_position_by_token_address(
         DataNotExistsError, NotSupportedError, InvalidParameterError
     ),
 )
-def list_all_coupon_position_by_token_address(
+def retrieve_coupon_position_by_token_address(
     position: CouponPositionWithDetail = Depends(GetPosition(BasePositionCoupon)),
 ):
     """

--- a/app/model/db/idx_position.py
+++ b/app/model/db/idx_position.py
@@ -16,6 +16,8 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 """
+from typing import Optional
+
 from sqlalchemy import BigInteger, Column, String
 
 from app.model.db.base import Base
@@ -48,6 +50,60 @@ class IDXPosition(Base):
         "pending_transfer": int,
     }
     FIELDS.update(Base.FIELDS)
+
+    @staticmethod
+    def bond(position: Optional["IDXPosition"]):
+        return {
+            "balance": position.balance if position and position.balance else 0,
+            "pending_transfer": position.pending_transfer
+            if position and position.pending_transfer
+            else 0,
+            "exchange_balance": position.exchange_balance
+            if position and position.exchange_balance
+            else 0,
+            "exchange_commitment": position.exchange_commitment
+            if position and position.exchange_commitment
+            else 0,
+        }
+
+    @staticmethod
+    def share(share: Optional["IDXPosition"]):
+        return {
+            "balance": share.balance if share and share.balance else 0,
+            "pending_transfer": share.pending_transfer
+            if share and share.pending_transfer
+            else 0,
+            "exchange_balance": share.exchange_balance
+            if share and share.exchange_balance
+            else 0,
+            "exchange_commitment": share.exchange_commitment
+            if share and share.exchange_commitment
+            else 0,
+        }
+
+    @staticmethod
+    def coupon(coupon: Optional["IDXPosition"]):
+        return {
+            "balance": coupon.balance if coupon and coupon.balance else 0,
+            "exchange_balance": coupon.exchange_balance
+            if coupon and coupon.exchange_balance
+            else 0,
+            "exchange_commitment": coupon.exchange_commitment
+            if coupon and coupon.exchange_commitment
+            else 0,
+        }
+
+    @staticmethod
+    def membership(membership: Optional["IDXPosition"]):
+        return {
+            "balance": membership.balance if membership and membership.balance else 0,
+            "exchange_balance": membership.exchange_balance
+            if membership and membership.exchange_balance
+            else 0,
+            "exchange_commitment": membership.exchange_commitment
+            if membership and membership.exchange_commitment
+            else 0,
+        }
 
 
 class IDXPositionBondBlockNumber(Base):

--- a/app/model/schema/__init__.py
+++ b/app/model/schema/__init__.py
@@ -99,6 +99,7 @@ from .position import (
     ListAllLockEventQuery,
     ListAllLockEventsResponse,
     ListAllPositionQuery,
+    ListAllTokenPositionQuery,
     LockEventCategory,
     LockEventSortItem,
     MembershipPositionsResponse,
@@ -107,6 +108,7 @@ from .position import (
     SecurityTokenPosition,
     SecurityTokenPositionWithAddress,
     SecurityTokenPositionWithDetail,
+    TokenPositionsResponse,
 )
 from .token import (
     CreateTokenHoldersCollectionRequest,

--- a/app/model/schema/position.py
+++ b/app/model/schema/position.py
@@ -50,7 +50,11 @@ class SecurityTokenPosition(BaseModel):
     )
 
 
-T = TypeVar("T", RetrieveStraightBondTokenResponse, RetrieveShareTokenResponse)
+SecurityTokenResponseT = TypeVar(
+    "SecurityTokenResponseT",
+    RetrieveStraightBondTokenResponse,
+    RetrieveShareTokenResponse,
+)
 
 
 class StraightBondPositionWithDetail(SecurityTokenPosition):
@@ -73,8 +77,10 @@ class SharePositionWithAddress(SecurityTokenPosition):
     token_address: str = Field(description="set when include_token_details=false")
 
 
-class SecurityTokenPositionWithDetail(SecurityTokenPosition, Generic[T]):
-    token: T | TokenAddress = Field(
+class SecurityTokenPositionWithDetail(
+    SecurityTokenPosition, Generic[SecurityTokenResponseT]
+):
+    token: SecurityTokenResponseT | TokenAddress = Field(
         description="set when include_token_details=false or null"
     )
 
@@ -130,11 +136,11 @@ class Locked(BaseModel):
     value: int
 
 
-class LockedWithTokenDetail(Locked, Generic[T]):
-    token: T = Field(..., description="Token information")
+class LockedWithTokenDetail(Locked, Generic[SecurityTokenResponseT]):
+    token: SecurityTokenResponseT = Field(..., description="Token information")
 
 
-class LockEvent(BaseModel, Generic[T]):
+class LockEvent(BaseModel):
     category: LockEventCategory = Field(description="history item category")
     transaction_hash: str = Field(description="Transaction hash")
     token_address: str = Field(description="Token address")
@@ -150,8 +156,8 @@ class LockEvent(BaseModel, Generic[T]):
     )
 
 
-class LockEventWithTokenDetail(LockEvent, Generic[T]):
-    token: T = Field(..., description="Token information")
+class LockEventWithTokenDetail(LockEvent, Generic[SecurityTokenResponseT]):
+    token: SecurityTokenResponseT = Field(..., description="Token information")
 
 
 ############################
@@ -268,10 +274,11 @@ class TokenPositionsResponse(BaseModel):
     ]
 
 
-class GenericSecurityTokenPositionsResponse(BaseModel, Generic[T]):
+class GenericSecurityTokenPositionsResponse(BaseModel, Generic[SecurityTokenResponseT]):
     result_set: ResultSet
     positions: Union[
-        list[SecurityTokenPositionWithDetail[T]], list[SecurityTokenPositionWithAddress]
+        list[SecurityTokenPositionWithDetail[SecurityTokenResponseT]],
+        list[SecurityTokenPositionWithAddress],
     ]
 
 
@@ -287,13 +294,15 @@ class CouponPositionsResponse(BaseModel):
     positions: Union[list[CouponPositionWithDetail], list[CouponPositionWithAddress]]
 
 
-class ListAllLockedPositionResponse(BaseModel, Generic[T]):
+class ListAllLockedPositionResponse(BaseModel, Generic[SecurityTokenResponseT]):
     result_set: ResultSet
-    locked_positions: Union[list[LockedWithTokenDetail[T]] | list[Locked]]
+    locked_positions: Union[
+        list[LockedWithTokenDetail[SecurityTokenResponseT]] | list[Locked]
+    ]
 
 
-class ListAllLockEventsResponse(BaseModel, Generic[T]):
+class ListAllLockEventsResponse(BaseModel, Generic[SecurityTokenResponseT]):
     result_set: ResultSet
-    events: Union[list[LockEventWithTokenDetail[T]], list[LockEvent]] = Field(
-        description="Lock/Unlock event list"
-    )
+    events: Union[
+        list[LockEventWithTokenDetail[SecurityTokenResponseT]], list[LockEvent]
+    ] = Field(description="Lock/Unlock event list")

--- a/docs/ibet_wallet_api.yaml
+++ b/docs/ibet_wallet_api.yaml
@@ -3677,6 +3677,62 @@ paths:
                 anyOf:
                   - $ref: '#/components/schemas/DataNotExistsErrorResponse'
                   - $ref: '#/components/schemas/NotSupportedErrorResponse'
+  /Position/{account_address}:
+    get:
+      tags:
+        - user_position
+      summary: Token Position
+      operationId: GetTokenPosition
+      parameters:
+        - required: true
+          schema:
+            title: Account Address
+            type: string
+          name: account_address
+          in: path
+        - description: start position
+          required: false
+          schema:
+            title: Offset
+            minimum: 0
+            type: integer
+            description: start position
+          name: offset
+          in: query
+        - description: number of set
+          required: false
+          schema:
+            title: Limit
+            minimum: 0
+            type: integer
+            description: number of set
+          name: limit
+          in: query
+        - description: type of token
+          required: false
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/TokenType'
+            description: type of token
+          name: token_type_list
+          in: query
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericSuccessResponse_TokenPositionsResponse_'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                title: Response 400 Gettokenposition
+                anyOf:
+                  - $ref: '#/components/schemas/InvalidParameterErrorResponse'
+                  - $ref: '#/components/schemas/RequestValidationErrorResponse'
   /Notifications:
     get:
       tags:
@@ -5987,6 +6043,22 @@ components:
             message: OK
         data:
           $ref: '#/components/schemas/TokenHoldersResponse'
+    GenericSuccessResponse_TokenPositionsResponse_:
+      title: GenericSuccessResponse[TokenPositionsResponse]
+      required:
+        - meta
+        - data
+      type: object
+      properties:
+        meta:
+          title: Meta
+          allOf:
+            - $ref: '#/components/schemas/Success200MetaModel'
+          example:
+            code: 200
+            message: OK
+        data:
+          $ref: '#/components/schemas/TokenPositionsResponse'
     GenericSuccessResponse_TokenStatusResponse_:
       title: GenericSuccessResponse[TokenStatusResponse]
       required:
@@ -6819,6 +6891,9 @@ components:
           format: date-time
         token:
           title: Token
+          anyOf:
+            - $ref: '#/components/schemas/RetrieveStraightBondTokenResponse'
+            - $ref: '#/components/schemas/RetrieveShareTokenResponse'
           description: Token information
     LockedWithTokenDetail:
       title: LockedWithTokenDetail
@@ -6844,6 +6919,9 @@ components:
           type: integer
         token:
           title: Token
+          anyOf:
+            - $ref: '#/components/schemas/RetrieveStraightBondTokenResponse'
+            - $ref: '#/components/schemas/RetrieveShareTokenResponse'
           description: Token information
     MembershipImage:
       title: MembershipImage
@@ -6879,7 +6957,7 @@ components:
         token_address:
           title: Token Address
           type: string
-          description: set when include_token_details=true
+          description: set when include_token_details=false
     MembershipPositionWithDetail:
       title: MembershipPositionWithDetail
       required:
@@ -6902,7 +6980,7 @@ components:
           title: Token
           allOf:
             - $ref: '#/components/schemas/RetrieveMembershipTokenResponse'
-          description: set when include_token_details=false or null
+          description: set when include_token_details=true
     MembershipPositionsResponse:
       title: MembershipPositionsResponse
       required:
@@ -8025,7 +8103,7 @@ components:
         token_address:
           title: Token Address
           type: string
-          description: set when include_token_details=true
+          description: set when include_token_details=false or null
     SecurityTokenPositionWithDetail:
       title: SecurityTokenPositionWithDetail
       required:
@@ -8055,7 +8133,9 @@ components:
         token:
           title: Token
           anyOf:
-            - {}
+            - anyOf:
+                - $ref: '#/components/schemas/RetrieveStraightBondTokenResponse'
+                - $ref: '#/components/schemas/RetrieveShareTokenResponse'
             - $ref: '#/components/schemas/app__model__schema__position__TokenAddress'
           description: set when include_token_details=false or null
     SendChatWebhookRequest:
@@ -8201,6 +8281,37 @@ components:
         details:
           title: Details
           type: object
+    SharePositionWithDetail:
+      title: SharePositionWithDetail
+      required:
+        - balance
+        - pending_transfer
+        - exchange_balance
+        - exchange_commitment
+        - token
+      type: object
+      properties:
+        balance:
+          title: Balance
+          type: integer
+        pending_transfer:
+          title: Pending Transfer
+          type: integer
+        exchange_balance:
+          title: Exchange Balance
+          type: integer
+        exchange_commitment:
+          title: Exchange Commitment
+          type: integer
+        locked:
+          title: Locked
+          type: integer
+          description: set when enable_index=true
+        token:
+          title: Token
+          allOf:
+            - $ref: '#/components/schemas/RetrieveShareTokenResponse'
+          description: set when include_token_details=true
     ShareTokensSortItem:
       title: ShareTokensSortItem
       enum:
@@ -8226,6 +8337,37 @@ components:
         - 1
       type: integer
       description: An enumeration.
+    StraightBondPositionWithDetail:
+      title: StraightBondPositionWithDetail
+      required:
+        - balance
+        - pending_transfer
+        - exchange_balance
+        - exchange_commitment
+        - token
+      type: object
+      properties:
+        balance:
+          title: Balance
+          type: integer
+        pending_transfer:
+          title: Pending Transfer
+          type: integer
+        exchange_balance:
+          title: Exchange Balance
+          type: integer
+        exchange_commitment:
+          title: Exchange Commitment
+          type: integer
+        locked:
+          title: Locked
+          type: integer
+          description: set when enable_index=true
+        token:
+          title: Token
+          allOf:
+            - $ref: '#/components/schemas/RetrieveStraightBondTokenResponse'
+          description: set when include_token_details=true
     StraightBondTokensSortItem:
       title: StraightBondTokensSortItem
       enum:
@@ -8441,6 +8583,24 @@ components:
       type: array
       items:
         $ref: '#/components/schemas/TokenHolder'
+    TokenPositionsResponse:
+      title: TokenPositionsResponse
+      required:
+        - result_set
+        - positions
+      type: object
+      properties:
+        result_set:
+          $ref: '#/components/schemas/ResultSet'
+        positions:
+          title: Positions
+          type: array
+          items:
+            anyOf:
+              - $ref: '#/components/schemas/StraightBondPositionWithDetail'
+              - $ref: '#/components/schemas/SharePositionWithDetail'
+              - $ref: '#/components/schemas/CouponPositionWithDetail'
+              - $ref: '#/components/schemas/MembershipPositionWithDetail'
     TokenStatusResponse:
       title: TokenStatusResponse
       required:

--- a/tests/app/position_PositionCoupon_test.py
+++ b/tests/app/position_PositionCoupon_test.py
@@ -29,6 +29,7 @@ from app.model.db import (
     IDXConsumeCoupon,
     IDXCouponToken,
     IDXPosition,
+    IDXTokenListItem,
     IDXTransfer,
     IDXTransferSourceEventType,
     Listing,
@@ -45,7 +46,7 @@ web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
 web3.middleware_onion.inject(geth_poa_middleware, layer=0)
 
 
-class TestPositionAccountAddressCoupon:
+class TestPositionCoupon:
     # Test API
     apiurl = "/Position/{account_address}/Coupon"
 
@@ -71,12 +72,10 @@ class TestPositionAccountAddressCoupon:
             "contactInformation": "問い合わせ先",
             "privacyPolicy": "プライバシーポリシー",
         }
-        token = issue_coupon_token(TestPositionAccountAddressCoupon.issuer, args)
-        coupon_register_list(
-            TestPositionAccountAddressCoupon.issuer, token, token_list_contract
-        )
+        token = issue_coupon_token(TestPositionCoupon.issuer, args)
+        coupon_register_list(TestPositionCoupon.issuer, token, token_list_contract)
         transfer_coupon_token(
-            TestPositionAccountAddressCoupon.issuer,
+            TestPositionCoupon.issuer,
             token,
             account["account_address"],
             1000000,
@@ -91,7 +90,7 @@ class TestPositionAccountAddressCoupon:
         account, exchange_contract, token_list_contract, commitment
     ):
         # Issue token
-        token = TestPositionAccountAddressCoupon.create_balance_data(
+        token = TestPositionCoupon.create_balance_data(
             account, exchange_contract, token_list_contract
         )
 
@@ -113,7 +112,7 @@ class TestPositionAccountAddressCoupon:
     @staticmethod
     def create_used_data(account, exchange_contract, token_list_contract, used):
         # Issue token
-        token = TestPositionAccountAddressCoupon.create_balance_data(
+        token = TestPositionCoupon.create_balance_data(
             account, exchange_contract, token_list_contract
         )
 
@@ -129,7 +128,7 @@ class TestPositionAccountAddressCoupon:
         account, to_account, exchange_contract, token_list_contract
     ):
         # Issue token
-        token = TestPositionAccountAddressCoupon.create_balance_data(
+        token = TestPositionCoupon.create_balance_data(
             account, exchange_contract, token_list_contract
         )
 
@@ -181,9 +180,7 @@ class TestPositionAccountAddressCoupon:
         idx_token = IDXCouponToken()
         idx_token.company_name = ""
         idx_token.token_address = token_address
-        idx_token.owner_address = TestPositionAccountAddressCoupon.issuer[
-            "account_address"
-        ]
+        idx_token.owner_address = TestPositionCoupon.issuer["account_address"]
         idx_token.token_template = "IbetCoupon"
         idx_token.name = "テストクーポン"
         idx_token.symbol = "COUPON"
@@ -207,6 +204,11 @@ class TestPositionAccountAddressCoupon:
         idx_token.contact_information = "問い合わせ先"
         idx_token.privacy_policy = "プライバシーポリシー"
         session.add(idx_token)
+        idx_token_list_item = IDXTokenListItem()
+        idx_token_list_item.token_address = token_address
+        idx_token_list_item.token_template = "IbetCoupon"
+        idx_token_list_item.owner_address = TestPositionCoupon.issuer["account_address"]
+        session.add(idx_token_list_item)
         session.commit()
 
     @staticmethod

--- a/tests/app/position_PositionMembership_test.py
+++ b/tests/app/position_PositionMembership_test.py
@@ -25,7 +25,7 @@ from web3.middleware import geth_poa_middleware
 
 from app import config
 from app.contracts import Contract
-from app.model.db import IDXMembershipToken, IDXPosition, Listing
+from app.model.db import IDXMembershipToken, IDXPosition, IDXTokenListItem, Listing
 from tests.account_config import eth_account
 from tests.contract_modules import (
     membership_issue,
@@ -174,6 +174,13 @@ class TestPositionMembership:
         idx_token.contact_information = "問い合わせ先"
         idx_token.privacy_policy = "プライバシーポリシー"
         session.add(idx_token)
+        idx_token_list_item = IDXTokenListItem()
+        idx_token_list_item.token_address = token_address
+        idx_token_list_item.token_template = "IbetMembership"
+        idx_token_list_item.owner_address = TestPositionMembership.issuer[
+            "account_address"
+        ]
+        session.add(idx_token_list_item)
         session.commit()
 
     @staticmethod

--- a/tests/app/position_PositionShare_test.py
+++ b/tests/app/position_PositionShare_test.py
@@ -22,7 +22,13 @@ from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
 from app import config
-from app.model.db import IDXLockedPosition, IDXPosition, IDXShareToken, Listing
+from app.model.db import (
+    IDXLockedPosition,
+    IDXPosition,
+    IDXShareToken,
+    IDXTokenListItem,
+    Listing,
+)
 from tests.account_config import eth_account
 from tests.contract_modules import share_lock, transfer_share_token
 from tests.utils import IbetShareUtils, PersonalInfoUtils
@@ -246,6 +252,11 @@ class TestPositionShare:
         idx_token.max_holding_quantity = 1
         idx_token.max_sell_amount = 1000
         session.add(idx_token)
+        idx_token_list_item = IDXTokenListItem()
+        idx_token_list_item.token_address = token_address
+        idx_token_list_item.token_template = "IbetShare"
+        idx_token_list_item.owner_address = TestPositionShare.issuer["account_address"]
+        session.add(idx_token_list_item)
         session.commit()
 
     @staticmethod

--- a/tests/app/position_PositionStraightBond_test.py
+++ b/tests/app/position_PositionStraightBond_test.py
@@ -25,7 +25,13 @@ from web3.middleware import geth_poa_middleware
 
 from app import config
 from app.contracts import Contract
-from app.model.db import IDXBondToken, IDXLockedPosition, IDXPosition, Listing
+from app.model.db import (
+    IDXBondToken,
+    IDXLockedPosition,
+    IDXPosition,
+    IDXTokenListItem,
+    Listing,
+)
 from tests.account_config import eth_account
 from tests.contract_modules import (
     bond_lock,
@@ -244,6 +250,13 @@ class TestPositionStraightBond:
         idx_token.personal_info_address = personal_info_address
         idx_token.transfer_approval_required = False
         session.add(idx_token)
+        idx_token_list_item = IDXTokenListItem()
+        idx_token_list_item.token_address = token_address
+        idx_token_list_item.token_template = "IbetStraightBond"
+        idx_token_list_item.owner_address = TestPositionStraightBond.issuer[
+            "account_address"
+        ]
+        session.add(idx_token_list_item)
         session.commit()
 
     @staticmethod

--- a/tests/app/position_Position_test.py
+++ b/tests/app/position_Position_test.py
@@ -937,6 +937,10 @@ class TestPosition:
         )
 
     def setup_data(self, session: Session, shared_contract, index=0):
+        config.BOND_TOKEN_ENABLED = False
+        config.SHARE_TOKEN_ENABLED = False
+        config.COUPON_TOKEN_ENABLED = False
+        config.MEMBERSHIP_TOKEN_ENABLED = False
         # StraightBond
         self.setup_bond(session=session, shared_contract=shared_contract, index=index)
         # Share
@@ -1764,6 +1768,10 @@ class TestPosition:
                 "app.config.TOKEN_LIST_CONTRACT_ADDRESS", token_list_contract
             ), mock.patch("app.config.BOND_TOKEN_ENABLED", True), mock.patch(
                 "app.config.SHARE_TOKEN_ENABLED", True
+            ), mock.patch(
+                "app.config.COUPON_TOKEN_ENABLED", False
+            ), mock.patch(
+                "app.config.MEMBERSHIP_TOKEN_ENABLED", False
             ):
                 # Request target API
                 resp = client.get(

--- a/tests/app/position_Position_test.py
+++ b/tests/app/position_Position_test.py
@@ -1,0 +1,2157 @@
+"""
+Copyright BOOSTRY Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+from unittest import mock
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+from web3 import Web3
+from web3.middleware import geth_poa_middleware
+
+from app import config
+from app.model.db import (
+    IDXLockedPosition,
+    IDXPosition,
+    IDXTransfer,
+    IDXTransferSourceEventType,
+    Listing,
+)
+from tests.account_config import eth_account
+from tests.app.position_PositionCoupon_test import TestPositionCoupon
+from tests.app.position_PositionMembership_test import TestPositionMembership
+from tests.app.position_PositionShare_test import TestPositionShare
+from tests.app.position_PositionStraightBond_test import TestPositionStraightBond
+
+web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
+web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+
+
+class TestPosition:
+    # Test API
+    apiurl = "/Position/{account_address}"
+
+    issuer = eth_account["issuer"]
+    account_1 = eth_account["deployer"]
+    account_2 = eth_account["trader"]
+    zero_address = {"address": config.ZERO_ADDRESS}
+
+    @staticmethod
+    def create_idx_position(
+        session: Session,
+        token_address: str,
+        account_address: str,
+        balance: int | None = None,
+        pending_transfer: int | None = None,
+        exchange_balance: int | None = None,
+        exchange_commitment: int | None = None,
+    ):
+        if (
+            not balance
+            and not exchange_balance
+            and not exchange_commitment
+            and not pending_transfer
+        ):
+            return
+        idx_position = IDXPosition()
+        idx_position.token_address = token_address
+        idx_position.account_address = account_address
+        if balance:
+            idx_position.balance = balance
+        if pending_transfer:
+            idx_position.pending_transfer = pending_transfer
+        if exchange_balance:
+            idx_position.exchange_balance = exchange_balance
+        if exchange_commitment:
+            idx_position.exchange_commitment = exchange_commitment
+        session.merge(idx_position)
+        session.commit()
+        pass
+
+    @staticmethod
+    def create_idx_locked_position(
+        session: Session,
+        token_address: str,
+        lock_address: str,
+        account_address: str,
+        value: int,
+    ):
+        # Issue token
+        idx_locked = IDXLockedPosition()
+        idx_locked.token_address = token_address
+        idx_locked.lock_address = lock_address
+        idx_locked.account_address = account_address
+        idx_locked.value = value
+        session.add(idx_locked)
+        session.commit()
+
+    @staticmethod
+    def list_token(token_address, session):
+        listed_token = Listing()
+        listed_token.token_address = token_address
+        listed_token.is_public = True
+        listed_token.max_holding_quantity = 1
+        listed_token.max_sell_amount = 1000
+        session.add(listed_token)
+
+    @staticmethod
+    def expected_bond_token():
+        return {
+            "company_name": "",
+            "contact_information": "問い合わせ先",
+            "face_value": 10000,
+            "interest_payment_date1": "0101",
+            "interest_payment_date10": "1001",
+            "interest_payment_date11": "1101",
+            "interest_payment_date12": "1201",
+            "interest_payment_date2": "0201",
+            "interest_payment_date3": "0301",
+            "interest_payment_date4": "0401",
+            "interest_payment_date5": "0501",
+            "interest_payment_date6": "0601",
+            "interest_payment_date7": "0701",
+            "interest_payment_date8": "0801",
+            "interest_payment_date9": "0901",
+            "interest_rate": 0.0602,
+            "is_offering": False,
+            "is_redeemed": False,
+            "max_holding_quantity": 1,
+            "max_sell_amount": 1000,
+            "memo": "メモ",
+            "name": "テスト債券",
+            "owner_address": TestPositionStraightBond.issuer["account_address"],
+            "privacy_policy": "プライバシーポリシー",
+            "purpose": "新商品の開発資金として利用。",
+            "redemption_date": "20191231",
+            "redemption_value": 10000,
+            "return_amount": "商品券をプレゼント",
+            "return_date": "20191231",
+            "rsa_publickey": "",
+            "status": True,
+            "symbol": "BOND",
+            "token_template": "IbetStraightBond",
+            "total_supply": 1000000,
+            "tradable_exchange": "0x0000000000000000000000000000000000000000",
+            "transfer_approval_required": False,
+            "transferable": True,
+        }
+
+    @staticmethod
+    def expected_share_token():
+        return {
+            "cancellation_date": "20200603",
+            "company_name": "",
+            "contact_information": "問い合わせ先",
+            "dividend_information": {
+                "dividend_payment_date": "20200502",
+                "dividend_record_date": "20200401",
+                "dividends": 1.01e-11,
+            },
+            "is_canceled": False,
+            "is_offering": False,
+            "issue_price": 1000,
+            "max_holding_quantity": 1,
+            "max_sell_amount": 1000,
+            "memo": "メモ",
+            "name": "テスト株式",
+            "owner_address": TestPositionShare.issuer["account_address"],
+            "principal_value": 1000,
+            "privacy_policy": "プライバシーポリシー",
+            "rsa_publickey": "",
+            "status": True,
+            "symbol": "SHARE",
+            "token_template": "IbetShare",
+            "total_supply": 1000000,
+            "tradable_exchange": "0x0000000000000000000000000000000000000000",
+            "transfer_approval_required": False,
+            "transferable": True,
+        }
+
+    @staticmethod
+    def expected_coupon_token():
+        return {
+            "owner_address": TestPositionCoupon.issuer["account_address"],
+            "company_name": "",
+            "contact_information": "問い合わせ先",
+            "details": "クーポン詳細",
+            "expiration_date": "20191231",
+            "image_url": [
+                {"id": 1, "url": ""},
+                {"id": 2, "url": ""},
+                {"id": 3, "url": ""},
+            ],
+            "initial_offering_status": False,
+            "max_holding_quantity": 1,
+            "max_sell_amount": 1000,
+            "memo": "クーポンメモ欄",
+            "name": "テストクーポン",
+            "privacy_policy": "プライバシーポリシー",
+            "return_details": "リターン詳細",
+            "rsa_publickey": "",
+            "status": True,
+            "symbol": "COUPON",
+            "token_template": "IbetCoupon",
+            "total_supply": 1000000,
+            "tradable_exchange": "0x0000000000000000000000000000000000000000",
+            "transferable": True,
+        }
+
+    @staticmethod
+    def expected_membership_token():
+        return {
+            "owner_address": TestPositionMembership.issuer["account_address"],
+            "company_name": "",
+            "contact_information": "問い合わせ先",
+            "details": "詳細",
+            "expiration_date": "20191231",
+            "image_url": [
+                {"id": 1, "url": ""},
+                {"id": 2, "url": ""},
+                {"id": 3, "url": ""},
+            ],
+            "initial_offering_status": False,
+            "max_holding_quantity": 1,
+            "max_sell_amount": 1000,
+            "memo": "メモ",
+            "name": "テスト会員権",
+            "privacy_policy": "プライバシーポリシー",
+            "return_details": "リターン詳細",
+            "rsa_publickey": "",
+            "status": True,
+            "symbol": "MEMBERSHIP",
+            "token_template": "IbetMembership",
+            "total_supply": 1000000,
+            "tradable_exchange": "0x0000000000000000000000000000000000000000",
+            "transferable": True,
+        }
+
+    def setup_bond(self, session: Session, shared_contract, index=0):
+        personal_info_contract = shared_contract["PersonalInfo"]
+
+        token_non_1 = "0x{:010x}{:010x}{:010x}{:010x}".format(9999999999, 0, index, 1)
+        token_non_2 = "0x{:010x}{:010x}{:010x}{:010x}".format(9999999999, 0, index, 2)
+        token_non_3 = "0x{:010x}{:010x}{:010x}{:010x}".format(9999999999, 0, index, 3)
+        token_non_4 = "0x{:010x}{:010x}{:010x}{:010x}".format(9999999999, 0, index, 4)
+        token_non_5 = "0x{:010x}{:010x}{:010x}{:010x}".format(9999999999, 0, index, 5)
+        token_non_6 = "0x{:010x}{:010x}{:010x}{:010x}".format(9999999999, 0, index, 6)
+
+        token_1 = "0x{:010x}{:010x}{:010x}{:010x}".format(0, 0, index, 1)
+        token_2 = "0x{:010x}{:010x}{:010x}{:010x}".format(0, 0, index, 2)
+        token_3 = "0x{:010x}{:010x}{:010x}{:010x}".format(0, 0, index, 3)
+        token_4 = "0x{:010x}{:010x}{:010x}{:010x}".format(0, 0, index, 4)
+        token_5 = "0x{:010x}{:010x}{:010x}{:010x}".format(0, 0, index, 5)
+
+        # Prepare data
+        self.create_idx_position(
+            session,
+            token_non_1,
+            self.account_2["account_address"],
+            balance=1000000,
+        )
+        self.list_token(token_non_1, session)  # not target
+        TestPositionStraightBond.create_idx_token(
+            session,
+            token_non_1,
+            personal_info_contract["address"],
+            config.ZERO_ADDRESS,
+        )
+        self.create_idx_position(
+            session,
+            token_non_2,
+            self.account_2["account_address"],
+            balance=1000000,
+        )
+        self.list_token(token_non_2, session)  # not target
+        TestPositionStraightBond.create_idx_token(
+            session,
+            token_non_2,
+            personal_info_contract["address"],
+            config.ZERO_ADDRESS,
+        )
+
+        self.create_idx_position(
+            session,
+            token_1,
+            self.account_1["account_address"],
+            balance=1000000,
+        )
+        self.list_token(token_1, session)  # not target
+        TestPositionStraightBond.create_idx_token(
+            session,
+            token_1,
+            personal_info_contract["address"],
+            config.ZERO_ADDRESS,
+        )
+
+        self.create_idx_position(
+            session,
+            token_2,
+            self.account_1["account_address"],
+            balance=1000000,
+        )
+        self.list_token(token_2, session)  # not target
+        TestPositionStraightBond.create_idx_token(
+            session,
+            token_2,
+            personal_info_contract["address"],
+            config.ZERO_ADDRESS,
+        )
+
+        self.create_idx_position(
+            session,
+            token_non_3,
+            self.account_2["account_address"],
+            balance=1000000,
+        )
+        self.list_token(token_non_3, session)  # not target
+        TestPositionStraightBond.create_idx_token(
+            session,
+            token_non_3,
+            personal_info_contract["address"],
+            config.ZERO_ADDRESS,
+        )
+
+        self.create_idx_position(
+            session,
+            token_non_4,
+            self.account_2["account_address"],
+            balance=1000000,
+        )
+        self.list_token(token_non_4, session)  # not target
+        TestPositionStraightBond.create_idx_token(
+            session,
+            token_non_4,
+            personal_info_contract["address"],
+            config.ZERO_ADDRESS,
+        )
+
+        self.create_idx_position(
+            session,
+            token_3,
+            self.account_1["account_address"],
+            balance=999900,
+            exchange_commitment=100,
+        )
+        self.list_token(token_3, session)  # not target
+        TestPositionStraightBond.create_idx_token(
+            session,
+            token_3,
+            personal_info_contract["address"],
+            config.ZERO_ADDRESS,
+        )
+
+        self.create_idx_position(
+            session,
+            token_4,
+            self.account_1["account_address"],
+            exchange_commitment=1000000,
+        )
+        self.list_token(token_4, session)
+        TestPositionStraightBond.create_idx_token(
+            session,
+            token_4,
+            personal_info_contract["address"],
+            config.ZERO_ADDRESS,
+        )
+
+        self.create_idx_position(
+            session,
+            token_non_5,
+            self.account_2["account_address"],
+            balance=1000000,
+        )
+        self.list_token(token_non_5, session)  # not target
+        TestPositionStraightBond.create_idx_token(
+            session,
+            token_non_5,
+            personal_info_contract["address"],
+            config.ZERO_ADDRESS,
+        )
+
+        self.create_idx_position(
+            session,
+            token_non_6,
+            self.account_2["account_address"],
+            balance=1000000,
+        )
+        self.list_token(token_non_6, session)  # not target
+        TestPositionStraightBond.create_idx_token(
+            session,
+            token_non_6,
+            personal_info_contract["address"],
+            config.ZERO_ADDRESS,
+        )
+
+        self.create_idx_locked_position(
+            session,
+            token_5,
+            self.account_2["account_address"],
+            self.account_1["account_address"],
+            1000,
+        )
+        self.create_idx_locked_position(
+            session,
+            token_5,
+            self.issuer["account_address"],
+            self.account_1["account_address"],
+            2000,
+        )
+        self.create_idx_locked_position(
+            session,
+            token_5,
+            self.issuer["account_address"],
+            self.account_2["account_address"],
+            5000,
+        )
+        self.list_token(token_5, session)
+        TestPositionStraightBond.create_idx_token(
+            session,
+            token_5,
+            personal_info_contract["address"],
+            config.ZERO_ADDRESS,
+        )
+
+    def setup_share(self, session: Session, shared_contract, index=0):
+        token_non_1 = "0x{:010x}{:010x}{:010x}{:010x}".format(9999999999, 1, index, 1)
+        token_non_2 = "0x{:010x}{:010x}{:010x}{:010x}".format(9999999999, 1, index, 2)
+        token_non_3 = "0x{:010x}{:010x}{:010x}{:010x}".format(9999999999, 1, index, 3)
+        token_non_4 = "0x{:010x}{:010x}{:010x}{:010x}".format(9999999999, 1, index, 4)
+        token_non_5 = "0x{:010x}{:010x}{:010x}{:010x}".format(9999999999, 1, index, 5)
+        token_non_6 = "0x{:010x}{:010x}{:010x}{:010x}".format(9999999999, 1, index, 6)
+
+        token_1 = "0x{:010x}{:010x}{:010x}{:010x}".format(0, 1, index, 1)
+        token_2 = "0x{:010x}{:010x}{:010x}{:010x}".format(0, 1, index, 2)
+        token_3 = "0x{:010x}{:010x}{:010x}{:010x}".format(0, 1, index, 3)
+        token_4 = "0x{:010x}{:010x}{:010x}{:010x}".format(0, 1, index, 4)
+        token_5 = "0x{:010x}{:010x}{:010x}{:010x}".format(0, 1, index, 5)
+        token_6 = "0x{:010x}{:010x}{:010x}{:010x}".format(0, 1, index, 6)
+        token_7 = "0x{:010x}{:010x}{:010x}{:010x}".format(0, 1, index, 7)
+
+        personal_info_contract = shared_contract["PersonalInfo"]
+        exchange_contract = shared_contract["IbetStraightBondExchange"]
+
+        # Prepare data
+        self.create_idx_position(
+            session,
+            token_non_1,
+            self.account_2["account_address"],
+            balance=1000000,
+        )
+        self.list_token(token_non_1, session)  # not target
+        TestPositionShare.create_idx_token(
+            session,
+            token_non_1,
+            personal_info_contract["address"],
+            config.ZERO_ADDRESS,
+        )
+
+        self.create_idx_position(
+            session,
+            token_non_2,
+            self.account_2["account_address"],
+            balance=1000000,
+        )
+        self.list_token(token_non_2, session)  # not target
+        TestPositionShare.create_idx_token(
+            session,
+            token_non_2,
+            personal_info_contract["address"],
+            config.ZERO_ADDRESS,
+        )
+
+        self.create_idx_position(
+            session, token_1, self.account_1["account_address"], balance=1000000
+        )
+        self.list_token(token_1, session)  # not target
+        TestPositionShare.create_idx_token(
+            session,
+            token_1,
+            personal_info_contract["address"],
+            config.ZERO_ADDRESS,
+        )
+
+        self.create_idx_position(
+            session, token_2, self.account_1["account_address"], balance=1000000
+        )
+        self.list_token(token_2, session)  # not target
+        TestPositionShare.create_idx_token(
+            session,
+            token_2,
+            personal_info_contract["address"],
+            config.ZERO_ADDRESS,
+        )
+
+        self.create_idx_position(
+            session,
+            token_non_3,
+            self.account_2["account_address"],
+            balance=1000000,
+        )
+        self.list_token(token_non_3, session)  # not target
+        TestPositionShare.create_idx_token(
+            session,
+            token_non_3,
+            personal_info_contract["address"],
+            config.ZERO_ADDRESS,
+        )
+
+        self.create_idx_position(
+            session,
+            token_non_4,
+            self.account_2["account_address"],
+            balance=1000000,
+        )
+        self.list_token(token_non_4, session)  # not target
+        TestPositionShare.create_idx_token(
+            session,
+            token_non_4,
+            personal_info_contract["address"],
+            config.ZERO_ADDRESS,
+        )
+
+        self.create_idx_position(
+            session,
+            token_3,
+            self.account_1["account_address"],
+            balance=999900,
+            pending_transfer=100,
+        )
+        self.list_token(token_3, session)  # not target
+        TestPositionShare.create_idx_token(
+            session,
+            token_3,
+            personal_info_contract["address"],
+            config.ZERO_ADDRESS,
+        )
+
+        self.create_idx_position(
+            session,
+            token_4,
+            self.account_1["account_address"],
+            pending_transfer=1000000,
+        )
+        self.list_token(token_4, session)
+        TestPositionShare.create_idx_token(
+            session,
+            token_4,
+            personal_info_contract["address"],
+            config.ZERO_ADDRESS,
+        )
+
+        self.create_idx_position(
+            session,
+            token_5,
+            self.account_1["account_address"],
+            balance=999900,
+            exchange_commitment=100,
+        )
+        self.list_token(token_5, session)
+        TestPositionShare.create_idx_token(
+            session,
+            token_5,
+            personal_info_contract["address"],
+            config.ZERO_ADDRESS,
+        )
+
+        self.create_idx_position(
+            session,
+            token_6,
+            self.account_1["account_address"],
+            exchange_commitment=1000000,
+        )
+        self.list_token(token_6, session)
+        TestPositionShare.create_idx_token(
+            session,
+            token_6,
+            personal_info_contract["address"],
+            config.ZERO_ADDRESS,
+        )
+
+        self.create_idx_position(
+            session,
+            token_non_5,
+            self.account_2["account_address"],
+            balance=1000000,
+        )
+        self.list_token(token_non_5, session)  # not target
+        TestPositionShare.create_idx_token(
+            session,
+            token_non_5,
+            personal_info_contract["address"],
+            config.ZERO_ADDRESS,
+        )
+
+        self.create_idx_position(
+            session,
+            token_non_6,
+            self.account_2["account_address"],
+            balance=1000000,
+        )
+        self.list_token(token_non_6, session)  # not target
+        TestPositionShare.create_idx_token(
+            session,
+            token_non_6,
+            personal_info_contract["address"],
+            config.ZERO_ADDRESS,
+        )
+
+        self.create_idx_locked_position(
+            session,
+            token_7,
+            self.account_2["account_address"],
+            self.account_1["account_address"],
+            1000,
+        )
+        self.create_idx_locked_position(
+            session,
+            token_7,
+            self.issuer["account_address"],
+            self.account_1["account_address"],
+            2000,
+        )
+        self.create_idx_locked_position(
+            session,
+            token_7,
+            self.issuer["account_address"],
+            self.account_2["account_address"],
+            5000,
+        )
+        self.list_token(token_7, session)
+        TestPositionShare.create_idx_token(
+            session,
+            token_7,
+            personal_info_contract["address"],
+            config.ZERO_ADDRESS,
+        )
+
+    def setup_coupon(self, session: Session, shared_contract, index=0):
+        token_non_1 = "0x{:010x}{:010x}{:010x}{:010x}".format(9999999999, 2, index, 1)
+        token_non_2 = "0x{:010x}{:010x}{:010x}{:010x}".format(9999999999, 2, index, 2)
+        token_non_3 = "0x{:010x}{:010x}{:010x}{:010x}".format(9999999999, 2, index, 3)
+        token_non_4 = "0x{:010x}{:010x}{:010x}{:010x}".format(9999999999, 2, index, 4)
+        token_non_5 = "0x{:010x}{:010x}{:010x}{:010x}".format(9999999999, 2, index, 5)
+        token_non_6 = "0x{:010x}{:010x}{:010x}{:010x}".format(9999999999, 2, index, 6)
+        token_non_7 = "0x{:010x}{:010x}{:010x}{:010x}".format(9999999999, 2, index, 7)
+        token_non_8 = "0x{:010x}{:010x}{:010x}{:010x}".format(9999999999, 2, index, 8)
+        token_non_9 = "0x{:010x}{:010x}{:010x}{:010x}".format(9999999999, 2, index, 9)
+
+        token_1 = "0x{:010x}{:010x}{:010x}{:010x}".format(0, 2, index, 1)
+        token_2 = "0x{:010x}{:010x}{:010x}{:010x}".format(0, 2, index, 2)
+        token_3 = "0x{:010x}{:010x}{:010x}{:010x}".format(0, 2, index, 3)
+        token_4 = "0x{:010x}{:010x}{:010x}{:010x}".format(0, 2, index, 4)
+        token_5 = "0x{:010x}{:010x}{:010x}{:010x}".format(0, 2, index, 5)
+        token_6 = "0x{:010x}{:010x}{:010x}{:010x}".format(0, 2, index, 6)
+        token_7 = "0x{:010x}{:010x}{:010x}{:010x}".format(0, 2, index, 7)
+
+        # Prepare data
+        self.create_idx_position(
+            session,
+            token_non_1,
+            self.account_2["account_address"],
+            balance=1000000,
+        )
+        self.list_token(token_non_1, session)  # not target
+        TestPositionCoupon.create_idx_token(session, token_non_1, config.ZERO_ADDRESS)
+
+        self.create_idx_position(
+            session,
+            token_non_2,
+            self.account_2["account_address"],
+            balance=1000000,
+        )
+        self.list_token(token_non_2, session)  # not target
+        TestPositionCoupon.create_idx_token(session, token_non_2, config.ZERO_ADDRESS)
+
+        self.create_idx_position(
+            session,
+            token_1,
+            self.account_1["account_address"],
+            balance=1000000,
+        )
+        self.list_token(token_1, session)
+        TestPositionCoupon.create_idx_token(session, token_1, config.ZERO_ADDRESS)
+
+        self.create_idx_position(
+            session,
+            token_2,
+            self.account_1["account_address"],
+            balance=1000000,
+        )
+        self.list_token(token_2, session)
+        TestPositionCoupon.create_idx_token(session, token_2, config.ZERO_ADDRESS)
+
+        self.create_idx_position(
+            session,
+            token_non_3,
+            self.account_2["account_address"],
+            balance=1000000,
+        )
+        self.list_token(token_non_3, session)  # not target
+        TestPositionCoupon.create_idx_token(session, token_non_3, config.ZERO_ADDRESS)
+
+        self.create_idx_position(
+            session,
+            token_non_4,
+            self.account_2["account_address"],
+            balance=1000000,
+        )
+        self.list_token(token_non_4, session)  # not target
+        TestPositionCoupon.create_idx_token(session, token_non_4, config.ZERO_ADDRESS)
+
+        self.create_idx_position(
+            session,
+            token_3,
+            self.account_1["account_address"],
+            balance=999900,
+            exchange_commitment=100,
+        )
+        self.list_token(token_3, session)
+        TestPositionCoupon.create_idx_token(session, token_3, config.ZERO_ADDRESS)
+
+        self.create_idx_position(
+            session,
+            token_4,
+            self.account_1["account_address"],
+            exchange_commitment=1000000,
+        )
+        self.list_token(token_4, session)
+        TestPositionCoupon.create_idx_token(session, token_4, config.ZERO_ADDRESS)
+
+        self.create_idx_position(
+            session,
+            token_non_5,
+            self.account_2["account_address"],
+            balance=1000000,
+        )
+        self.list_token(token_non_5, session)  # not target
+        TestPositionCoupon.create_idx_token(session, token_non_5, config.ZERO_ADDRESS)
+
+        self.create_idx_position(
+            session,
+            token_non_6,
+            self.account_2["account_address"],
+            balance=1000000,
+        )
+        self.list_token(token_non_6, session)  # not target
+        TestPositionCoupon.create_idx_token(session, token_non_6, config.ZERO_ADDRESS)
+
+        self.create_idx_position(
+            session,
+            token_5,
+            self.account_1["account_address"],
+            balance=999900,
+        )
+        TestPositionCoupon.create_idx_consume(
+            session, token_5, self.account_1["account_address"], 80
+        )
+        TestPositionCoupon.create_idx_consume(
+            session, token_5, self.account_1["account_address"], 20
+        )
+        self.list_token(token_5, session)
+        TestPositionCoupon.create_idx_token(session, token_5, config.ZERO_ADDRESS)
+
+        TestPositionCoupon.create_idx_consume(
+            session, token_6, self.account_1["account_address"], 800000
+        )
+        TestPositionCoupon.create_idx_consume(
+            session, token_6, self.account_1["account_address"], 200000
+        )
+        self.list_token(token_6, session)
+        TestPositionCoupon.create_idx_token(session, token_6, config.ZERO_ADDRESS)
+
+        self.create_idx_position(
+            session,
+            token_non_7,
+            self.account_2["account_address"],
+            balance=1000000,
+        )
+        self.list_token(token_non_7, session)  # not target
+        TestPositionCoupon.create_idx_token(session, token_non_7, config.ZERO_ADDRESS)
+
+        self.create_idx_position(
+            session,
+            token_non_8,
+            self.account_2["account_address"],
+            balance=1000000,
+        )
+        self.list_token(token_non_8, session)  # not target
+        TestPositionCoupon.create_idx_token(session, token_non_8, config.ZERO_ADDRESS)
+
+        self.create_idx_position(
+            session,
+            token_7,
+            self.account_2["account_address"],
+            balance=1000000,
+        )
+        self.list_token(token_7, session)
+        TestPositionCoupon.create_idx_token(session, token_7, config.ZERO_ADDRESS)
+
+        idx_transfer = IDXTransfer()
+        idx_transfer.transaction_hash = "tx1"
+        idx_transfer.token_address = token_7
+        idx_transfer.from_address = self.issuer["account_address"]
+        idx_transfer.to_address = self.account_1["account_address"]
+        idx_transfer.value = 100000
+        idx_transfer.source_event = IDXTransferSourceEventType.TRANSFER.value
+        session.add(idx_transfer)
+
+        self.create_idx_position(
+            session,
+            token_non_9,
+            self.account_2["account_address"],
+            balance=1000000,
+        )
+        self.list_token(token_non_9, session)  # not target
+        TestPositionCoupon.create_idx_token(session, token_non_9, config.ZERO_ADDRESS)
+
+    def setup_membership(self, session: Session, shared_contract, index=0):
+        token_non_1 = "0x{:010x}{:010x}{:010x}{:010x}".format(9999999999, 3, index, 1)
+        token_non_2 = "0x{:010x}{:010x}{:010x}{:010x}".format(9999999999, 3, index, 2)
+        token_non_3 = "0x{:010x}{:010x}{:010x}{:010x}".format(9999999999, 3, index, 3)
+        token_non_4 = "0x{:010x}{:010x}{:010x}{:010x}".format(9999999999, 3, index, 4)
+        token_non_5 = "0x{:010x}{:010x}{:010x}{:010x}".format(9999999999, 3, index, 5)
+        token_non_6 = "0x{:010x}{:010x}{:010x}{:010x}".format(9999999999, 3, index, 6)
+
+        token_1 = "0x{:010x}{:010x}{:010x}{:010x}".format(0, 3, index, 1)
+        token_2 = "0x{:010x}{:010x}{:010x}{:010x}".format(0, 3, index, 2)
+        token_3 = "0x{:010x}{:010x}{:010x}{:010x}".format(0, 3, index, 3)
+        token_4 = "0x{:010x}{:010x}{:010x}{:010x}".format(0, 3, index, 4)
+
+        # Prepare data
+        self.create_idx_position(
+            session,
+            token_non_1,
+            self.account_2["account_address"],
+            balance=1000000,
+        )
+        self.list_token(token_non_1, session)  # not target
+        TestPositionMembership.create_idx_token(
+            session, token_non_1, config.ZERO_ADDRESS
+        )
+
+        self.create_idx_position(
+            session,
+            token_non_2,
+            self.account_2["account_address"],
+            balance=1000000,
+        )
+        self.list_token(token_non_2, session)  # not target
+        TestPositionMembership.create_idx_token(
+            session, token_non_2, config.ZERO_ADDRESS
+        )
+
+        self.create_idx_position(
+            session,
+            token_1,
+            self.account_1["account_address"],
+            balance=1000000,
+        )
+        self.list_token(token_1, session)
+        TestPositionMembership.create_idx_token(session, token_1, config.ZERO_ADDRESS)
+
+        self.create_idx_position(
+            session,
+            token_2,
+            self.account_1["account_address"],
+            balance=1000000,
+        )
+        self.list_token(token_2, session)
+        TestPositionMembership.create_idx_token(session, token_2, config.ZERO_ADDRESS)
+
+        self.create_idx_position(
+            session,
+            token_non_3,
+            self.account_2["account_address"],
+            balance=1000000,
+        )
+        self.list_token(token_non_3, session)  # not target
+        TestPositionMembership.create_idx_token(
+            session, token_non_3, config.ZERO_ADDRESS
+        )
+
+        self.create_idx_position(
+            session,
+            token_non_4,
+            self.account_2["account_address"],
+            balance=1000000,
+        )
+        self.list_token(token_non_4, session)  # not target
+        TestPositionMembership.create_idx_token(
+            session, token_non_4, config.ZERO_ADDRESS
+        )
+
+        self.create_idx_position(
+            session,
+            token_3,
+            self.account_1["account_address"],
+            balance=999900,
+            exchange_commitment=100,
+        )
+        self.list_token(token_3, session)
+        TestPositionMembership.create_idx_token(session, token_3, config.ZERO_ADDRESS)
+
+        self.create_idx_position(
+            session,
+            token_4,
+            self.account_1["account_address"],
+            exchange_commitment=1000000,
+        )
+        self.list_token(token_4, session)
+        TestPositionMembership.create_idx_token(session, token_4, config.ZERO_ADDRESS)
+
+        self.create_idx_position(
+            session,
+            token_non_5,
+            self.account_2["account_address"],
+            balance=1000000,
+        )
+        self.list_token(token_non_5, session)  # not target
+        TestPositionMembership.create_idx_token(
+            session, token_non_5, config.ZERO_ADDRESS
+        )
+
+        self.create_idx_position(
+            session,
+            token_non_6,
+            self.account_2["account_address"],
+            balance=1000000,
+        )
+        self.list_token(token_non_6, session)  # not target
+        TestPositionMembership.create_idx_token(
+            session, token_non_6, config.ZERO_ADDRESS
+        )
+
+    def setup_data(self, session: Session, shared_contract, index=0):
+        # StraightBond
+        self.setup_bond(session=session, shared_contract=shared_contract, index=index)
+        # Share
+        self.setup_share(session=session, shared_contract=shared_contract, index=index)
+        # Coupon
+        self.setup_coupon(session=session, shared_contract=shared_contract, index=index)
+        # Membership
+        self.setup_membership(
+            session=session, shared_contract=shared_contract, index=index
+        )
+
+    ###########################################################################
+    # Normal
+    ###########################################################################
+
+    # <Normal_1>
+    # List all positions
+    def test_normal_1(self, client: TestClient, session: Session, shared_contract):
+        token_list_contract = shared_contract["TokenList"]
+        self.setup_data(session=session, shared_contract=shared_contract, index=0)
+
+        with mock.patch(
+            "app.config.TOKEN_LIST_CONTRACT_ADDRESS", token_list_contract
+        ), mock.patch("app.config.BOND_TOKEN_ENABLED", True), mock.patch(
+            "app.config.SHARE_TOKEN_ENABLED", True
+        ), mock.patch(
+            "app.config.COUPON_TOKEN_ENABLED", True
+        ), mock.patch(
+            "app.config.MEMBERSHIP_TOKEN_ENABLED", True
+        ):
+            # Request target API
+            resp = client.get(
+                self.apiurl.format(account_address=self.account_1["account_address"]),
+                params={},
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["data"] == {
+            "result_set": {
+                "count": 22,
+                "offset": None,
+                "limit": None,
+                "total": 22,
+            },
+            "positions": [
+                {
+                    "balance": 1000000,
+                    "exchange_balance": 0,
+                    "exchange_commitment": 0,
+                    "pending_transfer": 0,
+                    "locked": 0,
+                    "token": {
+                        "token_address": "0x0000000000000000000000000000000000000001",
+                        "personal_info_address": shared_contract["PersonalInfo"][
+                            "address"
+                        ],
+                        **self.expected_bond_token(),
+                    },
+                },
+                {
+                    "balance": 1000000,
+                    "exchange_balance": 0,
+                    "exchange_commitment": 0,
+                    "pending_transfer": 0,
+                    "locked": 0,
+                    "token": {
+                        "token_address": "0x0000000000000000000000000000000000000002",
+                        "personal_info_address": shared_contract["PersonalInfo"][
+                            "address"
+                        ],
+                        **self.expected_bond_token(),
+                    },
+                },
+                {
+                    "balance": 999900,
+                    "exchange_balance": 0,
+                    "exchange_commitment": 100,
+                    "pending_transfer": 0,
+                    "locked": 0,
+                    "token": {
+                        "token_address": "0x0000000000000000000000000000000000000003",
+                        "personal_info_address": shared_contract["PersonalInfo"][
+                            "address"
+                        ],
+                        **self.expected_bond_token(),
+                    },
+                },
+                {
+                    "balance": 0,
+                    "exchange_balance": 0,
+                    "exchange_commitment": 1000000,
+                    "pending_transfer": 0,
+                    "locked": 0,
+                    "token": {
+                        "token_address": "0x0000000000000000000000000000000000000004",
+                        "personal_info_address": shared_contract["PersonalInfo"][
+                            "address"
+                        ],
+                        **self.expected_bond_token(),
+                    },
+                },
+                {
+                    "balance": 0,
+                    "exchange_balance": 0,
+                    "exchange_commitment": 0,
+                    "pending_transfer": 0,
+                    "locked": 3000,
+                    "token": {
+                        "token_address": "0x0000000000000000000000000000000000000005",
+                        "personal_info_address": shared_contract["PersonalInfo"][
+                            "address"
+                        ],
+                        **self.expected_bond_token(),
+                    },
+                },
+                {
+                    "balance": 1000000,
+                    "exchange_balance": 0,
+                    "exchange_commitment": 0,
+                    "pending_transfer": 0,
+                    "locked": 0,
+                    "token": {
+                        "token_address": "0x0000000000000000000100000000000000000001",
+                        "personal_info_address": shared_contract["PersonalInfo"][
+                            "address"
+                        ],
+                        **self.expected_share_token(),
+                    },
+                },
+                {
+                    "balance": 1000000,
+                    "exchange_balance": 0,
+                    "exchange_commitment": 0,
+                    "pending_transfer": 0,
+                    "locked": 0,
+                    "token": {
+                        "token_address": "0x0000000000000000000100000000000000000002",
+                        "personal_info_address": shared_contract["PersonalInfo"][
+                            "address"
+                        ],
+                        **self.expected_share_token(),
+                    },
+                },
+                {
+                    "balance": 999900,
+                    "exchange_balance": 0,
+                    "exchange_commitment": 0,
+                    "pending_transfer": 100,
+                    "locked": 0,
+                    "token": {
+                        "token_address": "0x0000000000000000000100000000000000000003",
+                        "personal_info_address": shared_contract["PersonalInfo"][
+                            "address"
+                        ],
+                        **self.expected_share_token(),
+                    },
+                },
+                {
+                    "balance": 0,
+                    "exchange_balance": 0,
+                    "exchange_commitment": 0,
+                    "pending_transfer": 1000000,
+                    "locked": 0,
+                    "token": {
+                        "token_address": "0x0000000000000000000100000000000000000004",
+                        "personal_info_address": shared_contract["PersonalInfo"][
+                            "address"
+                        ],
+                        **self.expected_share_token(),
+                    },
+                },
+                {
+                    "balance": 999900,
+                    "exchange_balance": 0,
+                    "exchange_commitment": 100,
+                    "pending_transfer": 0,
+                    "locked": 0,
+                    "token": {
+                        "token_address": "0x0000000000000000000100000000000000000005",
+                        "personal_info_address": shared_contract["PersonalInfo"][
+                            "address"
+                        ],
+                        **self.expected_share_token(),
+                    },
+                },
+                {
+                    "balance": 0,
+                    "exchange_balance": 0,
+                    "exchange_commitment": 1000000,
+                    "locked": 0,
+                    "pending_transfer": 0,
+                    "token": {
+                        "token_address": "0x0000000000000000000100000000000000000006",
+                        "personal_info_address": shared_contract["PersonalInfo"][
+                            "address"
+                        ],
+                        **self.expected_share_token(),
+                    },
+                },
+                {
+                    "balance": 0,
+                    "exchange_balance": 0,
+                    "exchange_commitment": 0,
+                    "pending_transfer": 0,
+                    "locked": 3000,
+                    "token": {
+                        "token_address": "0x0000000000000000000100000000000000000007",
+                        "personal_info_address": shared_contract["PersonalInfo"][
+                            "address"
+                        ],
+                        **self.expected_share_token(),
+                    },
+                },
+                {
+                    "balance": 1000000,
+                    "exchange_balance": 0,
+                    "exchange_commitment": 0,
+                    "used": 0,
+                    "token": {
+                        "token_address": "0x0000000000000000000200000000000000000001",
+                        **self.expected_coupon_token(),
+                    },
+                },
+                {
+                    "balance": 1000000,
+                    "exchange_balance": 0,
+                    "exchange_commitment": 0,
+                    "used": 0,
+                    "token": {
+                        "token_address": "0x0000000000000000000200000000000000000002",
+                        **self.expected_coupon_token(),
+                    },
+                },
+                {
+                    "balance": 999900,
+                    "exchange_balance": 0,
+                    "exchange_commitment": 100,
+                    "used": 0,
+                    "token": {
+                        "token_address": "0x0000000000000000000200000000000000000003",
+                        **self.expected_coupon_token(),
+                    },
+                },
+                {
+                    "balance": 0,
+                    "exchange_balance": 0,
+                    "exchange_commitment": 1000000,
+                    "used": 0,
+                    "token": {
+                        "token_address": "0x0000000000000000000200000000000000000004",
+                        **self.expected_coupon_token(),
+                    },
+                },
+                {
+                    "balance": 999900,
+                    "exchange_balance": 0,
+                    "exchange_commitment": 0,
+                    "used": 100,
+                    "token": {
+                        "token_address": "0x0000000000000000000200000000000000000005",
+                        **self.expected_coupon_token(),
+                    },
+                },
+                {
+                    "balance": 0,
+                    "exchange_balance": 0,
+                    "exchange_commitment": 0,
+                    "used": 1000000,
+                    "token": {
+                        **self.expected_coupon_token(),
+                        "token_address": "0x0000000000000000000200000000000000000006",
+                    },
+                },
+                {
+                    "balance": 1000000,
+                    "exchange_balance": 0,
+                    "exchange_commitment": 0,
+                    "token": {
+                        "token_address": "0x0000000000000000000300000000000000000001",
+                        **self.expected_membership_token(),
+                    },
+                },
+                {
+                    "balance": 1000000,
+                    "exchange_balance": 0,
+                    "exchange_commitment": 0,
+                    "token": {
+                        "token_address": "0x0000000000000000000300000000000000000002",
+                        **self.expected_membership_token(),
+                    },
+                },
+                {
+                    "balance": 999900,
+                    "exchange_balance": 0,
+                    "exchange_commitment": 100,
+                    "token": {
+                        "token_address": "0x0000000000000000000300000000000000000003",
+                        **self.expected_membership_token(),
+                    },
+                },
+                {
+                    "balance": 0,
+                    "exchange_balance": 0,
+                    "exchange_commitment": 1000000,
+                    "token": {
+                        "token_address": "0x0000000000000000000300000000000000000004",
+                        **self.expected_membership_token(),
+                    },
+                },
+            ],
+        }
+
+    # <Normal_2>
+    # List bond positions
+    @pytest.mark.parametrize("query_filter", [True, False])
+    def test_normal_2(
+        self, query_filter, client: TestClient, session: Session, shared_contract
+    ):
+        token_list_contract = shared_contract["TokenList"]
+        self.setup_data(session=session, shared_contract=shared_contract, index=0)
+
+        if query_filter:
+            with mock.patch(
+                "app.config.TOKEN_LIST_CONTRACT_ADDRESS", token_list_contract
+            ), mock.patch("app.config.BOND_TOKEN_ENABLED", True), mock.patch(
+                "app.config.SHARE_TOKEN_ENABLED", True
+            ), mock.patch(
+                "app.config.COUPON_TOKEN_ENABLED", True
+            ), mock.patch(
+                "app.config.MEMBERSHIP_TOKEN_ENABLED", True
+            ):
+                # Request target API
+                resp = client.get(
+                    self.apiurl.format(
+                        account_address=self.account_1["account_address"]
+                    ),
+                    params={"token_type_list": ["IbetStraightBond"]},
+                )
+        else:
+            with mock.patch(
+                "app.config.TOKEN_LIST_CONTRACT_ADDRESS", token_list_contract
+            ), mock.patch("app.config.BOND_TOKEN_ENABLED", True), mock.patch(
+                "app.config.SHARE_TOKEN_ENABLED", False
+            ), mock.patch(
+                "app.config.COUPON_TOKEN_ENABLED", False
+            ), mock.patch(
+                "app.config.MEMBERSHIP_TOKEN_ENABLED", False
+            ):
+                # Request target API
+                resp = client.get(
+                    self.apiurl.format(
+                        account_address=self.account_1["account_address"]
+                    ),
+                    params={},
+                )
+
+        assert resp.status_code == 200
+        assert resp.json()["data"] == {
+            "result_set": {
+                "count": 5,
+                "offset": None,
+                "limit": None,
+                "total": 5,
+            },
+            "positions": [
+                {
+                    "balance": 1000000,
+                    "exchange_balance": 0,
+                    "exchange_commitment": 0,
+                    "pending_transfer": 0,
+                    "locked": 0,
+                    "token": {
+                        "token_address": "0x0000000000000000000000000000000000000001",
+                        "personal_info_address": shared_contract["PersonalInfo"][
+                            "address"
+                        ],
+                        **self.expected_bond_token(),
+                    },
+                },
+                {
+                    "balance": 1000000,
+                    "exchange_balance": 0,
+                    "exchange_commitment": 0,
+                    "pending_transfer": 0,
+                    "locked": 0,
+                    "token": {
+                        "token_address": "0x0000000000000000000000000000000000000002",
+                        "personal_info_address": shared_contract["PersonalInfo"][
+                            "address"
+                        ],
+                        **self.expected_bond_token(),
+                    },
+                },
+                {
+                    "balance": 999900,
+                    "exchange_balance": 0,
+                    "exchange_commitment": 100,
+                    "pending_transfer": 0,
+                    "locked": 0,
+                    "token": {
+                        "token_address": "0x0000000000000000000000000000000000000003",
+                        "personal_info_address": shared_contract["PersonalInfo"][
+                            "address"
+                        ],
+                        **self.expected_bond_token(),
+                    },
+                },
+                {
+                    "balance": 0,
+                    "exchange_balance": 0,
+                    "exchange_commitment": 1000000,
+                    "pending_transfer": 0,
+                    "locked": 0,
+                    "token": {
+                        "token_address": "0x0000000000000000000000000000000000000004",
+                        "personal_info_address": shared_contract["PersonalInfo"][
+                            "address"
+                        ],
+                        **self.expected_bond_token(),
+                    },
+                },
+                {
+                    "balance": 0,
+                    "exchange_balance": 0,
+                    "exchange_commitment": 0,
+                    "pending_transfer": 0,
+                    "locked": 3000,
+                    "token": {
+                        "token_address": "0x0000000000000000000000000000000000000005",
+                        "personal_info_address": shared_contract["PersonalInfo"][
+                            "address"
+                        ],
+                        **self.expected_bond_token(),
+                    },
+                },
+            ],
+        }
+
+    # <Normal_3>
+    # List share positions
+    @pytest.mark.parametrize("query_filter", [True, False])
+    def test_normal_3(
+        self, query_filter, client: TestClient, session: Session, shared_contract
+    ):
+        token_list_contract = shared_contract["TokenList"]
+        self.setup_data(session=session, shared_contract=shared_contract, index=0)
+
+        if query_filter:
+            with mock.patch(
+                "app.config.TOKEN_LIST_CONTRACT_ADDRESS", token_list_contract
+            ), mock.patch("app.config.BOND_TOKEN_ENABLED", True), mock.patch(
+                "app.config.SHARE_TOKEN_ENABLED", True
+            ), mock.patch(
+                "app.config.COUPON_TOKEN_ENABLED", True
+            ), mock.patch(
+                "app.config.MEMBERSHIP_TOKEN_ENABLED", True
+            ):
+                # Request target API
+                resp = client.get(
+                    self.apiurl.format(
+                        account_address=self.account_1["account_address"]
+                    ),
+                    params={"token_type_list": ["IbetShare"]},
+                )
+        else:
+            with mock.patch(
+                "app.config.TOKEN_LIST_CONTRACT_ADDRESS", token_list_contract
+            ), mock.patch("app.config.BOND_TOKEN_ENABLED", False), mock.patch(
+                "app.config.SHARE_TOKEN_ENABLED", True
+            ), mock.patch(
+                "app.config.COUPON_TOKEN_ENABLED", False
+            ), mock.patch(
+                "app.config.MEMBERSHIP_TOKEN_ENABLED", False
+            ):
+                # Request target API
+                resp = client.get(
+                    self.apiurl.format(
+                        account_address=self.account_1["account_address"]
+                    ),
+                    params={},
+                )
+
+        assert resp.status_code == 200
+        assert resp.json()["data"] == {
+            "result_set": {
+                "count": 7,
+                "offset": None,
+                "limit": None,
+                "total": 7,
+            },
+            "positions": [
+                {
+                    "balance": 1000000,
+                    "exchange_balance": 0,
+                    "exchange_commitment": 0,
+                    "pending_transfer": 0,
+                    "locked": 0,
+                    "token": {
+                        "token_address": "0x0000000000000000000100000000000000000001",
+                        "personal_info_address": shared_contract["PersonalInfo"][
+                            "address"
+                        ],
+                        **self.expected_share_token(),
+                    },
+                },
+                {
+                    "balance": 1000000,
+                    "exchange_balance": 0,
+                    "exchange_commitment": 0,
+                    "pending_transfer": 0,
+                    "locked": 0,
+                    "token": {
+                        "token_address": "0x0000000000000000000100000000000000000002",
+                        "personal_info_address": shared_contract["PersonalInfo"][
+                            "address"
+                        ],
+                        **self.expected_share_token(),
+                    },
+                },
+                {
+                    "balance": 999900,
+                    "exchange_balance": 0,
+                    "exchange_commitment": 0,
+                    "pending_transfer": 100,
+                    "locked": 0,
+                    "token": {
+                        "token_address": "0x0000000000000000000100000000000000000003",
+                        "personal_info_address": shared_contract["PersonalInfo"][
+                            "address"
+                        ],
+                        **self.expected_share_token(),
+                    },
+                },
+                {
+                    "balance": 0,
+                    "exchange_balance": 0,
+                    "exchange_commitment": 0,
+                    "pending_transfer": 1000000,
+                    "locked": 0,
+                    "token": {
+                        "token_address": "0x0000000000000000000100000000000000000004",
+                        "personal_info_address": shared_contract["PersonalInfo"][
+                            "address"
+                        ],
+                        **self.expected_share_token(),
+                    },
+                },
+                {
+                    "balance": 999900,
+                    "exchange_balance": 0,
+                    "exchange_commitment": 100,
+                    "pending_transfer": 0,
+                    "locked": 0,
+                    "token": {
+                        "token_address": "0x0000000000000000000100000000000000000005",
+                        "personal_info_address": shared_contract["PersonalInfo"][
+                            "address"
+                        ],
+                        **self.expected_share_token(),
+                    },
+                },
+                {
+                    "balance": 0,
+                    "exchange_balance": 0,
+                    "exchange_commitment": 1000000,
+                    "locked": 0,
+                    "pending_transfer": 0,
+                    "token": {
+                        "token_address": "0x0000000000000000000100000000000000000006",
+                        "personal_info_address": shared_contract["PersonalInfo"][
+                            "address"
+                        ],
+                        **self.expected_share_token(),
+                    },
+                },
+                {
+                    "balance": 0,
+                    "exchange_balance": 0,
+                    "exchange_commitment": 0,
+                    "pending_transfer": 0,
+                    "locked": 3000,
+                    "token": {
+                        "token_address": "0x0000000000000000000100000000000000000007",
+                        "personal_info_address": shared_contract["PersonalInfo"][
+                            "address"
+                        ],
+                        **self.expected_share_token(),
+                    },
+                },
+            ],
+        }
+
+    # <Normal_4>
+    # List coupon positions
+    @pytest.mark.parametrize("query_filter", [True, False])
+    def test_normal_4(
+        self, query_filter, client: TestClient, session: Session, shared_contract
+    ):
+        token_list_contract = shared_contract["TokenList"]
+        self.setup_data(session=session, shared_contract=shared_contract, index=0)
+
+        if query_filter:
+            with mock.patch(
+                "app.config.TOKEN_LIST_CONTRACT_ADDRESS", token_list_contract
+            ), mock.patch("app.config.BOND_TOKEN_ENABLED", True), mock.patch(
+                "app.config.SHARE_TOKEN_ENABLED", True
+            ), mock.patch(
+                "app.config.COUPON_TOKEN_ENABLED", True
+            ), mock.patch(
+                "app.config.MEMBERSHIP_TOKEN_ENABLED", True
+            ):
+                # Request target API
+                resp = client.get(
+                    self.apiurl.format(
+                        account_address=self.account_1["account_address"]
+                    ),
+                    params={"token_type_list": ["IbetCoupon"]},
+                )
+        else:
+            with mock.patch(
+                "app.config.TOKEN_LIST_CONTRACT_ADDRESS", token_list_contract
+            ), mock.patch("app.config.BOND_TOKEN_ENABLED", False), mock.patch(
+                "app.config.SHARE_TOKEN_ENABLED", False
+            ), mock.patch(
+                "app.config.COUPON_TOKEN_ENABLED", True
+            ), mock.patch(
+                "app.config.MEMBERSHIP_TOKEN_ENABLED", False
+            ):
+                # Request target API
+                resp = client.get(
+                    self.apiurl.format(
+                        account_address=self.account_1["account_address"]
+                    ),
+                    params={},
+                )
+
+        assert resp.status_code == 200
+        assert resp.json()["data"] == {
+            "result_set": {
+                "count": 6,
+                "offset": None,
+                "limit": None,
+                "total": 6,
+            },
+            "positions": [
+                {
+                    "balance": 1000000,
+                    "exchange_balance": 0,
+                    "exchange_commitment": 0,
+                    "used": 0,
+                    "token": {
+                        "token_address": "0x0000000000000000000200000000000000000001",
+                        **self.expected_coupon_token(),
+                    },
+                },
+                {
+                    "balance": 1000000,
+                    "exchange_balance": 0,
+                    "exchange_commitment": 0,
+                    "used": 0,
+                    "token": {
+                        "token_address": "0x0000000000000000000200000000000000000002",
+                        **self.expected_coupon_token(),
+                    },
+                },
+                {
+                    "balance": 999900,
+                    "exchange_balance": 0,
+                    "exchange_commitment": 100,
+                    "used": 0,
+                    "token": {
+                        "token_address": "0x0000000000000000000200000000000000000003",
+                        **self.expected_coupon_token(),
+                    },
+                },
+                {
+                    "balance": 0,
+                    "exchange_balance": 0,
+                    "exchange_commitment": 1000000,
+                    "used": 0,
+                    "token": {
+                        "token_address": "0x0000000000000000000200000000000000000004",
+                        **self.expected_coupon_token(),
+                    },
+                },
+                {
+                    "balance": 999900,
+                    "exchange_balance": 0,
+                    "exchange_commitment": 0,
+                    "used": 100,
+                    "token": {
+                        "token_address": "0x0000000000000000000200000000000000000005",
+                        **self.expected_coupon_token(),
+                    },
+                },
+                {
+                    "balance": 0,
+                    "exchange_balance": 0,
+                    "exchange_commitment": 0,
+                    "used": 1000000,
+                    "token": {
+                        **self.expected_coupon_token(),
+                        "token_address": "0x0000000000000000000200000000000000000006",
+                    },
+                },
+            ],
+        }
+
+    # <Normal_5>
+    # List membership positions
+    @pytest.mark.parametrize("query_filter", [True, False])
+    def test_normal_5(
+        self, query_filter, client: TestClient, session: Session, shared_contract
+    ):
+        token_list_contract = shared_contract["TokenList"]
+        self.setup_data(session=session, shared_contract=shared_contract, index=0)
+
+        if query_filter:
+            with mock.patch(
+                "app.config.TOKEN_LIST_CONTRACT_ADDRESS", token_list_contract
+            ), mock.patch("app.config.BOND_TOKEN_ENABLED", True), mock.patch(
+                "app.config.SHARE_TOKEN_ENABLED", True
+            ), mock.patch(
+                "app.config.COUPON_TOKEN_ENABLED", True
+            ), mock.patch(
+                "app.config.MEMBERSHIP_TOKEN_ENABLED", True
+            ):
+                # Request target API
+                resp = client.get(
+                    self.apiurl.format(
+                        account_address=self.account_1["account_address"]
+                    ),
+                    params={"token_type_list": ["IbetMembership"]},
+                )
+        else:
+            with mock.patch(
+                "app.config.TOKEN_LIST_CONTRACT_ADDRESS", token_list_contract
+            ), mock.patch("app.config.BOND_TOKEN_ENABLED", False), mock.patch(
+                "app.config.SHARE_TOKEN_ENABLED", False
+            ), mock.patch(
+                "app.config.COUPON_TOKEN_ENABLED", False
+            ), mock.patch(
+                "app.config.MEMBERSHIP_TOKEN_ENABLED", True
+            ):
+                # Request target API
+                resp = client.get(
+                    self.apiurl.format(
+                        account_address=self.account_1["account_address"]
+                    ),
+                    params={},
+                )
+
+        assert resp.status_code == 200
+        assert resp.json()["data"] == {
+            "result_set": {
+                "count": 4,
+                "offset": None,
+                "limit": None,
+                "total": 4,
+            },
+            "positions": [
+                {
+                    "balance": 1000000,
+                    "exchange_balance": 0,
+                    "exchange_commitment": 0,
+                    "token": {
+                        "token_address": "0x0000000000000000000300000000000000000001",
+                        **self.expected_membership_token(),
+                    },
+                },
+                {
+                    "balance": 1000000,
+                    "exchange_balance": 0,
+                    "exchange_commitment": 0,
+                    "token": {
+                        "token_address": "0x0000000000000000000300000000000000000002",
+                        **self.expected_membership_token(),
+                    },
+                },
+                {
+                    "balance": 999900,
+                    "exchange_balance": 0,
+                    "exchange_commitment": 100,
+                    "token": {
+                        "token_address": "0x0000000000000000000300000000000000000003",
+                        **self.expected_membership_token(),
+                    },
+                },
+                {
+                    "balance": 0,
+                    "exchange_balance": 0,
+                    "exchange_commitment": 1000000,
+                    "token": {
+                        "token_address": "0x0000000000000000000300000000000000000004",
+                        **self.expected_membership_token(),
+                    },
+                },
+            ],
+        }
+
+    # <Normal_6>
+    # List multiple token type positions
+    @pytest.mark.parametrize("query_filter", [True, False])
+    def test_normal_6(
+        self, query_filter, client: TestClient, session: Session, shared_contract
+    ):
+        token_list_contract = shared_contract["TokenList"]
+        self.setup_data(session=session, shared_contract=shared_contract, index=0)
+
+        if query_filter:
+            with mock.patch(
+                "app.config.TOKEN_LIST_CONTRACT_ADDRESS", token_list_contract
+            ), mock.patch("app.config.BOND_TOKEN_ENABLED", True), mock.patch(
+                "app.config.SHARE_TOKEN_ENABLED", True
+            ):
+                # Request target API
+                resp = client.get(
+                    self.apiurl.format(
+                        account_address=self.account_1["account_address"]
+                    ),
+                    params={},
+                )
+        else:
+            with mock.patch(
+                "app.config.TOKEN_LIST_CONTRACT_ADDRESS", token_list_contract
+            ), mock.patch("app.config.BOND_TOKEN_ENABLED", True), mock.patch(
+                "app.config.SHARE_TOKEN_ENABLED", True
+            ):
+                # Request target API
+                resp = client.get(
+                    self.apiurl.format(
+                        account_address=self.account_1["account_address"]
+                    ),
+                    params={"token_type_list": ["IbetStraightBond", "IbetShare"]},
+                )
+
+        assert resp.status_code == 200
+        assert resp.json()["data"] == {
+            "result_set": {
+                "count": 12,
+                "offset": None,
+                "limit": None,
+                "total": 12,
+            },
+            "positions": [
+                {
+                    "balance": 1000000,
+                    "exchange_balance": 0,
+                    "exchange_commitment": 0,
+                    "pending_transfer": 0,
+                    "locked": 0,
+                    "token": {
+                        "token_address": "0x0000000000000000000000000000000000000001",
+                        "personal_info_address": shared_contract["PersonalInfo"][
+                            "address"
+                        ],
+                        **self.expected_bond_token(),
+                    },
+                },
+                {
+                    "balance": 1000000,
+                    "exchange_balance": 0,
+                    "exchange_commitment": 0,
+                    "pending_transfer": 0,
+                    "locked": 0,
+                    "token": {
+                        "token_address": "0x0000000000000000000000000000000000000002",
+                        "personal_info_address": shared_contract["PersonalInfo"][
+                            "address"
+                        ],
+                        **self.expected_bond_token(),
+                    },
+                },
+                {
+                    "balance": 999900,
+                    "exchange_balance": 0,
+                    "exchange_commitment": 100,
+                    "pending_transfer": 0,
+                    "locked": 0,
+                    "token": {
+                        "token_address": "0x0000000000000000000000000000000000000003",
+                        "personal_info_address": shared_contract["PersonalInfo"][
+                            "address"
+                        ],
+                        **self.expected_bond_token(),
+                    },
+                },
+                {
+                    "balance": 0,
+                    "exchange_balance": 0,
+                    "exchange_commitment": 1000000,
+                    "pending_transfer": 0,
+                    "locked": 0,
+                    "token": {
+                        "token_address": "0x0000000000000000000000000000000000000004",
+                        "personal_info_address": shared_contract["PersonalInfo"][
+                            "address"
+                        ],
+                        **self.expected_bond_token(),
+                    },
+                },
+                {
+                    "balance": 0,
+                    "exchange_balance": 0,
+                    "exchange_commitment": 0,
+                    "pending_transfer": 0,
+                    "locked": 3000,
+                    "token": {
+                        "token_address": "0x0000000000000000000000000000000000000005",
+                        "personal_info_address": shared_contract["PersonalInfo"][
+                            "address"
+                        ],
+                        **self.expected_bond_token(),
+                    },
+                },
+                {
+                    "balance": 1000000,
+                    "exchange_balance": 0,
+                    "exchange_commitment": 0,
+                    "pending_transfer": 0,
+                    "locked": 0,
+                    "token": {
+                        "token_address": "0x0000000000000000000100000000000000000001",
+                        "personal_info_address": shared_contract["PersonalInfo"][
+                            "address"
+                        ],
+                        **self.expected_share_token(),
+                    },
+                },
+                {
+                    "balance": 1000000,
+                    "exchange_balance": 0,
+                    "exchange_commitment": 0,
+                    "pending_transfer": 0,
+                    "locked": 0,
+                    "token": {
+                        "token_address": "0x0000000000000000000100000000000000000002",
+                        "personal_info_address": shared_contract["PersonalInfo"][
+                            "address"
+                        ],
+                        **self.expected_share_token(),
+                    },
+                },
+                {
+                    "balance": 999900,
+                    "exchange_balance": 0,
+                    "exchange_commitment": 0,
+                    "pending_transfer": 100,
+                    "locked": 0,
+                    "token": {
+                        "token_address": "0x0000000000000000000100000000000000000003",
+                        "personal_info_address": shared_contract["PersonalInfo"][
+                            "address"
+                        ],
+                        **self.expected_share_token(),
+                    },
+                },
+                {
+                    "balance": 0,
+                    "exchange_balance": 0,
+                    "exchange_commitment": 0,
+                    "pending_transfer": 1000000,
+                    "locked": 0,
+                    "token": {
+                        "token_address": "0x0000000000000000000100000000000000000004",
+                        "personal_info_address": shared_contract["PersonalInfo"][
+                            "address"
+                        ],
+                        **self.expected_share_token(),
+                    },
+                },
+                {
+                    "balance": 999900,
+                    "exchange_balance": 0,
+                    "exchange_commitment": 100,
+                    "pending_transfer": 0,
+                    "locked": 0,
+                    "token": {
+                        "token_address": "0x0000000000000000000100000000000000000005",
+                        "personal_info_address": shared_contract["PersonalInfo"][
+                            "address"
+                        ],
+                        **self.expected_share_token(),
+                    },
+                },
+                {
+                    "balance": 0,
+                    "exchange_balance": 0,
+                    "exchange_commitment": 1000000,
+                    "locked": 0,
+                    "pending_transfer": 0,
+                    "token": {
+                        "token_address": "0x0000000000000000000100000000000000000006",
+                        "personal_info_address": shared_contract["PersonalInfo"][
+                            "address"
+                        ],
+                        **self.expected_share_token(),
+                    },
+                },
+                {
+                    "balance": 0,
+                    "exchange_balance": 0,
+                    "exchange_commitment": 0,
+                    "pending_transfer": 0,
+                    "locked": 3000,
+                    "token": {
+                        "token_address": "0x0000000000000000000100000000000000000007",
+                        "personal_info_address": shared_contract["PersonalInfo"][
+                            "address"
+                        ],
+                        **self.expected_share_token(),
+                    },
+                },
+            ],
+        }
+
+    # <Normal_7>
+    # Pagination
+    def test_normal_7(self, client: TestClient, session: Session, shared_contract):
+        token_list_contract = shared_contract["TokenList"]
+        self.setup_data(session=session, shared_contract=shared_contract, index=0)
+
+        with mock.patch(
+            "app.config.TOKEN_LIST_CONTRACT_ADDRESS", token_list_contract
+        ), mock.patch("app.config.BOND_TOKEN_ENABLED", True), mock.patch(
+            "app.config.SHARE_TOKEN_ENABLED", True
+        ), mock.patch(
+            "app.config.COUPON_TOKEN_ENABLED", True
+        ), mock.patch(
+            "app.config.MEMBERSHIP_TOKEN_ENABLED", True
+        ):
+            # Request target API
+            resp = client.get(
+                self.apiurl.format(account_address=self.account_1["account_address"]),
+                params={"offset": 3, "limit": 5},
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["data"] == {
+            "result_set": {
+                "count": 22,
+                "offset": 3,
+                "limit": 5,
+                "total": 22,
+            },
+            "positions": [
+                {
+                    "balance": 0,
+                    "exchange_balance": 0,
+                    "exchange_commitment": 1000000,
+                    "pending_transfer": 0,
+                    "locked": 0,
+                    "token": {
+                        "token_address": "0x0000000000000000000000000000000000000004",
+                        "personal_info_address": shared_contract["PersonalInfo"][
+                            "address"
+                        ],
+                        **self.expected_bond_token(),
+                    },
+                },
+                {
+                    "balance": 0,
+                    "exchange_balance": 0,
+                    "exchange_commitment": 0,
+                    "pending_transfer": 0,
+                    "locked": 3000,
+                    "token": {
+                        "token_address": "0x0000000000000000000000000000000000000005",
+                        "personal_info_address": shared_contract["PersonalInfo"][
+                            "address"
+                        ],
+                        **self.expected_bond_token(),
+                    },
+                },
+                {
+                    "balance": 1000000,
+                    "exchange_balance": 0,
+                    "exchange_commitment": 0,
+                    "pending_transfer": 0,
+                    "locked": 0,
+                    "token": {
+                        "token_address": "0x0000000000000000000100000000000000000001",
+                        "personal_info_address": shared_contract["PersonalInfo"][
+                            "address"
+                        ],
+                        **self.expected_share_token(),
+                    },
+                },
+                {
+                    "balance": 1000000,
+                    "exchange_balance": 0,
+                    "exchange_commitment": 0,
+                    "pending_transfer": 0,
+                    "locked": 0,
+                    "token": {
+                        "token_address": "0x0000000000000000000100000000000000000002",
+                        "personal_info_address": shared_contract["PersonalInfo"][
+                            "address"
+                        ],
+                        **self.expected_share_token(),
+                    },
+                },
+                {
+                    "balance": 999900,
+                    "exchange_balance": 0,
+                    "exchange_commitment": 0,
+                    "pending_transfer": 100,
+                    "locked": 0,
+                    "token": {
+                        "token_address": "0x0000000000000000000100000000000000000003",
+                        "personal_info_address": shared_contract["PersonalInfo"][
+                            "address"
+                        ],
+                        **self.expected_share_token(),
+                    },
+                },
+            ],
+        }
+
+    # <Normal_8>
+    # Pagination(over offset)
+    def test_normal_8(self, client: TestClient, session: Session, shared_contract):
+        token_list_contract = shared_contract["TokenList"]
+        self.setup_data(session=session, shared_contract=shared_contract, index=0)
+
+        with mock.patch(
+            "app.config.TOKEN_LIST_CONTRACT_ADDRESS", token_list_contract
+        ), mock.patch("app.config.BOND_TOKEN_ENABLED", True), mock.patch(
+            "app.config.SHARE_TOKEN_ENABLED", True
+        ), mock.patch(
+            "app.config.COUPON_TOKEN_ENABLED", True
+        ), mock.patch(
+            "app.config.MEMBERSHIP_TOKEN_ENABLED", True
+        ):
+            # Request target API
+            resp = client.get(
+                self.apiurl.format(account_address=self.account_1["account_address"]),
+                params={"offset": 22, "limit": 1},
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["data"] == {
+            "result_set": {
+                "count": 22,
+                "offset": 22,
+                "limit": 1,
+                "total": 22,
+            },
+            "positions": [],
+        }
+
+    ###########################################################################
+    # Error
+    ###########################################################################
+
+    # <Error_1>
+    # ParameterError: offset/limit(minus value)
+    def test_error_1(self, client: TestClient, session: Session):
+        # Request target API
+        resp = client.get(
+            self.apiurl.format(account_address=self.account_1["account_address"]),
+            params={
+                "offset": -1,
+                "limit": -1,
+            },
+        )
+
+        # Assertion
+        assert resp.status_code == 400
+        assert resp.json()["meta"] == {
+            "code": 88,
+            "description": [
+                {
+                    "ctx": {"limit_value": 0},
+                    "loc": ["query", "offset"],
+                    "msg": "ensure this value is greater than or equal to 0",
+                    "type": "value_error.number.not_ge",
+                },
+                {
+                    "ctx": {"limit_value": 0},
+                    "loc": ["query", "limit"],
+                    "msg": "ensure this value is greater than or equal to 0",
+                    "type": "value_error.number.not_ge",
+                },
+            ],
+            "message": "Invalid Parameter",
+        }
+
+    # <Error_2>
+    # ParameterError: offset/limit(not int), include_token_details(not bool)
+    def test_error_2(self, client: TestClient, session: Session):
+        # Request target API
+        resp = client.get(
+            self.apiurl.format(account_address=self.account_1["account_address"]),
+            params={
+                "offset": "test",
+                "limit": "test",
+            },
+        )
+
+        # Assertion
+        assert resp.status_code == 400
+        assert resp.json()["meta"] == {
+            "code": 88,
+            "description": [
+                {
+                    "loc": ["query", "offset"],
+                    "msg": "value is not a valid integer",
+                    "type": "type_error.integer",
+                },
+                {
+                    "loc": ["query", "limit"],
+                    "msg": "value is not a valid integer",
+                    "type": "type_error.integer",
+                },
+            ],
+            "message": "Invalid Parameter",
+        }

--- a/tests/batch/indexer_Position_Bond_test.py
+++ b/tests/batch/indexer_Position_Bond_test.py
@@ -1288,16 +1288,18 @@ class TestProcessor:
             personal_info_contract["address"],
             self.issuer["account_address"],
         )
+        from_block = web3.eth.block_number
         for i in range(0, 5):
             # Transfer
             bond_transfer_to_exchange(
                 self.issuer, {"address": self.trader["account_address"]}, token, 1000
             )
+        to_block = web3.eth.block_number
 
         # Get events for token address
         events = Contract.get_contract(
             "IbetStraightBond", token["address"]
-        ).events.Transfer.get_logs(fromBlock=0, toBlock=10000)
+        ).events.Transfer.get_logs(fromBlock=from_block, toBlock=to_block)
         # Ensure 5 events squashed to 2 events
         assert len(events) == 5
         filtered_events = processor.remove_duplicate_event_by_token_account_desc(

--- a/tests/batch/indexer_Position_Coupon_test.py
+++ b/tests/batch/indexer_Position_Coupon_test.py
@@ -618,16 +618,18 @@ class TestProcessor:
             self.issuer, config.ZERO_ADDRESS, token_list_contract
         )
         self.listing_token(token["address"], session)
+        from_block = web3.eth.block_number
         for i in range(0, 5):
             # Transfer
             transfer_coupon_token(
                 self.issuer, token, self.trader["account_address"], 10000
             )
+        to_block = web3.eth.block_number
 
         # Get events for token address
         events = Contract.get_contract(
             "IbetCoupon", token["address"]
-        ).events.Transfer.get_logs(fromBlock=0, toBlock=10000)
+        ).events.Transfer.get_logs(fromBlock=from_block, toBlock=to_block)
         # Ensure 5 events squashed to 2 events
         assert len(events) == 5
         filtered_events = processor.remove_duplicate_event_by_token_account_desc(

--- a/tests/batch/indexer_Position_Membership_test.py
+++ b/tests/batch/indexer_Position_Membership_test.py
@@ -575,16 +575,18 @@ class TestProcessor:
             self.issuer, config.ZERO_ADDRESS, token_list_contract
         )
         self.listing_token(token["address"], session)
+        from_block = web3.eth.block_number
         for i in range(0, 5):
             # Transfer
             membership_transfer_to_exchange(
                 self.issuer, {"address": self.trader["account_address"]}, token, 10000
             )
+        to_block = web3.eth.block_number
 
         # Get events for token address
         events = Contract.get_contract(
             "IbetMembership", token["address"]
-        ).events.Transfer.get_logs(fromBlock=0, toBlock=10000)
+        ).events.Transfer.get_logs(fromBlock=from_block, toBlock=to_block)
         # Ensure 5 events squashed to 2 events
         assert len(events) == 5
         filtered_events = processor.remove_duplicate_event_by_token_account_desc(

--- a/tests/batch/indexer_Position_Share_test.py
+++ b/tests/batch/indexer_Position_Share_test.py
@@ -1271,16 +1271,18 @@ class TestProcessor:
             personal_info_contract["address"],
             self.issuer["account_address"],
         )
+        from_block = web3.eth.block_number
         for i in range(0, 5):
             # Transfer
             share_transfer_to_exchange(
                 self.issuer, {"address": self.trader["account_address"]}, token, 10000
             )
+        to_block = web3.eth.block_number
 
         # Get events for token address
         events = Contract.get_contract(
             "IbetShare", token["address"]
-        ).events.Transfer.get_logs(fromBlock=0, toBlock=10000)
+        ).events.Transfer.get_logs(fromBlock=from_block, toBlock=to_block)
         # Ensure 5 events squashed to 2 events
         assert len(events) == 5
         filtered_events = processor.remove_duplicate_event_by_token_account_desc(


### PR DESCRIPTION
Close: #1354 

### Changes

#### API

- GET: **/Position/{account_address}**
  - return position info across all token types.
  - result can be filtered with `token_type_list` query.