### PR TITLE
Tagging account address

### DIFF
--- a/app/model/db/__init__.py
+++ b/app/model/db/__init__.py
@@ -52,3 +52,4 @@ from .messaging import ChatWebhook, Mail
 from .node import Node
 from .notification import Notification, NotificationBlockNumber, NotificationType
 from .tokenholders import TokenHolder, TokenHolderBatchStatus, TokenHoldersList
+from .user_info import AccountTag

--- a/app/model/db/user_info.py
+++ b/app/model/db/user_info.py
@@ -1,0 +1,36 @@
+"""
+Copyright BOOSTRY Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+from sqlalchemy import String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.model.db.base import Base
+
+
+class AccountTag(Base):
+    """Account tag"""
+
+    __tablename__ = "account_tag"
+
+    account_address: Mapped[str] = mapped_column(String(42), primary_key=True)
+    account_tag: Mapped[str | None] = mapped_column(
+        String(50), nullable=True, index=True
+    )
+
+    FIELDS = {"account_address": str, "account_tag": str}
+    FIELDS.update(Base.FIELDS)

--- a/app/model/schema/__init__.py
+++ b/app/model/schema/__init__.py
@@ -162,4 +162,5 @@ from .user_info import (
     RetrievePaymentAccountRegistrationStatusResponse,
     RetrievePersonalInfoQuery,
     RetrievePersonalInfoRegistrationStatusResponse,
+    TaggingAccountAddressRequest,
 )

--- a/app/model/schema/token.py
+++ b/app/model/schema/token.py
@@ -55,10 +55,14 @@ class CreateTokenHoldersCollectionRequest(BaseModel):
 
 @dataclass
 class ListAllTokenHoldersQuery:
-    exclude_owner: Annotated[Optional[bool], Query(description="exclude owner")] = False
     offset: Annotated[Optional[int], Query(description="start position", ge=0)] = None
     limit: Annotated[Optional[int], Query(description="number of set", ge=0)] = None
 
+    account_tag: Annotated[
+        Optional[str], Query(description="account tag (**this affects total number**)")
+    ] = None
+
+    exclude_owner: Annotated[Optional[bool], Query(description="exclude owner")] = False
     amount: Annotated[Optional[int], Query(description="amount")] = None
     amount_operator: Annotated[
         Optional[ValueOperator],
@@ -162,6 +166,9 @@ class SearchTokenHoldersRequest(BaseModel):
 
 @dataclass
 class RetrieveTokenHoldersCountQuery:
+    account_tag: Annotated[
+        Optional[str], Query(description="account tag (**this affects total number**)")
+    ] = None
     exclude_owner: Annotated[Optional[bool], Query(description="exclude owner")] = False
 
 
@@ -169,6 +176,11 @@ class RetrieveTokenHoldersCountQuery:
 class ListAllTransferHistoryQuery:
     offset: Annotated[Optional[int], Query(description="start position", ge=0)] = None
     limit: Annotated[Optional[int], Query(description="number of set", ge=0)] = None
+
+    account_tag: Annotated[
+        Optional[str], Query(description="account tag (**this affects total number**)")
+    ] = None
+
     source_event: Annotated[
         Optional[TransferSourceEvent], Query(description="source event of transfer")
     ] = None
@@ -237,6 +249,11 @@ class SearchTransferHistoryRequest(BaseModel):
 class ListAllTransferApprovalHistoryQuery:
     offset: Annotated[Optional[int], Query(description="start position", ge=0)] = None
     limit: Annotated[Optional[int], Query(description="number of set", ge=0)] = None
+
+    account_tag: Annotated[
+        Optional[str], Query(description="account tag (**this affects total number**)")
+    ] = None
+
     from_address: Annotated[Optional[str], Query(description="from address")] = None
     to_address: Annotated[Optional[str], Query(description="to address")] = None
     value: Annotated[Optional[int], Query(description="value")] = None

--- a/app/model/schema/user_info.py
+++ b/app/model/schema/user_info.py
@@ -33,6 +33,13 @@ from app.model.schema.base import ValidatedEthereumAddress
 ############################
 # REQUEST
 ############################
+class TaggingAccountAddressRequest(BaseModel):
+    account_address: ValidatedEthereumAddress = Field(
+        ..., description="Account address"
+    )
+    account_tag: str | None = Field(..., description="Account tag", max_length=50)
+
+
 @dataclass
 class RetrievePaymentAccountQuery:
     account_address: Annotated[

--- a/docs/ibet_wallet_api.yaml
+++ b/docs/ibet_wallet_api.yaml
@@ -701,13 +701,39 @@ paths:
               schema:
                 $ref: '#/components/schemas/RequestValidationErrorResponse'
           description: Bad Request
+  /User/Tag:
+    post:
+      tags:
+        - user_info
+      summary: Tagging account address
+      description: Tag any account address
+      operationId: TaggingAccountAddress
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TaggingAccountAddressRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RequestValidationErrorResponse'
   /User/PaymentAccount:
     get:
       tags:
         - user_info
-      summary: Registration status to PaymentGateway Contract
+      summary: Retrieve registration status for PersonalInfo contract
       description: Returns payment registration status of given account.
-      operationId: PaymentAccount
+      operationId: RetrievePaymentAccountRegistrationStatus
       parameters:
         - name: account_address
           in: query
@@ -743,9 +769,9 @@ paths:
     get:
       tags:
         - user_info
-      summary: Registration status to PersonalInfo Contract
+      summary: Retrieve registration status for PersonalInfo contract
       description: Returns personal information about given address.
-      operationId: PersonalInfo
+      operationId: RetrievePersonalInfoRegistrationStatus
       parameters:
         - name: account_address
           in: query
@@ -2575,17 +2601,6 @@ paths:
             description: Token address
             title: Token Address
           description: Token address
-        - name: exclude_owner
-          in: query
-          required: false
-          schema:
-            anyOf:
-              - type: boolean
-              - type: 'null'
-            description: exclude owner
-            default: false
-            title: Exclude Owner
-          description: exclude owner
         - name: offset
           in: query
           required: false
@@ -2608,6 +2623,27 @@ paths:
             description: number of set
             title: Limit
           description: number of set
+        - name: account_tag
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: 'null'
+            description: account tag (**this affects total number**)
+            title: Account Tag
+          description: account tag (**this affects total number**)
+        - name: exclude_owner
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - type: boolean
+              - type: 'null'
+            description: exclude owner
+            default: false
+            title: Exclude Owner
+          description: exclude owner
         - name: amount
           in: query
           required: false
@@ -2799,6 +2835,16 @@ paths:
             description: Token address
             title: Token Address
           description: Token address
+        - name: account_tag
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: 'null'
+            description: account tag (**this affects total number**)
+            title: Account Tag
+          description: account tag (**this affects total number**)
         - name: exclude_owner
           in: query
           required: false
@@ -2970,6 +3016,16 @@ paths:
             description: number of set
             title: Limit
           description: number of set
+        - name: account_tag
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: 'null'
+            description: account tag (**this affects total number**)
+            title: Account Tag
+          description: account tag (**this affects total number**)
         - name: source_event
           in: query
           required: false
@@ -3149,6 +3205,16 @@ paths:
             description: number of set
             title: Limit
           description: number of set
+        - name: account_tag
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: 'null'
+            description: account tag (**this affects total number**)
+            title: Account Tag
+          description: account tag (**this affects total number**)
         - name: from_address
           in: query
           required: false
@@ -10395,6 +10461,24 @@ components:
       required:
         - meta
       title: SuspendedTokenErrorResponse
+    TaggingAccountAddressRequest:
+      properties:
+        account_address:
+          type: string
+          title: Account Address
+          description: Account address
+        account_tag:
+          anyOf:
+            - type: string
+              maxLength: 50
+            - type: 'null'
+          title: Account Tag
+          description: Account tag
+      type: object
+      required:
+        - account_address
+        - account_tag
+      title: TaggingAccountAddressRequest
     Tick:
       properties:
         block_timestamp:

--- a/migrations/versions/4164b4e8dfe6_v23_12_0_feature_1447.py
+++ b/migrations/versions/4164b4e8dfe6_v23_12_0_feature_1447.py
@@ -1,0 +1,50 @@
+"""v23_12_0_feature_1447
+
+Revision ID: 4164b4e8dfe6
+Revises: 550546d384e7
+Create Date: 2023-11-21 11:17:58.139399
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+from app.database import get_db_schema
+
+# revision identifiers, used by Alembic.
+revision = "4164b4e8dfe6"
+down_revision = "550546d384e7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    connection = op.get_bind()
+
+    op.create_table(
+        "account_tag",
+        sa.Column("account_address", sa.String(length=42), nullable=False),
+        sa.Column("account_tag", sa.String(length=50), nullable=True),
+        sa.Column("created", sa.DateTime(), nullable=True),
+        sa.Column("modified", sa.DateTime(), nullable=True),
+        sa.PrimaryKeyConstraint("account_address"),
+        schema=get_db_schema(),
+    )
+    op.create_index(
+        op.f("ix_account_tag_account_tag"),
+        "account_tag",
+        ["account_tag"],
+        unique=False,
+        schema=get_db_schema(),
+    )
+
+
+def downgrade():
+    connection = op.get_bind()
+
+    op.drop_index(
+        op.f("ix_account_tag_account_tag"),
+        table_name="account_tag",
+        schema=get_db_schema(),
+    )
+    op.drop_table("account_tag", schema=get_db_schema())

--- a/tests/app/token_TransferHistory_test.py
+++ b/tests/app/token_TransferHistory_test.py
@@ -19,7 +19,7 @@ SPDX-License-Identifier: Apache-2.0
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
-from app.model.db import IDXTransfer, IDXTransferSourceEventType, Listing
+from app.model.db import AccountTag, IDXTransfer, IDXTransferSourceEventType, Listing
 
 
 class TestTokenTransferHistory:
@@ -131,7 +131,7 @@ class TestTokenTransferHistory:
 
     # Normal_3_1
     # Transferイベントあり：2件
-    def test_normal_3(self, client: TestClient, session: Session):
+    def test_normal_3_1(self, client: TestClient, session: Session):
         listing = {
             "token_address": self.token_address,
             "is_public": True,
@@ -198,10 +198,224 @@ class TestTokenTransferHistory:
         assert data[1]["source_event"] == IDXTransferSourceEventType.UNLOCK.value
         assert data[1]["data"] == {"message": "unlock"}
 
-    # Normal_3_2
+    # Normal_3_2_1
+    # Transferイベントあり：2件
+    # Filter(account_tag: from_address)
+    def test_normal_3_2_1(self, client: TestClient, session: Session):
+        # データ準備：Listing
+        listing = {
+            "token_address": self.token_address,
+            "is_public": True,
+        }
+        self.insert_listing(session, listing=listing)
+
+        # データ準備：AccountTag
+        account_tag = AccountTag()
+        account_tag.account_address = self.from_address
+        account_tag.account_tag = "test_tag"
+        session.add(account_tag)
+        session.commit()
+
+        # データ準備：IDXTransfer
+        transfer_event_1 = {
+            "transaction_hash": self.transaction_hash,
+            "token_address": self.token_address,
+            "from_address": self.from_address,
+            "to_address": self.to_address,
+            "value": 10,
+        }
+        self.insert_transfer_event(
+            session=session,
+            transfer_event=transfer_event_1,
+            transfer_source_event=IDXTransferSourceEventType.TRANSFER,
+            transfer_event_data=None,
+        )
+
+        transfer_event_2 = {
+            "transaction_hash": self.transaction_hash,
+            "token_address": self.token_address,
+            "from_address": self.to_address,
+            "to_address": self.from_address,
+            "value": 20,
+        }
+        self.insert_transfer_event(
+            session=session,
+            transfer_event=transfer_event_2,
+            transfer_source_event=IDXTransferSourceEventType.UNLOCK,
+            transfer_event_data={"message": "unlock"},
+        )
+
+        # テスト対象API呼び出し
+        apiurl = self.apiurl_base.format(contract_address=self.token_address)
+        resp = client.get(apiurl, params={"account_tag": "test_tag"})
+
+        # 検証
+        assert resp.status_code == 200
+        assert resp.json()["meta"] == {"code": 200, "message": "OK"}
+        assert resp.json()["data"]["result_set"] == {
+            "count": 2,
+            "offset": None,
+            "limit": None,
+            "total": 2,
+        }
+        data = resp.json()["data"]["transfer_history"]
+        assert len(data) == 2
+
+        assert data[0]["transaction_hash"] == transfer_event_1["transaction_hash"]
+        assert data[0]["token_address"] == transfer_event_1["token_address"]
+        assert data[0]["from_address"] == transfer_event_1["from_address"]
+        assert data[0]["to_address"] == transfer_event_1["to_address"]
+        assert data[0]["value"] == transfer_event_1["value"]
+        assert data[0]["source_event"] == IDXTransferSourceEventType.TRANSFER.value
+        assert data[0]["data"] is None
+
+        assert data[1]["transaction_hash"] == transfer_event_2["transaction_hash"]
+        assert data[1]["token_address"] == transfer_event_2["token_address"]
+        assert data[1]["from_address"] == transfer_event_2["from_address"]
+        assert data[1]["to_address"] == transfer_event_2["to_address"]
+        assert data[1]["value"] == transfer_event_2["value"]
+        assert data[1]["source_event"] == IDXTransferSourceEventType.UNLOCK.value
+        assert data[1]["data"] == {"message": "unlock"}
+
+    # Normal_3_2_2
+    # Transferイベントあり：2件
+    # Filter (account_tag: to_address)
+    def test_normal_3_2_2(self, client: TestClient, session: Session):
+        # データ準備：Listing
+        listing = {
+            "token_address": self.token_address,
+            "is_public": True,
+        }
+        self.insert_listing(session, listing=listing)
+
+        # データ準備：AccountTag
+        account_tag = AccountTag()
+        account_tag.account_address = self.to_address
+        account_tag.account_tag = "test_tag"
+        session.add(account_tag)
+        session.commit()
+
+        # データ準備：IDXTransfer
+        transfer_event_1 = {
+            "transaction_hash": self.transaction_hash,
+            "token_address": self.token_address,
+            "from_address": self.from_address,
+            "to_address": self.to_address,
+            "value": 10,
+        }
+        self.insert_transfer_event(
+            session=session,
+            transfer_event=transfer_event_1,
+            transfer_source_event=IDXTransferSourceEventType.TRANSFER,
+            transfer_event_data=None,
+        )
+
+        transfer_event_2 = {
+            "transaction_hash": self.transaction_hash,
+            "token_address": self.token_address,
+            "from_address": self.to_address,
+            "to_address": self.from_address,
+            "value": 20,
+        }
+        self.insert_transfer_event(
+            session=session,
+            transfer_event=transfer_event_2,
+            transfer_source_event=IDXTransferSourceEventType.UNLOCK,
+            transfer_event_data={"message": "unlock"},
+        )
+
+        # テスト対象API呼び出し
+        apiurl = self.apiurl_base.format(contract_address=self.token_address)
+        resp = client.get(apiurl, params={"account_tag": "test_tag"})
+
+        # 検証
+        assert resp.status_code == 200
+        assert resp.json()["meta"] == {"code": 200, "message": "OK"}
+        assert resp.json()["data"]["result_set"] == {
+            "count": 2,
+            "offset": None,
+            "limit": None,
+            "total": 2,
+        }
+        data = resp.json()["data"]["transfer_history"]
+        assert len(data) == 2
+
+        assert data[0]["transaction_hash"] == transfer_event_1["transaction_hash"]
+        assert data[0]["token_address"] == transfer_event_1["token_address"]
+        assert data[0]["from_address"] == transfer_event_1["from_address"]
+        assert data[0]["to_address"] == transfer_event_1["to_address"]
+        assert data[0]["value"] == transfer_event_1["value"]
+        assert data[0]["source_event"] == IDXTransferSourceEventType.TRANSFER.value
+        assert data[0]["data"] is None
+
+        assert data[1]["transaction_hash"] == transfer_event_2["transaction_hash"]
+        assert data[1]["token_address"] == transfer_event_2["token_address"]
+        assert data[1]["from_address"] == transfer_event_2["from_address"]
+        assert data[1]["to_address"] == transfer_event_2["to_address"]
+        assert data[1]["value"] == transfer_event_2["value"]
+        assert data[1]["source_event"] == IDXTransferSourceEventType.UNLOCK.value
+        assert data[1]["data"] == {"message": "unlock"}
+
+    # Normal_3_2_3
+    # Transferイベントあり：2件
+    # Filter (account_tag: ヒットしない)
+    def test_normal_3_2_3(self, client: TestClient, session: Session):
+        # データ準備：Listing
+        listing = {
+            "token_address": self.token_address,
+            "is_public": True,
+        }
+        self.insert_listing(session, listing=listing)
+
+        # データ準備：IDXTransfer
+        transfer_event_1 = {
+            "transaction_hash": self.transaction_hash,
+            "token_address": self.token_address,
+            "from_address": self.from_address,
+            "to_address": self.to_address,
+            "value": 10,
+        }
+        self.insert_transfer_event(
+            session=session,
+            transfer_event=transfer_event_1,
+            transfer_source_event=IDXTransferSourceEventType.TRANSFER,
+            transfer_event_data=None,
+        )
+
+        transfer_event_2 = {
+            "transaction_hash": self.transaction_hash,
+            "token_address": self.token_address,
+            "from_address": self.to_address,
+            "to_address": self.from_address,
+            "value": 20,
+        }
+        self.insert_transfer_event(
+            session=session,
+            transfer_event=transfer_event_2,
+            transfer_source_event=IDXTransferSourceEventType.UNLOCK,
+            transfer_event_data={"message": "unlock"},
+        )
+
+        # テスト対象API呼び出し
+        apiurl = self.apiurl_base.format(contract_address=self.token_address)
+        resp = client.get(apiurl, params={"account_tag": "test_tag"})
+
+        # 検証
+        assert resp.status_code == 200
+        assert resp.json()["meta"] == {"code": 200, "message": "OK"}
+        assert resp.json()["data"]["result_set"] == {
+            "count": 0,
+            "offset": None,
+            "limit": None,
+            "total": 0,
+        }
+        data = resp.json()["data"]["transfer_history"]
+        assert len(data) == 0
+
+    # Normal_4_1
     # Transferイベントあり：2件
     # Filter(source_event)
-    def test_normal_3_2(self, client: TestClient, session: Session):
+    def test_normal_4_1(self, client: TestClient, session: Session):
         listing = {
             "token_address": self.token_address,
             "is_public": True,
@@ -262,10 +476,10 @@ class TestTokenTransferHistory:
         assert data[0]["source_event"] == IDXTransferSourceEventType.UNLOCK.value
         assert data[0]["data"] == {"message": "unlock"}
 
-    # Normal_3_3
+    # Normal_4_2
     # Transferイベントあり：2件
     # Filter(data)
-    def test_normal_3_3(self, client: TestClient, session: Session):
+    def test_normal_4_2(self, client: TestClient, session: Session):
         listing = {
             "token_address": self.token_address,
             "is_public": True,
@@ -324,10 +538,10 @@ class TestTokenTransferHistory:
         assert data[0]["source_event"] == IDXTransferSourceEventType.UNLOCK.value
         assert data[0]["data"] == {"message": "unlock"}
 
-    # Normal_3_4_1
+    # Normal_4_3_1
     # Transferイベントあり：2件
     # Filter(value_operator: =)
-    def test_normal_3_5_1(self, client: TestClient, session: Session):
+    def test_normal_4_3_1(self, client: TestClient, session: Session):
         listing = {
             "token_address": self.token_address,
             "is_public": True,
@@ -387,10 +601,10 @@ class TestTokenTransferHistory:
         assert data[0]["source_event"] == IDXTransferSourceEventType.TRANSFER.value
         assert data[0]["data"] is None
 
-    # Normal_3_4_2
+    # Normal_4_3_2
     # Transferイベントあり：2件
     # Filter(value_operator: >=)
-    def test_normal_3_5_2(self, client: TestClient, session: Session):
+    def test_normal_4_3_2(self, client: TestClient, session: Session):
         listing = {
             "token_address": self.token_address,
             "is_public": True,
@@ -450,10 +664,10 @@ class TestTokenTransferHistory:
         assert data[0]["source_event"] == IDXTransferSourceEventType.UNLOCK.value
         assert data[0]["data"] == {"message": "unlock"}
 
-    # Normal_3_4_3
+    # Normal_4_3_3
     # Transferイベントあり：2件
     # Filter(value_operator: <=)
-    def test_normal_3_5_3(self, client: TestClient, session: Session):
+    def test_normal_4_3_3(self, client: TestClient, session: Session):
         listing = {
             "token_address": self.token_address,
             "is_public": True,
@@ -513,10 +727,10 @@ class TestTokenTransferHistory:
         assert data[0]["source_event"] == IDXTransferSourceEventType.TRANSFER.value
         assert data[0]["data"] is None
 
-    # Normal_3_5
+    # Normal_4_4
     # Transferイベントあり：2件
     # Filter(transaction_hash)
-    def test_normal_3_5(self, client: TestClient, session: Session):
+    def test_normal_4_4(self, client: TestClient, session: Session):
         listing = {
             "token_address": self.token_address,
             "is_public": True,
@@ -577,10 +791,10 @@ class TestTokenTransferHistory:
         assert data[0]["source_event"] == IDXTransferSourceEventType.TRANSFER.value
         assert data[0]["data"] is None
 
-    # Normal_3_6
+    # Normal_4_5
     # Transferイベントあり：2件
     # Filter(from_address)
-    def test_normal_3_6(self, client: TestClient, session: Session):
+    def test_normal_4_5(self, client: TestClient, session: Session):
         listing = {
             "token_address": self.token_address,
             "is_public": True,
@@ -639,10 +853,10 @@ class TestTokenTransferHistory:
         assert data[0]["source_event"] == IDXTransferSourceEventType.TRANSFER.value
         assert data[0]["data"] is None
 
-    # Normal_3_7
+    # Normal_4_6
     # Transferイベントあり：2件
     # Filter(to_address)
-    def test_normal_3_7(self, client: TestClient, session: Session):
+    def test_normal_4_6(self, client: TestClient, session: Session):
         listing = {
             "token_address": self.token_address,
             "is_public": True,
@@ -701,10 +915,10 @@ class TestTokenTransferHistory:
         assert data[0]["source_event"] == IDXTransferSourceEventType.TRANSFER.value
         assert data[0]["data"] is None
 
-    # Normal_4
+    # Normal_5_1
     # offset=1, limit=設定なし
     # Transferイベントあり：2件
-    def test_normal_4(self, client: TestClient, session: Session):
+    def test_normal_5_1(self, client: TestClient, session: Session):
         listing = {
             "token_address": self.token_address,
             "is_public": True,
@@ -764,10 +978,10 @@ class TestTokenTransferHistory:
         assert data[0]["source_event"] == IDXTransferSourceEventType.UNLOCK.value
         assert data[0]["data"] == {"message": "unlock"}
 
-    # Normal_5
+    # Normal_5_2
     # offset=0, limit=設定なし
     # Transferイベントあり：2件
-    def test_normal_5(self, client: TestClient, session: Session):
+    def test_normal_5_2(self, client: TestClient, session: Session):
         listing = {
             "token_address": self.token_address,
             "is_public": True,
@@ -835,10 +1049,10 @@ class TestTokenTransferHistory:
         assert data[1]["source_event"] == IDXTransferSourceEventType.UNLOCK.value
         assert data[1]["data"] == {"message": "unlock"}
 
-    # Normal_6
+    # Normal_5_3
     # offset =設定なし, limit=1
     # Transferイベントあり：2件
-    def test_normal_6(self, client: TestClient, session: Session):
+    def test_normal_5_3(self, client: TestClient, session: Session):
         listing = {
             "token_address": self.token_address,
             "is_public": True,

--- a/tests/app/userinfo_TaggingAccountAddress_test.py
+++ b/tests/app/userinfo_TaggingAccountAddress_test.py
@@ -1,0 +1,144 @@
+"""
+Copyright BOOSTRY Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.model.db import AccountTag
+from tests.account_config import eth_account
+
+
+class TestTaggingAccountAddress:
+    # テスト対象API
+    api_url = "/User/Tag"
+
+    # テストアカウント
+    test_account = eth_account["user1"]
+
+    ###########################################################################
+    # Normal
+    ###########################################################################
+
+    # <Normal_1>
+    # 新規データ登録
+    def test_normal_1(self, client: TestClient, session: Session, shared_contract):
+        # Call API
+        request_params = {
+            "account_address": self.test_account["account_address"],
+            "account_tag": "test_tag",
+        }
+        resp = client.post(self.api_url, json=request_params)
+
+        # Assertion
+        assert resp.status_code == 200
+        assert resp.json()["meta"] == {"code": 200, "message": "OK"}
+
+        account_tag_af = session.scalars(select(AccountTag).limit(1)).first()
+        assert account_tag_af.account_address == self.test_account["account_address"]
+        assert account_tag_af.account_tag == "test_tag"
+
+    # <Normal_2_1>
+    # 更新登録
+    def test_normal_2_1(self, client: TestClient, session: Session, shared_contract):
+        # Prepare data
+        account_tag = AccountTag()
+        account_tag.account_address = self.test_account["account_address"]
+        account_tag.account_tag = "test_tag_bf"
+        session.add(account_tag)
+        session.commit()
+
+        # Call API
+        request_params = {
+            "account_address": self.test_account["account_address"],
+            "account_tag": "test_tag_af",
+        }
+        resp = client.post(self.api_url, json=request_params)
+
+        # Assertion
+        assert resp.status_code == 200
+        assert resp.json()["meta"] == {"code": 200, "message": "OK"}
+
+        account_tag_af = session.scalars(select(AccountTag).limit(1)).first()
+        assert account_tag_af.account_address == self.test_account["account_address"]
+        assert account_tag_af.account_tag == "test_tag_af"
+
+    # <Normal_2_2>
+    # 更新登録（Noneに更新）
+    def test_normal_2_2(self, client: TestClient, session: Session, shared_contract):
+        # Prepare data
+        account_tag = AccountTag()
+        account_tag.account_address = self.test_account["account_address"]
+        account_tag.account_tag = "test_tag_bf"
+        session.add(account_tag)
+        session.commit()
+
+        # Call API
+        request_params = {
+            "account_address": self.test_account["account_address"],
+            "account_tag": None,
+        }
+        resp = client.post(self.api_url, json=request_params)
+
+        # Assertion
+        assert resp.status_code == 200
+        assert resp.json()["meta"] == {"code": 200, "message": "OK"}
+
+        account_tag_af = session.scalars(select(AccountTag).limit(1)).first()
+        assert account_tag_af.account_address == self.test_account["account_address"]
+        assert account_tag_af.account_tag is None
+
+    ###########################################################################
+    # Error
+    ###########################################################################
+
+    # <Error_1>
+    # Invalid Parameter
+    def test_error_1(self, client: TestClient, session: Session, shared_contract):
+        # Call API
+        request_params = {
+            "account_address": "invalid_account_address",
+            "account_tag": "a" * 51,
+        }
+        resp = client.post(self.api_url, json=request_params)
+
+        # Assertion
+        assert resp.status_code == 400
+        assert resp.json()["meta"] == {
+            "code": 88,
+            "message": "Invalid Parameter",
+            "description": [
+                {
+                    "type": "value_error",
+                    "loc": ["body", "account_address"],
+                    "msg": "Value error, Invalid ethereum address",
+                    "input": "invalid_account_address",
+                    "ctx": {"error": {}},
+                },
+                {
+                    "type": "string_too_long",
+                    "loc": ["body", "account_tag"],
+                    "msg": "String should have at most 50 characters",
+                    "input": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    "ctx": {"max_length": 50},
+                },
+            ],
+        }
+
+        account_tag_af = session.scalars(select(AccountTag).limit(1)).first()
+        assert account_tag_af is None


### PR DESCRIPTION
Close: #1447

- Add an API to add tags to account addresses.
  - `GET: /User/Tag`
- Add account tag as a request query for the following API.
  - `GET: /Token//{token_address}/Holders`
  - `GET: /Token/{token_address}/Holders/Count`
  - `GET: /Token/{token_address}/TransferHistory`
  - `GET: /Token/{token_address}/TransferApprovalHistory`

Currently, I have not made any changes to the `**/Search` API, but I think there is no problem in deleting it if it is not used.