### PR TITLE
Fix `liblzma` warning in image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,8 @@ RUN apt-get update -q \
  language-pack-ja-base \
  language-pack-ja \
  git \
- libyaml-cpp-dev
+ libyaml-cpp-dev \
+ liblzma-dev
 
 # remove unnessesory package files
 RUN apt clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -31,7 +31,8 @@ RUN apt-get update -q \
  language-pack-ja-base \
  language-pack-ja \
  git \
- libyaml-cpp-dev
+ libyaml-cpp-dev \
+ liblzma-dev
 
 # remove unnessesory package files
 RUN apt clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
Fixed warning like following in image build.

```bash
Step 10/19 : RUN . ~/.bash_profile  && pyenv install 3.11.2  && pyenv global 3.11.2  && pip install --upgrade pip
 ---> Running in 0662e9ecd5b9
Downloading Python-3.11.2.tar.xz...
-> https://www.python.org/ftp/python/3.11.2/Python-3.11.2.tar.xz
Installing Python-3.11.2...
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/apl/.pyenv/versions/3.11.2/lib/python3.11/lzma.py", line 27, in <module>
    from _lzma import *
ModuleNotFoundError: No module named '_lzma'
WARNING: The Python lzma extension was not compiled. Missing the lzma lib?
Installed Python-3.11.2 to /home/apl/.pyenv/versions/3.11.2
```