### PR TITLE
Fixed to use nested transaction when saving token cache

### DIFF
--- a/batch/indexer_Token_Detail.py
+++ b/batch/indexer_Token_Detail.py
@@ -123,8 +123,9 @@ class Processor:
                     )
                     token_detail = token_detail_obj.to_model()
                     token_detail.created = datetime.utcnow()
-                    await local_session.merge(token_detail)
-                    await local_session.commit()
+                    async with local_session.begin_nested():
+                        await local_session.merge(token_detail)
+                        await local_session.commit()
 
                     # Keep request interval constant to avoid throwing many request to JSON-RPC
                     elapsed_time = time.time() - start_time

--- a/batch/indexer_Token_Detail_ShortTerm.py
+++ b/batch/indexer_Token_Detail_ShortTerm.py
@@ -136,8 +136,9 @@ class Processor:
                     token = token_type.token_class.from_model(available_token)
                     await token.fetch_expiry_short()
                     token_model = token.to_model()
-                    await local_session.merge(token_model)
-                    await local_session.commit()
+                    async with local_session.begin_nested():
+                        await local_session.merge(token_model)
+                        await local_session.commit()
 
                     # Keep request interval constant to avoid throwing many request to JSON-RPC
                     elapsed_time = time.time() - start_time


### PR DESCRIPTION
Fix: #1486 

- Fixed to use nested transaction on saving token cache in order to reuse Session object after failing to save a token cache.