### PR TITLE
Detailed the response status of eth_sendRawTransaction

### DIFF
--- a/app/api/routers/eth.py
+++ b/app/api/routers/eth.py
@@ -240,8 +240,16 @@ async def send_raw_transaction(
         try:
             tx_hash = await async_web3.eth.send_raw_transaction(raw_tx_hex)
         except Exception as err:
-            result.append({"id": i + 1, "status": 0, "transaction_hash": None})
-            LOG.error(f"Send transaction failed: {err}")
+            error_msg = err.args[0].get("message")
+            if "nonce too low" in error_msg:
+                result.append({"id": i + 1, "status": 3, "transaction_hash": None})
+                LOG.warning(f"Sent transaction nonce is too low: {err}")
+            elif "already known" in error_msg:
+                result.append({"id": i + 1, "status": 4, "transaction_hash": None})
+                LOG.warning(f"Sent transaction has been already known: {err}")
+            else:
+                result.append({"id": i + 1, "status": 0, "transaction_hash": None})
+                LOG.error(f"Send transaction failed: {err}")
             continue
 
         # Handling a transaction execution result
@@ -412,8 +420,16 @@ async def send_raw_transaction_no_wait(
         try:
             transaction_hash = await async_web3.eth.send_raw_transaction(raw_tx_hex)
         except Exception as err:
-            result.append({"id": i + 1, "status": 0, "transaction_hash": None})
-            LOG.error(f"Send transaction failed: {err}")
+            error_msg = err.args[0].get("message")
+            if "nonce too low" in error_msg:
+                result.append({"id": i + 1, "status": 3, "transaction_hash": None})
+                LOG.warning(f"Sent transaction nonce is too low: {err}")
+            elif "already known" in error_msg:
+                result.append({"id": i + 1, "status": 4, "transaction_hash": None})
+                LOG.warning(f"Sent transaction has been already known: {err}")
+            else:
+                result.append({"id": i + 1, "status": 0, "transaction_hash": None})
+                LOG.error(f"Send transaction failed: {err}")
             continue
 
         result.append(

--- a/app/api/routers/eth.py
+++ b/app/api/routers/eth.py
@@ -240,13 +240,17 @@ async def send_raw_transaction(
         try:
             tx_hash = await async_web3.eth.send_raw_transaction(raw_tx_hex)
         except Exception as err:
-            error_msg = err.args[0].get("message")
-            if "nonce too low" in error_msg:
-                result.append({"id": i + 1, "status": 3, "transaction_hash": None})
-                LOG.warning(f"Sent transaction nonce is too low: {err}")
-            elif "already known" in error_msg:
-                result.append({"id": i + 1, "status": 4, "transaction_hash": None})
-                LOG.warning(f"Sent transaction has been already known: {err}")
+            if len(err.args) > 0:
+                error_msg = err.args[0].get("message")
+                if "nonce too low" in error_msg:
+                    result.append({"id": i + 1, "status": 3, "transaction_hash": None})
+                    LOG.warning(f"Sent transaction nonce is too low: {err}")
+                elif "already known" in error_msg:
+                    result.append({"id": i + 1, "status": 4, "transaction_hash": None})
+                    LOG.warning(f"Sent transaction has been already known: {err}")
+                else:
+                    result.append({"id": i + 1, "status": 0, "transaction_hash": None})
+                    LOG.error(f"Send transaction failed: {err}")
             else:
                 result.append({"id": i + 1, "status": 0, "transaction_hash": None})
                 LOG.error(f"Send transaction failed: {err}")
@@ -420,13 +424,17 @@ async def send_raw_transaction_no_wait(
         try:
             transaction_hash = await async_web3.eth.send_raw_transaction(raw_tx_hex)
         except Exception as err:
-            error_msg = err.args[0].get("message")
-            if "nonce too low" in error_msg:
-                result.append({"id": i + 1, "status": 3, "transaction_hash": None})
-                LOG.warning(f"Sent transaction nonce is too low: {err}")
-            elif "already known" in error_msg:
-                result.append({"id": i + 1, "status": 4, "transaction_hash": None})
-                LOG.warning(f"Sent transaction has been already known: {err}")
+            if len(err.args) > 0:
+                error_msg = err.args[0].get("message")
+                if "nonce too low" in error_msg:
+                    result.append({"id": i + 1, "status": 3, "transaction_hash": None})
+                    LOG.warning(f"Sent transaction nonce is too low: {err}")
+                elif "already known" in error_msg:
+                    result.append({"id": i + 1, "status": 4, "transaction_hash": None})
+                    LOG.warning(f"Sent transaction has been already known: {err}")
+                else:
+                    result.append({"id": i + 1, "status": 0, "transaction_hash": None})
+                    LOG.error(f"Send transaction failed: {err}")
             else:
                 result.append({"id": i + 1, "status": 0, "transaction_hash": None})
                 LOG.error(f"Send transaction failed: {err}")

--- a/app/model/schema/eth.py
+++ b/app/model/schema/eth.py
@@ -17,7 +17,7 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
-from enum import Enum
+from enum import Enum, IntEnum
 from typing import Annotated, Optional
 
 from fastapi import Query
@@ -27,6 +27,14 @@ from pydantic.dataclasses import dataclass
 ############################
 # COMMON
 ############################
+
+
+class SendRawTransactionStatus(IntEnum):
+    Failure = 0
+    Success = 1
+    Pending = 2
+    NonceTooLow = 3
+    AlreadyKnown = 4
 
 
 ############################
@@ -86,7 +94,7 @@ class TransactionCountResponse(BaseModel):
 
 class SendRawTransactionResponse(BaseModel):
     id: int = Field(..., examples=[1], description="transaction send order")
-    status: int = Field(
+    status: SendRawTransactionStatus = Field(
         ...,
         examples=[1],
         description="execution failure:0, execution success:1, execution success("
@@ -111,7 +119,7 @@ class SendRawTransactionsResponse(RootModel[list[SendRawTransactionResponse]]):
 
 class SendRawTransactionNoWaitResponse(BaseModel):
     id: int = Field(..., examples=[1], description="transaction send order")
-    status: int = Field(
+    status: SendRawTransactionStatus = Field(
         ..., examples=[1], description="execution failure:0, execution success:1"
     )
     transaction_hash: Optional[str] = Field(

--- a/docs/ibet_wallet_api.yaml
+++ b/docs/ibet_wallet_api.yaml
@@ -10178,8 +10178,8 @@ components:
           examples:
             - 1
         status:
-          type: integer
-          title: Status
+          allOf:
+            - $ref: '#/components/schemas/SendRawTransactionStatus'
           description: execution failure:0, execution success:1
           examples:
             - 1
@@ -10216,8 +10216,8 @@ components:
           examples:
             - 1
         status:
-          type: integer
-          title: Status
+          allOf:
+            - $ref: '#/components/schemas/SendRawTransactionStatus'
           description: >-
             execution failure:0, execution success:1, execution success(pending
             transaction):2
@@ -10250,6 +10250,15 @@ components:
         - id
         - status
       title: SendRawTransactionResponse
+    SendRawTransactionStatus:
+      type: integer
+      enum:
+        - 0
+        - 1
+        - 2
+        - 3
+        - 4
+      title: SendRawTransactionStatus
     SendRawTransactionsNoWaitResponse:
       items:
         $ref: '#/components/schemas/SendRawTransactionNoWaitResponse'

--- a/tests/app/eth_SendRawTransactionNowait_test.py
+++ b/tests/app/eth_SendRawTransactionNowait_test.py
@@ -17,7 +17,8 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
-from unittest.mock import patch
+from unittest import mock
+from unittest.mock import ANY, MagicMock, patch
 
 from eth_utils import to_checksum_address
 from fastapi.testclient import TestClient
@@ -27,12 +28,23 @@ from web3.middleware import geth_poa_middleware
 
 from app import config
 from app.contracts import Contract
-from app.model.db import ExecutableContract, Listing
+from app.model.db import ExecutableContract, Listing, Node
 from tests.account_config import eth_account
 from tests.contract_modules import coupon_register_list, issue_coupon_token
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
 web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+
+
+def insert_node_data(
+    session, is_synced, endpoint_uri=config.WEB3_HTTP_PROVIDER, priority=0
+):
+    node = Node()
+    node.is_synced = is_synced
+    node.endpoint_uri = endpoint_uri
+    node.priority = priority
+    session.add(node)
+    session.commit()
 
 
 def tokenlist_contract():
@@ -279,6 +291,194 @@ class TestEthSendRawTransactionNoWait:
         assert resp_data["id"] == 2
         assert resp_data["status"] == 1
         assert resp_data["transaction_hash"] is not None
+
+    # <Normal_3>
+    # nonce too low
+    def test_normal_3(self, client: TestClient, session: Session):
+        with mock.patch(
+            "app.utils.web3_utils.AsyncFailOverHTTPProvider.fail_over_mode", True
+        ):
+            insert_node_data(
+                session, is_synced=False, endpoint_uri="http://localhost:8546"
+            )
+            insert_node_data(
+                session,
+                is_synced=True,
+                endpoint_uri=config.WEB3_HTTP_PROVIDER,
+                priority=1,
+            )
+
+            # トークンリスト登録
+            tokenlist = tokenlist_contract()
+            config.TOKEN_LIST_CONTRACT_ADDRESS = tokenlist["address"]
+            issuer = eth_account["issuer"]
+            coupontoken_1 = issue_coupon_token(
+                issuer,
+                {
+                    "name": "name_test1",
+                    "symbol": "symbol_test1",
+                    "totalSupply": 1000000,
+                    "tradableExchange": config.ZERO_ADDRESS,
+                    "details": "details_test1",
+                    "returnDetails": "returnDetails_test1",
+                    "memo": "memo_test1",
+                    "expirationDate": "20211201",
+                    "transferable": True,
+                    "contactInformation": "contactInformation_test1",
+                    "privacyPolicy": "privacyPolicy_test1",
+                },
+            )
+            coupon_register_list(issuer, coupontoken_1, tokenlist)
+
+            # Listing,実行可能コントラクト登録
+            listing_token(session, coupontoken_1)
+            executable_contract_token(session, coupontoken_1)
+
+            token_contract_1 = web3.eth.contract(
+                address=to_checksum_address(coupontoken_1["address"]),
+                abi=coupontoken_1["abi"],
+            )
+
+            local_account_1 = web3.eth.account.create()
+
+            # テスト用のトランザクション実行前の事前準備
+            pre_tx = token_contract_1.functions.transfer(
+                to_checksum_address(local_account_1.address), 10
+            ).build_transaction(
+                {
+                    "from": to_checksum_address(issuer["account_address"]),
+                    "gas": 6000000,
+                    "gasPrice": 0,
+                }
+            )
+            tx_hash = web3.eth.send_transaction(pre_tx)
+            web3.eth.wait_for_transaction_receipt(tx_hash)
+
+            tx = token_contract_1.functions.consume(10).build_transaction(
+                {
+                    "from": to_checksum_address(local_account_1.address),
+                    "gas": 6000000,
+                    "gasPrice": 0,
+                }
+            )
+            tx["nonce"] = web3.eth.get_transaction_count(
+                to_checksum_address(local_account_1.address)
+            )
+            signed_tx_1 = web3.eth.account.sign_transaction(tx, local_account_1.key)
+
+            session.commit()
+
+            request_params = {"raw_tx_hex_list": [signed_tx_1.rawTransaction.hex()]}
+            headers = {"Content-Type": "application/json"}
+            with mock.patch(
+                "web3.eth.async_eth.AsyncEth.send_raw_transaction",
+                MagicMock(
+                    side_effect=ValueError(
+                        {"code": -320000, "message": "nonce too low"}
+                    )
+                ),
+            ):
+                resp = client.post(self.apiurl, headers=headers, json=request_params)
+
+            assert resp.status_code == 200
+            assert resp.json()["meta"] == {"code": 200, "message": "OK"}
+            assert resp.json()["data"] == [
+                {"id": 1, "status": 3, "transaction_hash": ANY}
+            ]
+
+    # <Normal_4>
+    # already known
+    def test_normal_4(self, client: TestClient, session: Session):
+        with mock.patch(
+            "app.utils.web3_utils.AsyncFailOverHTTPProvider.fail_over_mode", True
+        ):
+            insert_node_data(
+                session, is_synced=False, endpoint_uri="http://localhost:8546"
+            )
+            insert_node_data(
+                session,
+                is_synced=True,
+                endpoint_uri=config.WEB3_HTTP_PROVIDER,
+                priority=1,
+            )
+
+            # トークンリスト登録
+            tokenlist = tokenlist_contract()
+            config.TOKEN_LIST_CONTRACT_ADDRESS = tokenlist["address"]
+            issuer = eth_account["issuer"]
+            coupontoken_1 = issue_coupon_token(
+                issuer,
+                {
+                    "name": "name_test1",
+                    "symbol": "symbol_test1",
+                    "totalSupply": 1000000,
+                    "tradableExchange": config.ZERO_ADDRESS,
+                    "details": "details_test1",
+                    "returnDetails": "returnDetails_test1",
+                    "memo": "memo_test1",
+                    "expirationDate": "20211201",
+                    "transferable": True,
+                    "contactInformation": "contactInformation_test1",
+                    "privacyPolicy": "privacyPolicy_test1",
+                },
+            )
+            coupon_register_list(issuer, coupontoken_1, tokenlist)
+
+            # Listing,実行可能コントラクト登録
+            listing_token(session, coupontoken_1)
+            executable_contract_token(session, coupontoken_1)
+
+            token_contract_1 = web3.eth.contract(
+                address=to_checksum_address(coupontoken_1["address"]),
+                abi=coupontoken_1["abi"],
+            )
+
+            local_account_1 = web3.eth.account.create()
+
+            # テスト用のトランザクション実行前の事前準備
+            pre_tx = token_contract_1.functions.transfer(
+                to_checksum_address(local_account_1.address), 10
+            ).build_transaction(
+                {
+                    "from": to_checksum_address(issuer["account_address"]),
+                    "gas": 6000000,
+                    "gasPrice": 0,
+                }
+            )
+            tx_hash = web3.eth.send_transaction(pre_tx)
+            web3.eth.wait_for_transaction_receipt(tx_hash)
+
+            tx = token_contract_1.functions.consume(10).build_transaction(
+                {
+                    "from": to_checksum_address(local_account_1.address),
+                    "gas": 6000000,
+                    "gasPrice": 0,
+                }
+            )
+            tx["nonce"] = web3.eth.get_transaction_count(
+                to_checksum_address(local_account_1.address)
+            )
+            signed_tx_1 = web3.eth.account.sign_transaction(tx, local_account_1.key)
+
+            session.commit()
+
+            request_params = {"raw_tx_hex_list": [signed_tx_1.rawTransaction.hex()]}
+            headers = {"Content-Type": "application/json"}
+            with mock.patch(
+                "web3.eth.async_eth.AsyncEth.send_raw_transaction",
+                MagicMock(
+                    side_effect=ValueError(
+                        {"code": -320000, "message": "already known"}
+                    )
+                ),
+            ):
+                resp = client.post(self.apiurl, headers=headers, json=request_params)
+
+            assert resp.status_code == 200
+            assert resp.json()["meta"] == {"code": 200, "message": "OK"}
+            assert resp.json()["data"] == [
+                {"id": 1, "status": 4, "transaction_hash": ANY}
+            ]
 
     ###########################################################################
     # Error

--- a/tests/app/eth_SendRawTransaction_test.py
+++ b/tests/app/eth_SendRawTransaction_test.py
@@ -414,6 +414,194 @@ class TestEthSendRawTransaction:
         assert resp.json()["meta"] == {"code": 200, "message": "OK"}
         assert resp.json()["data"] == [{"id": 1, "status": 2, "transaction_hash": ANY}]
 
+    # <Normal_4>
+    # nonce too low
+    def test_normal_4(self, client: TestClient, session: Session):
+        with mock.patch(
+            "app.utils.web3_utils.AsyncFailOverHTTPProvider.fail_over_mode", True
+        ):
+            insert_node_data(
+                session, is_synced=False, endpoint_uri="http://localhost:8546"
+            )
+            insert_node_data(
+                session,
+                is_synced=True,
+                endpoint_uri=config.WEB3_HTTP_PROVIDER,
+                priority=1,
+            )
+
+            # トークンリスト登録
+            tokenlist = tokenlist_contract()
+            config.TOKEN_LIST_CONTRACT_ADDRESS = tokenlist["address"]
+            issuer = eth_account["issuer"]
+            coupontoken_1 = issue_coupon_token(
+                issuer,
+                {
+                    "name": "name_test1",
+                    "symbol": "symbol_test1",
+                    "totalSupply": 1000000,
+                    "tradableExchange": config.ZERO_ADDRESS,
+                    "details": "details_test1",
+                    "returnDetails": "returnDetails_test1",
+                    "memo": "memo_test1",
+                    "expirationDate": "20211201",
+                    "transferable": True,
+                    "contactInformation": "contactInformation_test1",
+                    "privacyPolicy": "privacyPolicy_test1",
+                },
+            )
+            coupon_register_list(issuer, coupontoken_1, tokenlist)
+
+            # Listing,実行可能コントラクト登録
+            listing_token(session, coupontoken_1)
+            executable_contract_token(session, coupontoken_1)
+
+            token_contract_1 = web3.eth.contract(
+                address=to_checksum_address(coupontoken_1["address"]),
+                abi=coupontoken_1["abi"],
+            )
+
+            local_account_1 = web3.eth.account.create()
+
+            # テスト用のトランザクション実行前の事前準備
+            pre_tx = token_contract_1.functions.transfer(
+                to_checksum_address(local_account_1.address), 10
+            ).build_transaction(
+                {
+                    "from": to_checksum_address(issuer["account_address"]),
+                    "gas": 6000000,
+                    "gasPrice": 0,
+                }
+            )
+            tx_hash = web3.eth.send_transaction(pre_tx)
+            web3.eth.wait_for_transaction_receipt(tx_hash)
+
+            tx = token_contract_1.functions.consume(10).build_transaction(
+                {
+                    "from": to_checksum_address(local_account_1.address),
+                    "gas": 6000000,
+                    "gasPrice": 0,
+                }
+            )
+            tx["nonce"] = web3.eth.get_transaction_count(
+                to_checksum_address(local_account_1.address)
+            )
+            signed_tx_1 = web3.eth.account.sign_transaction(tx, local_account_1.key)
+
+            session.commit()
+
+            request_params = {"raw_tx_hex_list": [signed_tx_1.rawTransaction.hex()]}
+            headers = {"Content-Type": "application/json"}
+            with mock.patch(
+                "web3.eth.async_eth.AsyncEth.send_raw_transaction",
+                MagicMock(
+                    side_effect=ValueError(
+                        {"code": -320000, "message": "nonce too low"}
+                    )
+                ),
+            ):
+                resp = client.post(self.apiurl, headers=headers, json=request_params)
+
+            assert resp.status_code == 200
+            assert resp.json()["meta"] == {"code": 200, "message": "OK"}
+            assert resp.json()["data"] == [
+                {"id": 1, "status": 3, "transaction_hash": ANY}
+            ]
+
+    # <Normal_5>
+    # already known
+    def test_normal_5(self, client: TestClient, session: Session):
+        with mock.patch(
+            "app.utils.web3_utils.AsyncFailOverHTTPProvider.fail_over_mode", True
+        ):
+            insert_node_data(
+                session, is_synced=False, endpoint_uri="http://localhost:8546"
+            )
+            insert_node_data(
+                session,
+                is_synced=True,
+                endpoint_uri=config.WEB3_HTTP_PROVIDER,
+                priority=1,
+            )
+
+            # トークンリスト登録
+            tokenlist = tokenlist_contract()
+            config.TOKEN_LIST_CONTRACT_ADDRESS = tokenlist["address"]
+            issuer = eth_account["issuer"]
+            coupontoken_1 = issue_coupon_token(
+                issuer,
+                {
+                    "name": "name_test1",
+                    "symbol": "symbol_test1",
+                    "totalSupply": 1000000,
+                    "tradableExchange": config.ZERO_ADDRESS,
+                    "details": "details_test1",
+                    "returnDetails": "returnDetails_test1",
+                    "memo": "memo_test1",
+                    "expirationDate": "20211201",
+                    "transferable": True,
+                    "contactInformation": "contactInformation_test1",
+                    "privacyPolicy": "privacyPolicy_test1",
+                },
+            )
+            coupon_register_list(issuer, coupontoken_1, tokenlist)
+
+            # Listing,実行可能コントラクト登録
+            listing_token(session, coupontoken_1)
+            executable_contract_token(session, coupontoken_1)
+
+            token_contract_1 = web3.eth.contract(
+                address=to_checksum_address(coupontoken_1["address"]),
+                abi=coupontoken_1["abi"],
+            )
+
+            local_account_1 = web3.eth.account.create()
+
+            # テスト用のトランザクション実行前の事前準備
+            pre_tx = token_contract_1.functions.transfer(
+                to_checksum_address(local_account_1.address), 10
+            ).build_transaction(
+                {
+                    "from": to_checksum_address(issuer["account_address"]),
+                    "gas": 6000000,
+                    "gasPrice": 0,
+                }
+            )
+            tx_hash = web3.eth.send_transaction(pre_tx)
+            web3.eth.wait_for_transaction_receipt(tx_hash)
+
+            tx = token_contract_1.functions.consume(10).build_transaction(
+                {
+                    "from": to_checksum_address(local_account_1.address),
+                    "gas": 6000000,
+                    "gasPrice": 0,
+                }
+            )
+            tx["nonce"] = web3.eth.get_transaction_count(
+                to_checksum_address(local_account_1.address)
+            )
+            signed_tx_1 = web3.eth.account.sign_transaction(tx, local_account_1.key)
+
+            session.commit()
+
+            request_params = {"raw_tx_hex_list": [signed_tx_1.rawTransaction.hex()]}
+            headers = {"Content-Type": "application/json"}
+            with mock.patch(
+                "web3.eth.async_eth.AsyncEth.send_raw_transaction",
+                MagicMock(
+                    side_effect=ValueError(
+                        {"code": -320000, "message": "already known"}
+                    )
+                ),
+            ):
+                resp = client.post(self.apiurl, headers=headers, json=request_params)
+
+            assert resp.status_code == 200
+            assert resp.json()["meta"] == {"code": 200, "message": "OK"}
+            assert resp.json()["data"] == [
+                {"id": 1, "status": 4, "transaction_hash": ANY}
+            ]
+
     ###########################################################################
     # Error
     ###########################################################################


### PR DESCRIPTION
Close: #1482 

- Detailed the response status of eth_sendRawTransaction to distinguish whether the error returned from quorum RPC is `already known`, `nonce too low` or a failure
  - POST: `/Eth/SendRawTransaction`
  - POST: `/Eth/SendRawTransactionNoWait`