### PR TITLE
api: Eliminate duplication in owner list

### DIFF
--- a/app/api/routers/company_info.py
+++ b/app/api/routers/company_info.py
@@ -293,9 +293,8 @@ def has_listing_owner_function_creator(
     listing_owner_set: set[str],
 ) -> Callable[[dict], bool]:
     def has_listing_owner_function(company_info: dict):
-        for address in listing_owner_set:
-            if to_checksum_address(company_info["address"]) == address:
-                return True
+        if to_checksum_address(company_info["address"]) in listing_owner_set:
+            return True
         return False
 
     return has_listing_owner_function

--- a/app/api/routers/company_info.py
+++ b/app/api/routers/company_info.py
@@ -129,12 +129,12 @@ def list_all_companies(
         ).all()
 
     # Filter only issuers that issue the listed tokens
-    listing_owner_list = []
+    listing_owner_set = set()
     for token in available_tokens:
         try:
             owner_address_is_cached = [t for t in token[1:5] if t is not None]
             if owner_address_is_cached:
-                listing_owner_list.append(owner_address_is_cached[0])
+                listing_owner_set.add(owner_address_is_cached[0])
                 continue
 
             token_address = to_checksum_address(token[0].token_address)
@@ -147,11 +147,11 @@ def list_all_companies(
                 args=(),
                 default_returns=config.ZERO_ADDRESS,
             )
-            listing_owner_list.append(owner_address)
+            listing_owner_set.add(owner_address)
         except Exception as e:
             LOG.warning(e)
 
-    has_listing_owner_function = has_listing_owner_function_creator(listing_owner_list)
+    has_listing_owner_function = has_listing_owner_function_creator(listing_owner_set)
     filtered_company_list = filter(has_listing_owner_function, company_list)
 
     return json_response(
@@ -290,10 +290,10 @@ def get_token_model(token_template: str):
 
 
 def has_listing_owner_function_creator(
-    listing_owner_list: list[str],
+    listing_owner_set: set[str],
 ) -> Callable[[dict], bool]:
-    def has_listing_owner_function(company_info):
-        for address in listing_owner_list:
+    def has_listing_owner_function(company_info: dict):
+        for address in listing_owner_set:
             if to_checksum_address(company_info["address"]) == address:
                 return True
         return False

--- a/app/api/routers/token.py
+++ b/app/api/routers/token.py
@@ -388,7 +388,7 @@ def get_token_holders_collection(
     list_id: UUID = Path(
         description="Unique id to be assigned to each token holder list."
         "This must be Version4 UUID.",
-        example="cfd83622-34dc-4efe-a68b-2cc275d3d824",
+        examples=["cfd83622-34dc-4efe-a68b-2cc275d3d824"],
     ),
 ):
     """


### PR DESCRIPTION
Improve the performance of the `/Companies` API.

Since there was a logic that processed duplicated data in the loop processing, I eliminated the duplication of the data to be processed and improved the performance.