### PR TITLE
Collect all TokenList items regardless of token enable settings

### DIFF
--- a/batch/indexer_Token_List.py
+++ b/batch/indexer_Token_List.py
@@ -48,15 +48,6 @@ class Processor:
         self.token_list_contract = AsyncContract.get_contract(
             contract_name="TokenList", address=config.TOKEN_LIST_CONTRACT_ADDRESS
         )
-        self.available_token_template_list = []
-        if config.BOND_TOKEN_ENABLED:
-            self.available_token_template_list.append(TokenType.IbetStraightBond)
-        if config.SHARE_TOKEN_ENABLED:
-            self.available_token_template_list.append(TokenType.IbetShare)
-        if config.MEMBERSHIP_TOKEN_ENABLED:
-            self.available_token_template_list.append(TokenType.IbetMembership)
-        if config.COUPON_TOKEN_ENABLED:
-            self.available_token_template_list.append(TokenType.IbetCoupon)
 
     @staticmethod
     def __get_db_session():
@@ -81,6 +72,7 @@ class Processor:
                         block_from=_from_block,
                         block_to=_to_block,
                     )
+                    _from_block += 1000000
                     _to_block += 1000000
                 await self.__sync_all(
                     db_session=local_session,
@@ -101,7 +93,7 @@ class Processor:
                 block_number=latest_block,
             )
             await local_session.commit()
-        except Exception as e:
+        except Exception:
             await local_session.rollback()
             raise
         finally:
@@ -159,9 +151,6 @@ class Processor:
         :param owner_address: owner address
         :return: None
         """
-        if token_template not in self.available_token_template_list:
-            return
-
         idx_token_list: Optional[IDXTokenListItem] = (
             await db_session.scalars(
                 select(IDXTokenListItem)

--- a/batch/indexer_Token_List.py
+++ b/batch/indexer_Token_List.py
@@ -48,6 +48,12 @@ class Processor:
         self.token_list_contract = AsyncContract.get_contract(
             contract_name="TokenList", address=config.TOKEN_LIST_CONTRACT_ADDRESS
         )
+        self.available_token_template_list = [
+            TokenType.IbetStraightBond,
+            TokenType.IbetShare,
+            TokenType.IbetMembership,
+            TokenType.IbetCoupon,
+        ]
 
     @staticmethod
     def __get_db_session():
@@ -151,6 +157,8 @@ class Processor:
         :param owner_address: owner address
         :return: None
         """
+        if token_template not in self.available_token_template_list:
+            return
         idx_token_list: Optional[IDXTokenListItem] = (
             await db_session.scalars(
                 select(IDXTokenListItem)

--- a/migrations/versions/3d3b90fda898_v24_3_0_feature_1483.py
+++ b/migrations/versions/3d3b90fda898_v24_3_0_feature_1483.py
@@ -1,0 +1,31 @@
+"""v24_3_0_feature_1483
+
+Revision ID: 3d3b90fda898
+Revises: f6f13d28bb48
+Create Date: 2024-02-21 09:47:53.425654
+
+"""
+
+from alembic import op
+from sqlalchemy import delete
+from app.model.db import IDXTokenListBlockNumber
+
+
+# revision identifiers, used by Alembic.
+revision = "3d3b90fda898"
+down_revision = "f6f13d28bb48"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    connection = op.get_bind()
+
+    # Delete all `token_cache` data
+    op.get_bind().execute(delete(IDXTokenListBlockNumber))
+
+
+def downgrade():
+    connection = op.get_bind()
+
+    pass


### PR DESCRIPTION
Close: #1483 

- Made TokenList indexer collect all TokenList items of ibet token regardless of token enable settings.
- Added migration file to initialize existing `idx_token_list_block_number`.
- Added some unit tests.