### PR TITLE
Remove unnecessary line in server stop func

### DIFF
--- a/bin/run_server.sh
+++ b/bin/run_server.sh
@@ -52,7 +52,6 @@ function start () {
 
 function stop () {
   ps -ef | grep gunicorn | awk '{print $2}' | xargs kill -9
-  ps -ef | grep "batch/processor_Block_Sync_Status.py" | awk '{print $2}' | xargs kill -9
 }
 
 


### PR DESCRIPTION
- Removed unnecessary kill command from stop function in  `./bin/run_server.sh`.
  - Currently, the `stop` function is not used from anywhere when server process is run in container environment.