### PR TITLE
Fix to use same DB engine setting parameters in async batches

### DIFF
--- a/app/database/__init__.py
+++ b/app/database/__init__.py
@@ -92,6 +92,13 @@ AsyncSessionLocal = async_sessionmaker(
     bind=async_engine,
     class_=AsyncSession,
 )
+BatchAsyncSessionLocal = async_sessionmaker(
+    autocommit=False,
+    autoflush=True,
+    expire_on_commit=False,
+    bind=batch_async_engine,
+    class_=AsyncSession,
+)
 
 
 def db_session():

--- a/app/log.py
+++ b/app/log.py
@@ -23,6 +23,8 @@ from app import config
 logging.basicConfig(level=config.LOG_LEVEL)
 LOG = logging.getLogger("ibet_wallet_app")
 LOG.propagate = False
+logging.getLogger("httpx").setLevel(logging.WARNING)
+logging.getLogger("httpcore").setLevel(logging.WARNING)
 
 if config.APP_ENV == "live":
     stream_handler = logging.StreamHandler(open(config.APP_LOGFILE, "a"))

--- a/batch/indexer_Block_Tx_Data.py
+++ b/batch/indexer_Block_Tx_Data.py
@@ -33,7 +33,7 @@ sys.path.append(path)
 import log
 
 from app.config import WEB3_CHAINID
-from app.database import batch_async_engine
+from app.database import BatchAsyncSessionLocal
 from app.errors import ServiceUnavailable
 from app.model.db import IDXBlockData, IDXBlockDataBlockNumber, IDXTxData
 from app.utils.web3_utils import AsyncWeb3Wrapper
@@ -49,7 +49,7 @@ class Processor:
 
     @staticmethod
     def __get_db_session():
-        return AsyncSession(autocommit=False, autoflush=True, bind=batch_async_engine)
+        return BatchAsyncSessionLocal()
 
     async def process(self):
         local_session = self.__get_db_session()

--- a/batch/indexer_CompanyList.py
+++ b/batch/indexer_CompanyList.py
@@ -33,7 +33,7 @@ sys.path.append(path)
 import log
 
 from app.config import COMPANY_LIST_SLEEP_INTERVAL, COMPANY_LIST_URL, REQUEST_TIMEOUT
-from app.database import batch_async_engine
+from app.database import BatchAsyncSessionLocal
 from app.errors import ServiceUnavailable
 from app.model.db import Company
 
@@ -58,9 +58,7 @@ class Processor:
             LOG.exception(f"Failed to get company list: {e}")
             return
 
-        db_session = AsyncSession(
-            autocommit=False, autoflush=True, bind=batch_async_engine
-        )
+        db_session = BatchAsyncSessionLocal()
         try:
             # Upsert company list
             updated_company_dict: dict[str, True] = {}

--- a/batch/indexer_Consume_Coupon.py
+++ b/batch/indexer_Consume_Coupon.py
@@ -36,7 +36,7 @@ import log
 
 from app.config import TOKEN_LIST_CONTRACT_ADDRESS, TZ, ZERO_ADDRESS
 from app.contracts import AsyncContract
-from app.database import batch_async_engine
+from app.database import BatchAsyncSessionLocal
 from app.errors import ServiceUnavailable
 from app.model.db import IDXConsumeCoupon, Listing
 from app.model.schema.base import TokenType
@@ -60,7 +60,7 @@ class Processor:
 
     @staticmethod
     def __get_db_session():
-        return AsyncSession(autocommit=False, autoflush=True, bind=batch_async_engine)
+        return BatchAsyncSessionLocal()
 
     async def initial_sync(self):
         local_session = self.__get_db_session()

--- a/batch/indexer_DEX.py
+++ b/batch/indexer_DEX.py
@@ -38,7 +38,7 @@ from app.config import (
     TZ,
 )
 from app.contracts import AsyncContract
-from app.database import batch_async_engine
+from app.database import BatchAsyncSessionLocal
 from app.errors import ServiceUnavailable
 from app.model.db import (
     AgreementStatus,
@@ -78,12 +78,7 @@ class Processor:
 
     @staticmethod
     def __get_db_session():
-        return AsyncSession(
-            autocommit=False,
-            autoflush=True,
-            expire_on_commit=False,
-            bind=batch_async_engine,
-        )
+        return BatchAsyncSessionLocal()
 
     async def initial_sync(self):
         local_session = self.__get_db_session()

--- a/batch/indexer_Position_Bond.py
+++ b/batch/indexer_Position_Bond.py
@@ -38,7 +38,7 @@ import log
 
 from app.config import TOKEN_LIST_CONTRACT_ADDRESS, ZERO_ADDRESS
 from app.contracts import AsyncContract
-from app.database import batch_async_engine
+from app.database import BatchAsyncSessionLocal
 from app.errors import ServiceUnavailable
 from app.model.db import (
     IDXLock,
@@ -155,12 +155,7 @@ class Processor:
 
     @staticmethod
     def __get_db_session():
-        return AsyncSession(
-            autocommit=False,
-            autoflush=True,
-            expire_on_commit=False,
-            bind=batch_async_engine,
-        )
+        return BatchAsyncSessionLocal()
 
     async def initial_sync(self):
         local_session = self.__get_db_session()

--- a/batch/indexer_Position_Coupon.py
+++ b/batch/indexer_Position_Coupon.py
@@ -35,7 +35,7 @@ import log
 
 from app.config import TOKEN_LIST_CONTRACT_ADDRESS, ZERO_ADDRESS
 from app.contracts import AsyncContract
-from app.database import batch_async_engine
+from app.database import BatchAsyncSessionLocal
 from app.errors import ServiceUnavailable
 from app.model.db import IDXPosition, IDXPositionCouponBlockNumber, Listing
 from app.model.schema.base import TokenType
@@ -143,12 +143,7 @@ class Processor:
 
     @staticmethod
     def __get_db_session():
-        return AsyncSession(
-            autocommit=False,
-            autoflush=True,
-            expire_on_commit=False,
-            bind=batch_async_engine,
-        )
+        return BatchAsyncSessionLocal()
 
     async def initial_sync(self):
         local_session = self.__get_db_session()

--- a/batch/indexer_Position_Membership.py
+++ b/batch/indexer_Position_Membership.py
@@ -35,7 +35,7 @@ import log
 
 from app.config import TOKEN_LIST_CONTRACT_ADDRESS, ZERO_ADDRESS
 from app.contracts import AsyncContract
-from app.database import batch_async_engine
+from app.database import BatchAsyncSessionLocal
 from app.errors import ServiceUnavailable
 from app.model.db import IDXPosition, IDXPositionMembershipBlockNumber, Listing
 from app.model.schema.base import TokenType
@@ -143,12 +143,7 @@ class Processor:
 
     @staticmethod
     def __get_db_session():
-        return AsyncSession(
-            autocommit=False,
-            autoflush=True,
-            expire_on_commit=False,
-            bind=batch_async_engine,
-        )
+        return BatchAsyncSessionLocal()
 
     async def initial_sync(self):
         local_session = self.__get_db_session()

--- a/batch/indexer_Position_Share.py
+++ b/batch/indexer_Position_Share.py
@@ -37,7 +37,7 @@ import log
 
 from app.config import TOKEN_LIST_CONTRACT_ADDRESS, ZERO_ADDRESS
 from app.contracts import AsyncContract
-from app.database import batch_async_engine
+from app.database import BatchAsyncSessionLocal
 from app.errors import ServiceUnavailable
 from app.model.db import (
     IDXLock,
@@ -154,12 +154,7 @@ class Processor:
 
     @staticmethod
     def __get_db_session():
-        return AsyncSession(
-            autocommit=False,
-            autoflush=True,
-            expire_on_commit=False,
-            bind=batch_async_engine,
-        )
+        return BatchAsyncSessionLocal()
 
     async def initial_sync(self):
         local_session = self.__get_db_session()

--- a/batch/indexer_Token_Detail.py
+++ b/batch/indexer_Token_Detail.py
@@ -36,7 +36,7 @@ sys.path.append(path)
 import log
 
 from app import config
-from app.database import batch_async_engine
+from app.database import BatchAsyncSessionLocal
 from app.errors import ServiceUnavailable
 from app.model.blockchain import BondToken, CouponToken, MembershipToken, ShareToken
 from app.model.blockchain.token import TokenClassTypes
@@ -87,12 +87,7 @@ class Processor:
 
     @staticmethod
     def __get_db_session() -> AsyncSession:
-        return AsyncSession(
-            autocommit=False,
-            autoflush=True,
-            expire_on_commit=False,
-            bind=batch_async_engine,
-        )
+        return BatchAsyncSessionLocal()
 
     async def process(self):
         LOG.info("Syncing token details")

--- a/batch/indexer_Token_Detail_ShortTerm.py
+++ b/batch/indexer_Token_Detail_ShortTerm.py
@@ -34,7 +34,7 @@ sys.path.append(path)
 import log
 
 from app import config
-from app.database import batch_async_engine
+from app.database import BatchAsyncSessionLocal
 from app.errors import ServiceUnavailable
 from app.model.blockchain import (
     BondToken,
@@ -106,12 +106,7 @@ class Processor:
 
     @staticmethod
     def __get_db_session() -> AsyncSession:
-        return AsyncSession(
-            autocommit=False,
-            autoflush=True,
-            expire_on_commit=False,
-            bind=batch_async_engine,
-        )
+        return BatchAsyncSessionLocal()
 
     async def process(self):
         LOG.info("Syncing token details")

--- a/batch/indexer_Token_Holders.py
+++ b/batch/indexer_Token_Holders.py
@@ -32,7 +32,7 @@ sys.path.append(path)
 
 from app.config import TOKEN_LIST_CONTRACT_ADDRESS, ZERO_ADDRESS
 from app.contracts import AsyncContract
-from app.database import batch_async_engine
+from app.database import BatchAsyncSessionLocal
 from app.errors import ServiceUnavailable
 from app.model.db import TokenHolder, TokenHolderBatchStatus, TokenHoldersList
 from app.model.schema.base import TokenType
@@ -83,12 +83,7 @@ class Processor:
 
     @staticmethod
     def __get_db_session() -> AsyncSession:
-        return AsyncSession(
-            autocommit=False,
-            autoflush=True,
-            expire_on_commit=False,
-            bind=batch_async_engine,
-        )
+        return BatchAsyncSessionLocal()
 
     async def __load_target(self, db_session: AsyncSession) -> bool:
         self.target: TokenHoldersList = (

--- a/batch/indexer_Token_List.py
+++ b/batch/indexer_Token_List.py
@@ -33,7 +33,7 @@ import log
 
 from app import config
 from app.contracts import AsyncContract
-from app.database import batch_async_engine
+from app.database import BatchAsyncSessionLocal
 from app.errors import ServiceUnavailable
 from app.model.db import IDXTokenListBlockNumber, IDXTokenListItem
 from app.model.schema.base import TokenType
@@ -64,12 +64,7 @@ class Processor:
 
     @staticmethod
     def __get_db_session():
-        return AsyncSession(
-            autocommit=False,
-            autoflush=True,
-            expire_on_commit=False,
-            bind=batch_async_engine,
-        )
+        return BatchAsyncSessionLocal()
 
     async def process(self):
         local_session = self.__get_db_session()

--- a/batch/indexer_Transfer.py
+++ b/batch/indexer_Transfer.py
@@ -36,7 +36,7 @@ import log
 
 from app.config import TOKEN_LIST_CONTRACT_ADDRESS, ZERO_ADDRESS
 from app.contracts import AsyncContract
-from app.database import batch_async_engine
+from app.database import BatchAsyncSessionLocal
 from app.errors import ServiceUnavailable
 from app.model.db import (
     IDXTransfer,
@@ -221,9 +221,7 @@ class Processor:
     """
 
     async def sync_new_logs(self):
-        local_session = AsyncSession(
-            autocommit=False, autoflush=True, bind=batch_async_engine
-        )
+        local_session = BatchAsyncSessionLocal()
         latest_block = await async_web3.eth.block_number
         try:
             LOG.info("Syncing to={}".format(latest_block))

--- a/batch/indexer_TransferApproval.py
+++ b/batch/indexer_TransferApproval.py
@@ -34,7 +34,7 @@ import log
 
 from app.config import TOKEN_LIST_CONTRACT_ADDRESS, ZERO_ADDRESS
 from app.contracts import AsyncContract
-from app.database import batch_async_engine
+from app.database import BatchAsyncSessionLocal
 from app.errors import ServiceUnavailable
 from app.model.db import IDXTransferApproval, IDXTransferApprovalBlockNumber, Listing
 from app.model.schema.base import TokenType
@@ -228,7 +228,7 @@ class Processor:
 
     @staticmethod
     def __get_db_session():
-        return AsyncSession(autocommit=False, autoflush=True, bind=batch_async_engine)
+        return BatchAsyncSessionLocal()
 
     async def initial_sync(self):
         local_session = self.__get_db_session()

--- a/batch/processor_Notifications_Coupon_Exchange.py
+++ b/batch/processor_Notifications_Coupon_Exchange.py
@@ -39,7 +39,7 @@ from app.config import (
     WORKER_COUNT,
 )
 from app.contracts import AsyncContract
-from app.database import batch_async_engine
+from app.database import BatchAsyncSessionLocal
 from app.errors import ServiceUnavailable
 from app.model.db import Notification, NotificationBlockNumber, NotificationType
 from app.model.schema.base import TokenType
@@ -101,9 +101,7 @@ class Watcher:
 
     async def loop(self):
         start_time = time.time()
-        db_session = AsyncSession(
-            autocommit=False, autoflush=True, bind=batch_async_engine
-        )
+        db_session = BatchAsyncSessionLocal()
 
         try:
             # Get synchronized block number

--- a/batch/processor_Notifications_Membership_Exchange.py
+++ b/batch/processor_Notifications_Membership_Exchange.py
@@ -39,7 +39,7 @@ from app.config import (
     WORKER_COUNT,
 )
 from app.contracts import AsyncContract
-from app.database import batch_async_engine
+from app.database import BatchAsyncSessionLocal
 from app.errors import ServiceUnavailable
 from app.model.db import Notification, NotificationBlockNumber, NotificationType
 from app.model.schema.base import TokenType
@@ -101,9 +101,7 @@ class Watcher:
 
     async def loop(self):
         start_time = time.time()
-        db_session = AsyncSession(
-            autocommit=False, autoflush=True, bind=batch_async_engine
-        )
+        db_session = BatchAsyncSessionLocal()
 
         try:
             # Get synchronized block number

--- a/batch/processor_Notifications_Token.py
+++ b/batch/processor_Notifications_Token.py
@@ -413,7 +413,7 @@ class WatchCancelTransfer(Watcher):
             contract=token_contract, function_name="name", args=(), default_returns=""
         )
         for entry in log_entries:
-            if not token_list.is_registered(entry["address"]):
+            if not await token_list.is_registered(entry["address"]):
                 continue
 
             company = company_list.find(token_owner_address)

--- a/batch/processor_Notifications_Token.py
+++ b/batch/processor_Notifications_Token.py
@@ -41,7 +41,7 @@ from app.config import (
     WORKER_COUNT,
 )
 from app.contracts import AsyncContract
-from app.database import batch_async_engine
+from app.database import BatchAsyncSessionLocal
 from app.errors import ServiceUnavailable
 from app.model.db import (
     IDXTokenListItem,
@@ -126,9 +126,7 @@ class Watcher:
 
     async def loop(self):
         start_time = time.time()
-        db_session = AsyncSession(
-            autocommit=False, autoflush=True, bind=batch_async_engine
-        )
+        db_session = BatchAsyncSessionLocal()
 
         try:
             # Get listed tokens

--- a/batch/processor_Send_Chat_Webhook.py
+++ b/batch/processor_Send_Chat_Webhook.py
@@ -33,7 +33,7 @@ sys.path.append(path)
 import log
 
 from app.config import CHAT_WEBHOOK_URL
-from app.database import batch_async_engine
+from app.database import BatchAsyncSessionLocal
 from app.model.db import ChatWebhook
 
 LOG = log.get_logger(process_name="PROCESSOR-SEND-CHAT-WEBHOOK")
@@ -41,9 +41,7 @@ LOG = log.get_logger(process_name="PROCESSOR-SEND-CHAT-WEBHOOK")
 
 class Processor:
     async def process(self):
-        db_session = AsyncSession(
-            autocommit=False, autoflush=True, bind=batch_async_engine
-        )
+        db_session = BatchAsyncSessionLocal()
         try:
             hook_list: Sequence[ChatWebhook] = (
                 await db_session.scalars(select(ChatWebhook))

--- a/tests/batch/indexer_Block_Tx_Data_test.py
+++ b/tests/batch/indexer_Block_Tx_Data_test.py
@@ -116,6 +116,7 @@ class TestProcessor:
 
         # Generate empty block
         web3.provider.make_request(RPCEndpoint("evm_mine"), [])
+        web3.provider.make_request(RPCEndpoint("evm_mine"), [])
 
         # Execute batch processing
         asyncio.run(processor.process())
@@ -132,8 +133,9 @@ class TestProcessor:
         block_data: Sequence[IDXBlockData] = session.scalars(
             select(IDXBlockData).order_by(IDXBlockData.number)
         ).all()
-        assert len(block_data) == 1
+        assert len(block_data) == 2
         assert block_data[0].number == before_block_number + 1
+        assert block_data[1].number == before_block_number + 2
 
         tx_data: Sequence[IDXTxData] = session.scalars(
             select(IDXTxData).order_by(IDXTxData.block_number)

--- a/tests/batch/processor_Notifications_Token_test.py
+++ b/tests/batch/processor_Notifications_Token_test.py
@@ -1316,8 +1316,6 @@ class TestWatchCancelTransfer:
         # Transfer
         share_apply_for_transfer(self.trader, token_1, self.trader2, 10, "TEST_DATA1")
         share_apply_for_transfer(self.trader, token_1, self.trader2, 20, "TEST_DATA2")
-        share_cancel_transfer(self.issuer, token_1, 0, "TEST_DATA1")
-        share_cancel_transfer(self.issuer, token_1, 1, "TEST_DATA2")
 
         idx_token_list_item = IDXTokenListItem()
         idx_token_list_item.token_address = token_1["address"]
@@ -1339,6 +1337,9 @@ class TestWatchCancelTransfer:
         # Transfer
         share_apply_for_transfer(self.trader, token_2, self.trader2, 10, "TEST_DATA1")
         share_apply_for_transfer(self.trader, token_2, self.trader2, 20, "TEST_DATA2")
+
+        share_cancel_transfer(self.issuer, token_1, 0, "TEST_DATA1")
+        share_cancel_transfer(self.issuer, token_1, 1, "TEST_DATA2")
         share_cancel_transfer(self.issuer, token_2, 0, "TEST_DATA1")
         share_cancel_transfer(self.issuer, token_2, 1, "TEST_DATA2")
 
@@ -1359,11 +1360,11 @@ class TestWatchCancelTransfer:
         _notification_list = session.scalars(
             select(Notification).order_by(Notification.created)
         ).all()
-        assert len(_notification_list) == 2
+        assert len(_notification_list) == 4
 
         _notification = _notification_list[0]
         assert _notification.notification_id == "0x{:012x}{:06x}{:06x}{:02x}".format(
-            block_number - 1, 0, 0, 0
+            block_number - 3, 0, 0, 0
         )
         assert _notification.notification_type == NotificationType.CANCEL_TRANSFER.value
         assert _notification.priority == 0
@@ -1385,7 +1386,7 @@ class TestWatchCancelTransfer:
 
         _notification = _notification_list[1]
         assert _notification.notification_id == "0x{:012x}{:06x}{:06x}{:02x}".format(
-            block_number, 0, 0, 0
+            block_number - 2, 0, 0, 0
         )
         assert _notification.notification_type == NotificationType.CANCEL_TRANSFER.value
         assert _notification.priority == 0
@@ -1400,6 +1401,50 @@ class TestWatchCancelTransfer:
         assert _notification.metainfo == {
             "company_name": "株式会社DEMO",
             "token_address": token_1["address"],
+            "token_name": "テスト株式",
+            "exchange_address": "",
+            "token_type": "IbetShare",
+        }
+
+        _notification = _notification_list[2]
+        assert _notification.notification_id == "0x{:012x}{:06x}{:06x}{:02x}".format(
+            block_number - 1, 0, 0, 0
+        )
+        assert _notification.notification_type == NotificationType.CANCEL_TRANSFER.value
+        assert _notification.priority == 0
+        assert _notification.address == self.trader["account_address"]
+        assert _notification.block_timestamp is not None
+        assert _notification.args == {
+            "index": 0,
+            "from": self.trader["account_address"],
+            "to": self.trader2["account_address"],
+            "data": "TEST_DATA1",
+        }
+        assert _notification.metainfo == {
+            "company_name": "株式会社DEMO",
+            "token_address": token_2["address"],
+            "token_name": "テスト株式",
+            "exchange_address": "",
+            "token_type": "IbetShare",
+        }
+
+        _notification = _notification_list[3]
+        assert _notification.notification_id == "0x{:012x}{:06x}{:06x}{:02x}".format(
+            block_number, 0, 0, 0
+        )
+        assert _notification.notification_type == NotificationType.CANCEL_TRANSFER.value
+        assert _notification.priority == 0
+        assert _notification.address == self.trader["account_address"]
+        assert _notification.block_timestamp is not None
+        assert _notification.args == {
+            "index": 1,
+            "from": self.trader["account_address"],
+            "to": self.trader2["account_address"],
+            "data": "TEST_DATA2",
+        }
+        assert _notification.metainfo == {
+            "company_name": "株式会社DEMO",
+            "token_address": token_2["address"],
             "token_name": "テスト株式",
             "exchange_address": "",
             "token_type": "IbetShare",

--- a/tests/batch/processor_Notifications_Token_test.py
+++ b/tests/batch/processor_Notifications_Token_test.py
@@ -1183,7 +1183,7 @@ class TestWatchCancelTransfer:
         assert _notification_block_number.latest_block_number == block_number
 
     # <Normal_2>
-    # Multi event logs
+    # Single Token / Multi event logs
     def test_normal_2(
         self, watcher_factory, session, shared_contract, mocked_company_list
     ):
@@ -1289,8 +1289,138 @@ class TestWatchCancelTransfer:
         assert _notification_block_number.latest_block_number == block_number
 
     # <Normal_3>
-    # No event logs
+    # Multi token / Multi event logs
     def test_normal_3(
+        self, watcher_factory, session, shared_contract, mocked_company_list
+    ):
+        watcher = watcher_factory("WatchCancelTransfer")
+
+        exchange_contract = shared_contract["IbetShareExchange"]
+        token_list_contract = shared_contract["TokenList"]
+        personal_info_contract = shared_contract["PersonalInfo"]
+
+        register_personalinfo(self.trader, personal_info_contract)
+        register_personalinfo(self.trader2, personal_info_contract)
+
+        token_1 = prepare_share_token(
+            self.issuer,
+            exchange_contract,
+            token_list_contract,
+            personal_info_contract,
+            session,
+        )
+
+        transfer_share_token(self.issuer, self.trader, token_1, 100)
+        share_set_transfer_approval_required(self.issuer, token_1, True)
+
+        # Transfer
+        share_apply_for_transfer(self.trader, token_1, self.trader2, 10, "TEST_DATA1")
+        share_apply_for_transfer(self.trader, token_1, self.trader2, 20, "TEST_DATA2")
+        share_cancel_transfer(self.issuer, token_1, 0, "TEST_DATA1")
+        share_cancel_transfer(self.issuer, token_1, 1, "TEST_DATA2")
+
+        idx_token_list_item = IDXTokenListItem()
+        idx_token_list_item.token_address = token_1["address"]
+        idx_token_list_item.owner_address = self.issuer["account_address"]
+        idx_token_list_item.token_template = "IbetShare"
+        session.add(idx_token_list_item)
+
+        token_2 = prepare_share_token(
+            self.issuer,
+            exchange_contract,
+            token_list_contract,
+            personal_info_contract,
+            session,
+        )
+
+        transfer_share_token(self.issuer, self.trader, token_2, 100)
+        share_set_transfer_approval_required(self.issuer, token_2, True)
+
+        # Transfer
+        share_apply_for_transfer(self.trader, token_2, self.trader2, 10, "TEST_DATA1")
+        share_apply_for_transfer(self.trader, token_2, self.trader2, 20, "TEST_DATA2")
+        share_cancel_transfer(self.issuer, token_2, 0, "TEST_DATA1")
+        share_cancel_transfer(self.issuer, token_2, 1, "TEST_DATA2")
+
+        idx_token_list_item = IDXTokenListItem()
+        idx_token_list_item.token_address = token_2["address"]
+        idx_token_list_item.owner_address = self.issuer["account_address"]
+        idx_token_list_item.token_template = "IbetShare"
+        session.add(idx_token_list_item)
+
+        session.commit()
+
+        # Run target process
+        asyncio.run(watcher.loop())
+
+        # Assertion
+        block_number = web3.eth.block_number
+
+        _notification_list = session.scalars(
+            select(Notification).order_by(Notification.created)
+        ).all()
+        assert len(_notification_list) == 2
+
+        _notification = _notification_list[0]
+        assert _notification.notification_id == "0x{:012x}{:06x}{:06x}{:02x}".format(
+            block_number - 1, 0, 0, 0
+        )
+        assert _notification.notification_type == NotificationType.CANCEL_TRANSFER.value
+        assert _notification.priority == 0
+        assert _notification.address == self.trader["account_address"]
+        assert _notification.block_timestamp is not None
+        assert _notification.args == {
+            "index": 0,
+            "from": self.trader["account_address"],
+            "to": self.trader2["account_address"],
+            "data": "TEST_DATA1",
+        }
+        assert _notification.metainfo == {
+            "company_name": "株式会社DEMO",
+            "token_address": token_1["address"],
+            "token_name": "テスト株式",
+            "exchange_address": "",
+            "token_type": "IbetShare",
+        }
+
+        _notification = _notification_list[1]
+        assert _notification.notification_id == "0x{:012x}{:06x}{:06x}{:02x}".format(
+            block_number, 0, 0, 0
+        )
+        assert _notification.notification_type == NotificationType.CANCEL_TRANSFER.value
+        assert _notification.priority == 0
+        assert _notification.address == self.trader["account_address"]
+        assert _notification.block_timestamp is not None
+        assert _notification.args == {
+            "index": 1,
+            "from": self.trader["account_address"],
+            "to": self.trader2["account_address"],
+            "data": "TEST_DATA2",
+        }
+        assert _notification.metainfo == {
+            "company_name": "株式会社DEMO",
+            "token_address": token_1["address"],
+            "token_name": "テスト株式",
+            "exchange_address": "",
+            "token_type": "IbetShare",
+        }
+
+        _notification_block_number: NotificationBlockNumber = session.scalars(
+            select(NotificationBlockNumber)
+            .where(
+                and_(
+                    NotificationBlockNumber.notification_type
+                    == NotificationType.CANCEL_TRANSFER,
+                    NotificationBlockNumber.contract_address == token_1["address"],
+                )
+            )
+            .limit(1)
+        ).first()
+        assert _notification_block_number.latest_block_number == block_number
+
+    # <Normal_4>
+    # No event logs
+    def test_normal_4(
         self, watcher_factory, session, shared_contract, mocked_company_list
     ):
         watcher = watcher_factory("WatchCancelTransfer")

--- a/tests/batch/processor_Send_Chat_Webhook_test.py
+++ b/tests/batch/processor_Send_Chat_Webhook_test.py
@@ -20,7 +20,7 @@ import asyncio
 import json
 import logging
 from unittest import mock
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock
 
 import pytest
 from sqlalchemy import select
@@ -52,7 +52,7 @@ class TestProcessorSendChatWebhook:
     # No unsent hook exists
     def test_normal_1(self, processor, session, caplog):
         # Run processor
-        with mock.patch("httpx.AsyncClient.post", MagicMock(side_effect=None)):
+        with mock.patch("httpx.AsyncClient.post", AsyncMock(side_effect=None)):
             asyncio.run(processor.process())
             session.commit()
 
@@ -64,12 +64,15 @@ class TestProcessorSendChatWebhook:
     def test_normal_2(self, processor, session, caplog):
         # Prepare data
         hook = ChatWebhook()
-        hook.message = json.dumps({"title": "test_title", "text": "test_text"})
+        hook.message = json.dumps({"title": "test_title1", "text": "test_text"})
+        session.add(hook)
+        hook = ChatWebhook()
+        hook.message = json.dumps({"title": "test_title2", "text": "test_text"})
         session.add(hook)
         session.commit()
 
         # Run processor
-        with mock.patch("httpx.AsyncClient.post", MagicMock(side_effect=None)):
+        with mock.patch("httpx.AsyncClient.post", AsyncMock(side_effect=None)):
             asyncio.run(processor.process())
             session.commit()
 
@@ -88,7 +91,7 @@ class TestProcessorSendChatWebhook:
         session.commit()
 
         # Run processor
-        with mock.patch("httpx.AsyncClient.post", MagicMock(side_effect=Exception())):
+        with mock.patch("httpx.AsyncClient.post", AsyncMock(side_effect=Exception())):
             asyncio.run(processor.process())
             session.commit()
 
@@ -116,7 +119,7 @@ class TestProcessorSendChatWebhook:
 
         # Run processor
         with (
-            mock.patch("httpx.AsyncClient.post", MagicMock(side_effect=None)),
+            mock.patch("httpx.AsyncClient.post", AsyncMock(side_effect=None)),
             mock.patch.object(Session, "commit", side_effect=SQLAlchemyError()),
             pytest.raises(SQLAlchemyError),
         ):


### PR DESCRIPTION
Fix: #1469 

- Modified so that async batches use same DB engine setting parameter which includes `expire_on_commit=False`.
  - `expire_on_commit=False` parameter makes it enable to access model object once after batches run `commit()`.
    In #1469, some batches used default DB engine setting and raised exceptions because it could not access model object after it run `commit()`. This PR is intended to fix it.