### PR TITLE
Upgrade web3py to v7

### DIFF
--- a/app/api/routers/events.py
+++ b/app/api/routers/events.py
@@ -105,8 +105,8 @@ async def list_all_e2e_messaging_event_logs(
         contract_event = getattr(contract.events, attr)
         try:
             events = await contract_event.get_logs(
-                fromBlock=request_query.from_block,
-                toBlock=request_query.to_block,
+                from_block=request_query.from_block,
+                to_block=request_query.to_block,
                 argument_filters=argument_filters_dict,
             )
         except Web3ValidationError:
@@ -120,7 +120,7 @@ async def list_all_e2e_messaging_event_logs(
                 {
                     "event": event["event"],
                     "args": dict(event["args"]),
-                    "transaction_hash": event["transactionHash"].hex(),
+                    "transaction_hash": event["transactionHash"].to_0x_hex(),
                     "block_number": block_number,
                     "block_timestamp": block_timestamp,
                     "log_index": event["logIndex"],
@@ -190,8 +190,8 @@ async def list_all_ibet_escrow_event_logs(
         contract_event = getattr(contract.events, attr)
         try:
             events = await contract_event.get_logs(
-                fromBlock=request_query.from_block,
-                toBlock=request_query.to_block,
+                from_block=request_query.from_block,
+                to_block=request_query.to_block,
                 argument_filters=argument_filters_dict,
             )
         except Web3ValidationError:
@@ -205,7 +205,7 @@ async def list_all_ibet_escrow_event_logs(
                 {
                     "event": event["event"],
                     "args": dict(event["args"]),
-                    "transaction_hash": event["transactionHash"].hex(),
+                    "transaction_hash": event["transactionHash"].to_0x_hex(),
                     "block_number": block_number,
                     "block_timestamp": block_timestamp,
                     "log_index": event["logIndex"],
@@ -285,8 +285,8 @@ async def list_all_ibet_security_token_escrow_event_logs(
         contract_event = getattr(contract.events, attr)
         try:
             events = await contract_event.get_logs(
-                fromBlock=request_query.from_block,
-                toBlock=request_query.to_block,
+                from_block=request_query.from_block,
+                to_block=request_query.to_block,
                 argument_filters=argument_filters_dict,
             )
         except Web3ValidationError:
@@ -300,7 +300,7 @@ async def list_all_ibet_security_token_escrow_event_logs(
                 {
                     "event": event["event"],
                     "args": dict(event["args"]),
-                    "transaction_hash": event["transactionHash"].hex(),
+                    "transaction_hash": event["transactionHash"].to_0x_hex(),
                     "block_number": block_number,
                     "block_timestamp": block_timestamp,
                     "log_index": event["logIndex"],
@@ -381,8 +381,8 @@ async def list_all_ibet_security_token_escrow_event_logs(
         contract_event = getattr(contract.events, attr)
         try:
             events = await contract_event.get_logs(
-                fromBlock=request_query.from_block,
-                toBlock=request_query.to_block,
+                from_block=request_query.from_block,
+                to_block=request_query.to_block,
                 argument_filters=argument_filters_dict,
             )
         except Web3ValidationError:
@@ -396,7 +396,7 @@ async def list_all_ibet_security_token_escrow_event_logs(
                 {
                     "event": event["event"],
                     "args": dict(event["args"]),
-                    "transaction_hash": event["transactionHash"].hex(),
+                    "transaction_hash": event["transactionHash"].to_0x_hex(),
                     "block_number": block_number,
                     "block_timestamp": block_timestamp,
                     "log_index": event["logIndex"],
@@ -455,8 +455,8 @@ async def list_all_ibet_security_token_interface_event_logs(
         contract_event = getattr(contract.events, attr)
         try:
             events = await contract_event.get_logs(
-                fromBlock=request_query.from_block,
-                toBlock=request_query.to_block,
+                from_block=request_query.from_block,
+                to_block=request_query.to_block,
                 argument_filters=argument_filters_dict,
             )
         except Web3ValidationError:
@@ -470,7 +470,7 @@ async def list_all_ibet_security_token_interface_event_logs(
                 {
                     "event": event["event"],
                     "args": dict(event["args"]),
-                    "transaction_hash": event["transactionHash"].hex(),
+                    "transaction_hash": event["transactionHash"].to_0x_hex(),
                     "block_number": block_number,
                     "block_timestamp": block_timestamp,
                     "log_index": event["logIndex"],

--- a/app/utils/web3_utils.py
+++ b/app/utils/web3_utils.py
@@ -32,7 +32,7 @@ from sqlalchemy.orm import Session
 from web3 import AsyncHTTPProvider, AsyncWeb3, HTTPProvider, Web3
 from web3.eth import AsyncEth
 from web3.geth import AsyncGeth
-from web3.middleware import async_geth_poa_middleware, geth_poa_middleware
+from web3.middleware import ExtraDataToPOAMiddleware
 from web3.net import AsyncNet
 from web3.types import RPCEndpoint, RPCResponse
 
@@ -78,7 +78,7 @@ class Web3Wrapper:
             web3 = Web3(
                 FailOverHTTPProvider(request_kwargs={"timeout": request_timeout})
             )
-            web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+            web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
             thread_local.web3 = web3
 
         return web3
@@ -116,7 +116,7 @@ class AsyncWeb3Wrapper:
             async_web3 = AsyncWeb3(
                 AsyncFailOverHTTPProvider(request_kwargs={"timeout": request_timeout})
             )
-            async_web3.middleware_onion.inject(async_geth_poa_middleware, layer=0)
+            async_web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
             thread_local.async_web3 = async_web3
 
         return async_web3

--- a/batch/indexer_Block_Tx_Data.py
+++ b/batch/indexer_Block_Tx_Data.py
@@ -66,23 +66,25 @@ class Processor:
                 # Synchronize block data
                 block_model = IDXBlockData()
                 block_model.number = block_data.get("number")
-                block_model.parent_hash = block_data.get("parentHash").hex()
-                block_model.sha3_uncles = block_data.get("sha3Uncles").hex()
+                block_model.parent_hash = block_data.get("parentHash").to_0x_hex()
+                block_model.sha3_uncles = block_data.get("sha3Uncles").to_0x_hex()
                 block_model.miner = block_data.get("miner")
-                block_model.state_root = block_data.get("stateRoot").hex()
-                block_model.transactions_root = block_data.get("transactionsRoot").hex()
-                block_model.receipts_root = block_data.get("receiptsRoot").hex()
-                block_model.logs_bloom = block_data.get("logsBloom").hex()
+                block_model.state_root = block_data.get("stateRoot").to_0x_hex()
+                block_model.transactions_root = block_data.get(
+                    "transactionsRoot"
+                ).to_0x_hex()
+                block_model.receipts_root = block_data.get("receiptsRoot").to_0x_hex()
+                block_model.logs_bloom = block_data.get("logsBloom").to_0x_hex()
                 block_model.difficulty = block_data.get("difficulty")
                 block_model.gas_limit = block_data.get("gasLimit")
                 block_model.gas_used = block_data.get("gasUsed")
                 block_model.timestamp = block_data.get("timestamp")
                 block_model.proof_of_authority_data = block_data.get(
                     "proofOfAuthorityData"
-                ).hex()
-                block_model.mix_hash = block_data.get("mixHash").hex()
-                block_model.nonce = block_data.get("nonce").hex()
-                block_model.hash = block_data.get("hash").hex()
+                ).to_0x_hex()
+                block_model.mix_hash = block_data.get("mixHash").to_0x_hex()
+                block_model.nonce = block_data.get("nonce").to_0x_hex()
+                block_model.hash = block_data.get("hash").to_0x_hex()
                 block_model.size = block_data.get("size")
 
                 transactions: Sequence[TxData] = block_data.get("transactions")
@@ -90,8 +92,8 @@ class Processor:
                 for transaction in transactions:
                     # Synchronize tx data
                     tx_model = IDXTxData()
-                    tx_model.hash = transaction.get("hash").hex()
-                    tx_model.block_hash = transaction.get("blockHash").hex()
+                    tx_model.hash = transaction.get("hash").to_0x_hex()
+                    tx_model.block_hash = transaction.get("blockHash").to_0x_hex()
                     tx_model.block_number = transaction.get("blockNumber")
                     tx_model.transaction_index = transaction.get("transactionIndex")
                     tx_model.from_address = to_checksum_address(transaction.get("from"))
@@ -100,14 +102,14 @@ class Processor:
                         if transaction.get("to")
                         else None
                     )
-                    tx_model.input = transaction.get("input").hex()
+                    tx_model.input = transaction.get("input").to_0x_hex()
                     tx_model.gas = transaction.get("gas")
                     tx_model.gas_price = transaction.get("gasPrice")
                     tx_model.value = transaction.get("value")
                     tx_model.nonce = transaction.get("nonce")
                     local_session.add(tx_model)
 
-                    transaction_hash_list.append(transaction.get("hash").hex())
+                    transaction_hash_list.append(transaction.get("hash").to_0x_hex())
 
                 block_model.transactions = transaction_hash_list
                 local_session.add(block_model)

--- a/batch/indexer_Consume_Coupon.py
+++ b/batch/indexer_Consume_Coupon.py
@@ -156,14 +156,14 @@ class Processor:
         for token in self.token_list:
             try:
                 events = await token.events.Consume.get_logs(
-                    fromBlock=block_from, toBlock=block_to
+                    from_block=block_from, to_block=block_to
                 )
             except ABIEventFunctionNotFound:
                 events = []
             try:
                 for event in events:
                     args = event["args"]
-                    transaction_hash = event["transactionHash"].hex()
+                    transaction_hash = event["transactionHash"].to_0x_hex()
                     block_timestamp = datetime.fromtimestamp(
                         (await async_web3.eth.get_block(event["blockNumber"]))[
                             "timestamp"

--- a/batch/indexer_DEX.py
+++ b/batch/indexer_DEX.py
@@ -152,7 +152,7 @@ class Processor:
         for exchange_contract in self.exchange_list:
             try:
                 events = await exchange_contract.events.NewOrder.get_logs(
-                    fromBlock=block_from, toBlock=block_to
+                    from_block=block_from, to_block=block_to
                 )
             except ABIEventFunctionNotFound:
                 events = []
@@ -169,7 +169,7 @@ class Processor:
                                 .limit(1)
                             )
                         ).first()
-                        transaction_hash = event["transactionHash"].hex()
+                        transaction_hash = event["transactionHash"].to_0x_hex()
                         order_timestamp = datetime.fromtimestamp(
                             (await async_web3.eth.get_block(event["blockNumber"]))[
                                 "timestamp"
@@ -202,7 +202,7 @@ class Processor:
         for exchange_contract in self.exchange_list:
             try:
                 events = await exchange_contract.events.CancelOrder.get_logs(
-                    fromBlock=block_from, toBlock=block_to
+                    from_block=block_from, to_block=block_to
                 )
             except ABIEventFunctionNotFound:
                 events = []
@@ -222,7 +222,7 @@ class Processor:
         for exchange_contract in self.exchange_list:
             try:
                 events = await exchange_contract.events.ForceCancelOrder.get_logs(
-                    fromBlock=block_from, toBlock=block_to
+                    from_block=block_from, to_block=block_to
                 )
             except ABIEventFunctionNotFound:
                 events = []
@@ -240,7 +240,7 @@ class Processor:
         for exchange_contract in self.exchange_list:
             try:
                 events = await exchange_contract.events.Agree.get_logs(
-                    fromBlock=block_from, toBlock=block_to
+                    from_block=block_from, to_block=block_to
                 )
             except ABIEventFunctionNotFound:
                 events = []
@@ -261,7 +261,7 @@ class Processor:
                             counterpart_address = args["sellAddress"]
                         else:
                             counterpart_address = args["buyAddress"]
-                        transaction_hash = event["transactionHash"].hex()
+                        transaction_hash = event["transactionHash"].to_0x_hex()
                         agreement_timestamp = datetime.fromtimestamp(
                             (await async_web3.eth.get_block(event["blockNumber"]))[
                                 "timestamp"
@@ -289,7 +289,7 @@ class Processor:
         for exchange_contract in self.exchange_list:
             try:
                 events = await exchange_contract.events.SettlementOK.get_logs(
-                    fromBlock=block_from, toBlock=block_to
+                    from_block=block_from, to_block=block_to
                 )
             except ABIEventFunctionNotFound:
                 events = []
@@ -318,7 +318,7 @@ class Processor:
         for exchange_contract in self.exchange_list:
             try:
                 events = await exchange_contract.events.SettlementNG.get_logs(
-                    fromBlock=block_from, toBlock=block_to
+                    from_block=block_from, to_block=block_to
                 )
             except ABIEventFunctionNotFound:
                 events = []

--- a/batch/indexer_Position_Bond.py
+++ b/batch/indexer_Position_Bond.py
@@ -303,7 +303,7 @@ class Processor:
                 continue
             try:
                 events: list[LogReceipt] = await token.events.Transfer.get_logs(
-                    fromBlock=block_from, toBlock=block_to
+                    from_block=block_from, to_block=block_to
                 )
             except ABIEventFunctionNotFound:
                 events = []
@@ -312,7 +312,7 @@ class Processor:
                     events=events, account_keys=["from", "to"]
                 )
                 for _account in accounts_filtered:
-                    if (await async_web3.eth.get_code(_account)).hex() == "0x":
+                    if (await async_web3.eth.get_code(_account)).to_0x_hex() == "0x":
                         (
                             _balance,
                             _pending_transfer,
@@ -345,7 +345,7 @@ class Processor:
                 continue
             try:
                 events = await token.events.Lock.get_logs(
-                    fromBlock=block_from, toBlock=block_to
+                    from_block=block_from, to_block=block_to
                 )
             except ABIEventFunctionNotFound:
                 events = []
@@ -364,7 +364,7 @@ class Processor:
                     # Index Lock event
                     self.__insert_lock_idx(
                         db_session=db_session,
-                        transaction_hash=event["transactionHash"].hex(),
+                        transaction_hash=event["transactionHash"].to_0x_hex(),
                         msg_sender=msg_sender,
                         block_number=event["blockNumber"],
                         token_address=token.address,
@@ -425,7 +425,7 @@ class Processor:
                 continue
             try:
                 events = await token.events.Unlock.get_logs(
-                    fromBlock=block_from, toBlock=block_to
+                    from_block=block_from, to_block=block_to
                 )
             except ABIEventFunctionNotFound:
                 events = []
@@ -445,7 +445,7 @@ class Processor:
                     # Index Unlock event
                     self.__insert_unlock_idx(
                         db_session=db_session,
-                        transaction_hash=event["transactionHash"].hex(),
+                        transaction_hash=event["transactionHash"].to_0x_hex(),
                         msg_sender=msg_sender,
                         block_number=event["blockNumber"],
                         token_address=token.address,
@@ -507,7 +507,7 @@ class Processor:
                 continue
             try:
                 events = await token.events.Issue.get_logs(
-                    fromBlock=block_from, toBlock=block_to
+                    from_block=block_from, to_block=block_to
                 )
             except ABIEventFunctionNotFound:
                 events = []
@@ -543,7 +543,7 @@ class Processor:
                 continue
             try:
                 events = await token.events.Redeem.get_logs(
-                    fromBlock=block_from, toBlock=block_to
+                    from_block=block_from, to_block=block_to
                 )
             except ABIEventFunctionNotFound:
                 events = []
@@ -579,7 +579,7 @@ class Processor:
                 continue
             try:
                 events = await token.events.ApplyForTransfer.get_logs(
-                    fromBlock=block_from, toBlock=block_to
+                    from_block=block_from, to_block=block_to
                 )
             except ABIEventFunctionNotFound:
                 events = []
@@ -615,7 +615,7 @@ class Processor:
                 continue
             try:
                 events = await token.events.CancelTransfer.get_logs(
-                    fromBlock=block_from, toBlock=block_to
+                    from_block=block_from, to_block=block_to
                 )
             except ABIEventFunctionNotFound:
                 events = []
@@ -651,7 +651,7 @@ class Processor:
                 continue
             try:
                 events = await token.events.ApproveTransfer.get_logs(
-                    fromBlock=block_from, toBlock=block_to
+                    from_block=block_from, to_block=block_to
                 )
             except ABIEventFunctionNotFound:
                 events = []
@@ -696,7 +696,7 @@ class Processor:
                 # NewOrder event
                 try:
                     _event_list = await exchange.events.NewOrder.get_logs(
-                        fromBlock=block_from, toBlock=block_to
+                        from_block=block_from, to_block=block_to
                     )
                 except ABIEventFunctionNotFound:
                     _event_list = []
@@ -721,7 +721,7 @@ class Processor:
                 # CancelOrder event
                 try:
                     _event_list = await exchange.events.CancelOrder.get_logs(
-                        fromBlock=block_from, toBlock=block_to
+                        from_block=block_from, to_block=block_to
                     )
                 except ABIEventFunctionNotFound:
                     _event_list = []
@@ -746,7 +746,7 @@ class Processor:
                 # ForceCancelOrder event
                 try:
                     _event_list = await exchange.events.ForceCancelOrder.get_logs(
-                        fromBlock=block_from, toBlock=block_to
+                        from_block=block_from, to_block=block_to
                     )
                 except ABIEventFunctionNotFound:
                     _event_list = []
@@ -771,7 +771,7 @@ class Processor:
                 # Agree event
                 try:
                     _event_list = await exchange.events.Agree.get_logs(
-                        fromBlock=block_from, toBlock=block_to
+                        from_block=block_from, to_block=block_to
                     )
                 except ABIEventFunctionNotFound:
                     _event_list = []
@@ -796,7 +796,7 @@ class Processor:
                 # SettlementOK event
                 try:
                     _event_list = await exchange.events.SettlementOK.get_logs(
-                        fromBlock=block_from, toBlock=block_to
+                        from_block=block_from, to_block=block_to
                     )
                 except ABIEventFunctionNotFound:
                     _event_list = []
@@ -831,7 +831,7 @@ class Processor:
                 # SettlementNG event
                 try:
                     _event_list = await exchange.events.SettlementNG.get_logs(
-                        fromBlock=block_from, toBlock=block_to
+                        from_block=block_from, to_block=block_to
                     )
                 except ABIEventFunctionNotFound:
                     _event_list = []
@@ -917,7 +917,7 @@ class Processor:
                 # EscrowCreated event
                 try:
                     _event_list = await escrow.events.EscrowCreated.get_logs(
-                        fromBlock=block_from, toBlock=block_to
+                        from_block=block_from, to_block=block_to
                     )
                 except ABIEventFunctionNotFound:
                     _event_list = []
@@ -940,7 +940,7 @@ class Processor:
                 # EscrowCanceled event
                 try:
                     _event_list = await escrow.events.EscrowCanceled.get_logs(
-                        fromBlock=block_from, toBlock=block_to
+                        from_block=block_from, to_block=block_to
                     )
                 except ABIEventFunctionNotFound:
                     _event_list = []
@@ -963,7 +963,7 @@ class Processor:
                 # HolderChanged event
                 try:
                     _event_list = await escrow.events.HolderChanged.get_logs(
-                        fromBlock=block_from, toBlock=block_to
+                        from_block=block_from, to_block=block_to
                     )
                 except ABIEventFunctionNotFound:
                     _event_list = []
@@ -1051,7 +1051,7 @@ class Processor:
                 # DeliveryCreated event
                 try:
                     _event_list = await dvp.events.DeliveryCreated.get_logs(
-                        fromBlock=block_from, toBlock=block_to
+                        from_block=block_from, to_block=block_to
                     )
                 except ABIEventFunctionNotFound:
                     _event_list = []
@@ -1074,7 +1074,7 @@ class Processor:
                 # DeliveryCanceled event
                 try:
                     _event_list = await dvp.events.DeliveryCanceled.get_logs(
-                        fromBlock=block_from, toBlock=block_to
+                        from_block=block_from, to_block=block_to
                     )
                 except ABIEventFunctionNotFound:
                     _event_list = []
@@ -1097,7 +1097,7 @@ class Processor:
                 # DeliveryAborted event
                 try:
                     _event_list = await dvp.events.DeliveryAborted.get_logs(
-                        fromBlock=block_from, toBlock=block_to
+                        from_block=block_from, to_block=block_to
                     )
                 except ABIEventFunctionNotFound:
                     _event_list = []
@@ -1120,7 +1120,7 @@ class Processor:
                     # HolderChanged event
                 try:
                     _event_list = await dvp.events.HolderChanged.get_logs(
-                        fromBlock=block_from, toBlock=block_to
+                        from_block=block_from, to_block=block_to
                     )
                 except ABIEventFunctionNotFound:
                     _event_list = []

--- a/batch/indexer_Position_Coupon.py
+++ b/batch/indexer_Position_Coupon.py
@@ -283,7 +283,7 @@ class Processor:
                 continue
             try:
                 events = await token.events.Transfer.get_logs(
-                    fromBlock=block_from, toBlock=block_to
+                    from_block=block_from, to_block=block_to
                 )
             except ABIEventFunctionNotFound:
                 events = []
@@ -292,7 +292,7 @@ class Processor:
                     events=events, account_keys=["from", "to"]
                 )
                 for _account in accounts_filtered:
-                    if (await async_web3.eth.get_code(_account)).hex() == "0x":
+                    if (await async_web3.eth.get_code(_account)).to_0x_hex() == "0x":
                         (
                             _balance,
                             _exchange_balance,
@@ -323,7 +323,7 @@ class Processor:
                 continue
             try:
                 events = await token.events.Consume.get_logs(
-                    fromBlock=block_from, toBlock=block_to
+                    from_block=block_from, to_block=block_to
                 )
             except ABIEventFunctionNotFound:
                 events = []
@@ -339,7 +339,7 @@ class Processor:
                         db_session=db_session,
                         token_address=to_checksum_address(token.address),
                         account_address=consumer_address,
-                        xsbalance=balance,
+                        balance=balance,
                     )
             except Exception as e:
                 raise e
@@ -366,7 +366,7 @@ class Processor:
                 # NewOrder event
                 try:
                     _event_list = await exchange.events.NewOrder.get_logs(
-                        fromBlock=block_from, toBlock=block_to
+                        from_block=block_from, to_block=block_to
                     )
                 except ABIEventFunctionNotFound:
                     _event_list = []
@@ -391,7 +391,7 @@ class Processor:
                 # CancelOrder event
                 try:
                     _event_list = await exchange.events.CancelOrder.get_logs(
-                        fromBlock=block_from, toBlock=block_to
+                        from_block=block_from, to_block=block_to
                     )
                 except ABIEventFunctionNotFound:
                     _event_list = []
@@ -416,7 +416,7 @@ class Processor:
                 # ForceCancelOrder event
                 try:
                     _event_list = await exchange.events.ForceCancelOrder.get_logs(
-                        fromBlock=block_from, toBlock=block_to
+                        from_block=block_from, to_block=block_to
                     )
                 except ABIEventFunctionNotFound:
                     _event_list = []
@@ -441,7 +441,7 @@ class Processor:
                 # Agree event
                 try:
                     _event_list = await exchange.events.Agree.get_logs(
-                        fromBlock=block_from, toBlock=block_to
+                        from_block=block_from, to_block=block_to
                     )
                 except ABIEventFunctionNotFound:
                     _event_list = []
@@ -466,7 +466,7 @@ class Processor:
                 # SettlementOK event
                 try:
                     _event_list = await exchange.events.SettlementOK.get_logs(
-                        fromBlock=block_from, toBlock=block_to
+                        from_block=block_from, to_block=block_to
                     )
                 except ABIEventFunctionNotFound:
                     _event_list = []
@@ -501,7 +501,7 @@ class Processor:
                 # SettlementNG event
                 try:
                     _event_list = await exchange.events.SettlementNG.get_logs(
-                        fromBlock=block_from, toBlock=block_to
+                        from_block=block_from, to_block=block_to
                     )
                 except ABIEventFunctionNotFound:
                     _event_list = []
@@ -585,7 +585,7 @@ class Processor:
                 # EscrowCreated event
                 try:
                     _event_list = await escrow.events.EscrowCreated.get_logs(
-                        fromBlock=block_from, toBlock=block_to
+                        from_block=block_from, to_block=block_to
                     )
                 except ABIEventFunctionNotFound:
                     _event_list = []
@@ -608,7 +608,7 @@ class Processor:
                 # EscrowCanceled event
                 try:
                     _event_list = await escrow.events.EscrowCanceled.get_logs(
-                        fromBlock=block_from, toBlock=block_to
+                        from_block=block_from, to_block=block_to
                     )
                 except ABIEventFunctionNotFound:
                     _event_list = []
@@ -631,7 +631,7 @@ class Processor:
                 # EscrowFinished event
                 try:
                     _event_list = await escrow.events.EscrowFinished.get_logs(
-                        fromBlock=block_from, toBlock=block_to
+                        from_block=block_from, to_block=block_to
                     )
                 except ABIEventFunctionNotFound:
                     _event_list = []

--- a/batch/indexer_Position_Membership.py
+++ b/batch/indexer_Position_Membership.py
@@ -283,7 +283,7 @@ class Processor:
                 continue
             try:
                 events = await token.events.Transfer.get_logs(
-                    fromBlock=block_from, toBlock=block_to
+                    from_block=block_from, to_block=block_to
                 )
             except ABIEventFunctionNotFound:
                 events = []
@@ -292,7 +292,7 @@ class Processor:
                     events=events, account_keys=["from", "to"]
                 )
                 for _account in accounts_filtered:
-                    if (await async_web3.eth.get_code(_account)).hex() == "0x":
+                    if (await async_web3.eth.get_code(_account)).to_0x_hex() == "0x":
                         (
                             _balance,
                             _exchange_balance,
@@ -331,7 +331,7 @@ class Processor:
                 # NewOrder event
                 try:
                     _event_list = await exchange.events.NewOrder.get_logs(
-                        fromBlock=block_from, toBlock=block_to
+                        from_block=block_from, to_block=block_to
                     )
                 except ABIEventFunctionNotFound:
                     _event_list = []
@@ -356,7 +356,7 @@ class Processor:
                 # CancelOrder event
                 try:
                     _event_list = await exchange.events.CancelOrder.get_logs(
-                        fromBlock=block_from, toBlock=block_to
+                        from_block=block_from, to_block=block_to
                     )
                 except ABIEventFunctionNotFound:
                     _event_list = []
@@ -381,7 +381,7 @@ class Processor:
                 # ForceCancelOrder event
                 try:
                     _event_list = await exchange.events.ForceCancelOrder.get_logs(
-                        fromBlock=block_from, toBlock=block_to
+                        from_block=block_from, to_block=block_to
                     )
                 except ABIEventFunctionNotFound:
                     _event_list = []
@@ -406,7 +406,7 @@ class Processor:
                 # Agree event
                 try:
                     _event_list = await exchange.events.Agree.get_logs(
-                        fromBlock=block_from, toBlock=block_to
+                        from_block=block_from, to_block=block_to
                     )
                 except ABIEventFunctionNotFound:
                     _event_list = []
@@ -431,7 +431,7 @@ class Processor:
                 # SettlementOK event
                 try:
                     _event_list = await exchange.events.SettlementOK.get_logs(
-                        fromBlock=block_from, toBlock=block_to
+                        from_block=block_from, to_block=block_to
                     )
                 except ABIEventFunctionNotFound:
                     _event_list = []
@@ -466,7 +466,7 @@ class Processor:
                 # SettlementNG event
                 try:
                     _event_list = await exchange.events.SettlementNG.get_logs(
-                        fromBlock=block_from, toBlock=block_to
+                        from_block=block_from, to_block=block_to
                     )
                 except ABIEventFunctionNotFound:
                     _event_list = []
@@ -550,7 +550,7 @@ class Processor:
                 # EscrowCreated event
                 try:
                     _event_list = await escrow.events.EscrowCreated.get_logs(
-                        fromBlock=block_from, toBlock=block_to
+                        from_block=block_from, to_block=block_to
                     )
                 except ABIEventFunctionNotFound:
                     _event_list = []
@@ -573,7 +573,7 @@ class Processor:
                 # EscrowCanceled event
                 try:
                     _event_list = await escrow.events.EscrowCanceled.get_logs(
-                        fromBlock=block_from, toBlock=block_to
+                        from_block=block_from, to_block=block_to
                     )
                 except ABIEventFunctionNotFound:
                     _event_list = []
@@ -596,7 +596,7 @@ class Processor:
                 # EscrowFinished event
                 try:
                     _event_list = await escrow.events.EscrowFinished.get_logs(
-                        fromBlock=block_from, toBlock=block_to
+                        from_block=block_from, to_block=block_to
                     )
                 except ABIEventFunctionNotFound:
                     _event_list = []

--- a/batch/indexer_Position_Share.py
+++ b/batch/indexer_Position_Share.py
@@ -302,7 +302,7 @@ class Processor:
                 continue
             try:
                 events = await token.events.Transfer.get_logs(
-                    fromBlock=block_from, toBlock=block_to
+                    from_block=block_from, to_block=block_to
                 )
             except ABIEventFunctionNotFound:
                 events = []
@@ -311,7 +311,7 @@ class Processor:
                     events=events, account_keys=["from", "to"]
                 )
                 for _account in accounts_filtered:
-                    if (await async_web3.eth.get_code(_account)).hex() == "0x":
+                    if (await async_web3.eth.get_code(_account)).to_0x_hex() == "0x":
                         (
                             _balance,
                             _pending_transfer,
@@ -344,7 +344,7 @@ class Processor:
                 continue
             try:
                 events = await token.events.Lock.get_logs(
-                    fromBlock=block_from, toBlock=block_to
+                    from_block=block_from, to_block=block_to
                 )
             except ABIEventFunctionNotFound:
                 events = []
@@ -363,7 +363,7 @@ class Processor:
                     # Index Lock event
                     self.__insert_lock_idx(
                         db_session=db_session,
-                        transaction_hash=event["transactionHash"].hex(),
+                        transaction_hash=event["transactionHash"].to_0x_hex(),
                         msg_sender=msg_sender,
                         block_number=event["blockNumber"],
                         token_address=token.address,
@@ -424,7 +424,7 @@ class Processor:
                 continue
             try:
                 events = await token.events.Unlock.get_logs(
-                    fromBlock=block_from, toBlock=block_to
+                    from_block=block_from, to_block=block_to
                 )
             except ABIEventFunctionNotFound:
                 events = []
@@ -444,7 +444,7 @@ class Processor:
                     # Index Unlock event
                     self.__insert_unlock_idx(
                         db_session=db_session,
-                        transaction_hash=event["transactionHash"].hex(),
+                        transaction_hash=event["transactionHash"].to_0x_hex(),
                         msg_sender=msg_sender,
                         block_number=event["blockNumber"],
                         token_address=token.address,
@@ -506,7 +506,7 @@ class Processor:
                 continue
             try:
                 events = await token.events.Issue.get_logs(
-                    fromBlock=block_from, toBlock=block_to
+                    from_block=block_from, to_block=block_to
                 )
             except ABIEventFunctionNotFound:
                 events = []
@@ -542,7 +542,7 @@ class Processor:
                 continue
             try:
                 events = await token.events.Redeem.get_logs(
-                    fromBlock=block_from, toBlock=block_to
+                    from_block=block_from, to_block=block_to
                 )
             except ABIEventFunctionNotFound:
                 events = []
@@ -578,7 +578,7 @@ class Processor:
                 continue
             try:
                 events = await token.events.ApplyForTransfer.get_logs(
-                    fromBlock=block_from, toBlock=block_to
+                    from_block=block_from, to_block=block_to
                 )
             except ABIEventFunctionNotFound:
                 events = []
@@ -614,7 +614,7 @@ class Processor:
                 continue
             try:
                 events = await token.events.CancelTransfer.get_logs(
-                    fromBlock=block_from, toBlock=block_to
+                    from_block=block_from, to_block=block_to
                 )
             except ABIEventFunctionNotFound:
                 events = []
@@ -650,7 +650,7 @@ class Processor:
                 continue
             try:
                 events = await token.events.ApproveTransfer.get_logs(
-                    fromBlock=block_from, toBlock=block_to
+                    from_block=block_from, to_block=block_to
                 )
             except ABIEventFunctionNotFound:
                 events = []
@@ -695,7 +695,7 @@ class Processor:
                 # NewOrder event
                 try:
                     _event_list = await exchange.events.NewOrder.get_logs(
-                        fromBlock=block_from, toBlock=block_to
+                        from_block=block_from, to_block=block_to
                     )
                 except ABIEventFunctionNotFound:
                     _event_list = []
@@ -720,7 +720,7 @@ class Processor:
                 # CancelOrder event
                 try:
                     _event_list = await exchange.events.CancelOrder.get_logs(
-                        fromBlock=block_from, toBlock=block_to
+                        from_block=block_from, to_block=block_to
                     )
                 except ABIEventFunctionNotFound:
                     _event_list = []
@@ -745,7 +745,7 @@ class Processor:
                 # ForceCancelOrder event
                 try:
                     _event_list = await exchange.events.ForceCancelOrder.get_logs(
-                        fromBlock=block_from, toBlock=block_to
+                        from_block=block_from, to_block=block_to
                     )
                 except ABIEventFunctionNotFound:
                     _event_list = []
@@ -770,7 +770,7 @@ class Processor:
                 # Agree event
                 try:
                     _event_list = await exchange.events.Agree.get_logs(
-                        fromBlock=block_from, toBlock=block_to
+                        from_block=block_from, to_block=block_to
                     )
                 except ABIEventFunctionNotFound:
                     _event_list = []
@@ -795,7 +795,7 @@ class Processor:
                 # SettlementOK event
                 try:
                     _event_list = await exchange.events.SettlementOK.get_logs(
-                        fromBlock=block_from, toBlock=block_to
+                        from_block=block_from, to_block=block_to
                     )
                 except ABIEventFunctionNotFound:
                     _event_list = []
@@ -830,7 +830,7 @@ class Processor:
                 # SettlementNG event
                 try:
                     _event_list = await exchange.events.SettlementNG.get_logs(
-                        fromBlock=block_from, toBlock=block_to
+                        from_block=block_from, to_block=block_to
                     )
                 except ABIEventFunctionNotFound:
                     _event_list = []
@@ -916,7 +916,7 @@ class Processor:
                 # EscrowCreated event
                 try:
                     _event_list = await escrow.events.EscrowCreated.get_logs(
-                        fromBlock=block_from, toBlock=block_to
+                        from_block=block_from, to_block=block_to
                     )
                 except ABIEventFunctionNotFound:
                     _event_list = []
@@ -939,7 +939,7 @@ class Processor:
                 # EscrowCanceled event
                 try:
                     _event_list = await escrow.events.EscrowCanceled.get_logs(
-                        fromBlock=block_from, toBlock=block_to
+                        from_block=block_from, to_block=block_to
                     )
                 except ABIEventFunctionNotFound:
                     _event_list = []
@@ -962,7 +962,7 @@ class Processor:
                 # HolderChanged event
                 try:
                     _event_list = await escrow.events.HolderChanged.get_logs(
-                        fromBlock=block_from, toBlock=block_to
+                        from_block=block_from, to_block=block_to
                     )
                 except ABIEventFunctionNotFound:
                     _event_list = []
@@ -1050,7 +1050,7 @@ class Processor:
                 # DeliveryCreated event
                 try:
                     _event_list = await dvp.events.DeliveryCreated.get_logs(
-                        fromBlock=block_from, toBlock=block_to
+                        from_block=block_from, to_block=block_to
                     )
                 except ABIEventFunctionNotFound:
                     _event_list = []
@@ -1073,7 +1073,7 @@ class Processor:
                 # DeliveryCanceled event
                 try:
                     _event_list = await dvp.events.DeliveryCanceled.get_logs(
-                        fromBlock=block_from, toBlock=block_to
+                        from_block=block_from, to_block=block_to
                     )
                 except ABIEventFunctionNotFound:
                     _event_list = []
@@ -1096,7 +1096,7 @@ class Processor:
                 # DeliveryAborted event
                 try:
                     _event_list = await dvp.events.DeliveryAborted.get_logs(
-                        fromBlock=block_from, toBlock=block_to
+                        from_block=block_from, to_block=block_to
                     )
                 except ABIEventFunctionNotFound:
                     _event_list = []
@@ -1119,7 +1119,7 @@ class Processor:
                     # HolderChanged event
                 try:
                     _event_list = await dvp.events.HolderChanged.get_logs(
-                        fromBlock=block_from, toBlock=block_to
+                        from_block=block_from, to_block=block_to
                     )
                 except ABIEventFunctionNotFound:
                     _event_list = []

--- a/batch/indexer_Token_List.py
+++ b/batch/indexer_Token_List.py
@@ -124,7 +124,7 @@ class Processor:
         """
         try:
             events = await self.token_list_contract.events.Register.get_logs(
-                fromBlock=block_from, toBlock=block_to
+                from_block=block_from, to_block=block_to
             )
         except ABIEventFunctionNotFound:
             events = []

--- a/batch/indexer_Transfer.py
+++ b/batch/indexer_Transfer.py
@@ -329,14 +329,14 @@ class Processor:
                     # block_from <= skip_block < block_to
                     LOG.debug(f"{token.address}: block_from <= skip_block < block_to")
                     events = await token.events.Transfer.get_logs(
-                        fromBlock=skip_block + 1, toBlock=block_to
+                        from_block=skip_block + 1, to_block=block_to
                     )
                 else:
                     # No logs or
                     # skip_block < block_from < block_to
                     LOG.debug(f"{token.address}: skip_block < block_from < block_to")
                     events = await token.events.Transfer.get_logs(
-                        fromBlock=block_from, toBlock=block_to
+                        from_block=block_from, to_block=block_to
                     )
             except ABIEventFunctionNotFound:
                 events = []
@@ -360,7 +360,7 @@ class Processor:
                             continue
                         self.__insert_idx(
                             db_session=db_session,
-                            transaction_hash=event["transactionHash"].hex(),
+                            transaction_hash=event["transactionHash"].to_0x_hex(),
                             token_address=to_checksum_address(token.address),
                             from_account_address=args.get("from", ZERO_ADDRESS),
                             to_account_address=args.get("to", ZERO_ADDRESS),
@@ -396,14 +396,14 @@ class Processor:
                     # block_from <= skip_block < block_to
                     LOG.debug(f"{token.address}: block_from <= skip_block < block_to")
                     events = await token.events.Unlock.get_logs(
-                        fromBlock=skip_block + 1, toBlock=block_to
+                        from_block=skip_block + 1, to_block=block_to
                     )
                 else:
                     # No logs or
                     # skip_block < block_from < block_to
                     LOG.debug(f"{token.address}: skip_block < block_from < block_to")
                     events = await token.events.Unlock.get_logs(
-                        fromBlock=block_from, toBlock=block_to
+                        from_block=block_from, to_block=block_to
                     )
             except ABIEventFunctionNotFound:
                 events = []
@@ -412,7 +412,7 @@ class Processor:
             try:
                 for event in events:
                     args = event["args"]
-                    transaction_hash = event["transactionHash"].hex()
+                    transaction_hash = event["transactionHash"].to_0x_hex()
                     block_timestamp = datetime.fromtimestamp(
                         (await async_web3.eth.get_block(event["blockNumber"]))[
                             "timestamp"

--- a/batch/indexer_TransferApproval.py
+++ b/batch/indexer_TransferApproval.py
@@ -321,7 +321,7 @@ class Processor:
                 continue
             try:
                 events = await token.events.ApplyForTransfer.get_logs(
-                    fromBlock=block_from, toBlock=block_to
+                    from_block=block_from, to_block=block_to
                 )
             except ABIEventFunctionNotFound:
                 events = []
@@ -363,7 +363,7 @@ class Processor:
                 continue
             try:
                 events = await token.events.CancelTransfer.get_logs(
-                    fromBlock=block_from, toBlock=block_to
+                    from_block=block_from, to_block=block_to
                 )
             except ABIEventFunctionNotFound:
                 events = []
@@ -397,7 +397,7 @@ class Processor:
                 continue
             try:
                 events = await token.events.ApproveTransfer.get_logs(
-                    fromBlock=block_from, toBlock=block_to
+                    from_block=block_from, to_block=block_to
                 )
             except ABIEventFunctionNotFound:
                 events = []
@@ -434,7 +434,7 @@ class Processor:
             exchange = target.exchange_contract
             try:
                 events = await exchange.events.ApplyForTransfer.get_logs(
-                    fromBlock=block_from, toBlock=block_to
+                    from_block=block_from, to_block=block_to
                 )
             except ABIEventFunctionNotFound:
                 events = []
@@ -483,7 +483,7 @@ class Processor:
             exchange = target.exchange_contract
             try:
                 events = await exchange.events.CancelTransfer.get_logs(
-                    fromBlock=block_from, toBlock=block_to
+                    from_block=block_from, to_block=block_to
                 )
             except ABIEventFunctionNotFound:
                 events = []
@@ -524,8 +524,8 @@ class Processor:
             exchange = target.exchange_contract
             try:
                 events = await exchange.events.EscrowFinished.get_logs(
-                    fromBlock=block_from,
-                    toBlock=block_to,
+                    from_block=block_from,
+                    to_block=block_to,
                     argument_filters={"transferApprovalRequired": True},
                 )
             except ABIEventFunctionNotFound:
@@ -567,7 +567,7 @@ class Processor:
             exchange = target.exchange_contract
             try:
                 events = await exchange.events.ApproveTransfer.get_logs(
-                    fromBlock=block_from, toBlock=block_to
+                    from_block=block_from, to_block=block_to
                 )
             except ABIEventFunctionNotFound:
                 events = []

--- a/batch/processor_Notifications_Coupon_Exchange.py
+++ b/batch/processor_Notifications_Coupon_Exchange.py
@@ -127,7 +127,7 @@ class Watcher:
             try:
                 _event = getattr(self.contract.events, self.filter_name)
                 entries = await _event.get_logs(
-                    fromBlock=from_block_number, toBlock=to_block_number
+                    from_block=from_block_number, to_block=to_block_number
                 )
             except ABIEventFunctionNotFound:
                 entries = []

--- a/batch/processor_Notifications_Membership_Exchange.py
+++ b/batch/processor_Notifications_Membership_Exchange.py
@@ -127,7 +127,7 @@ class Watcher:
             try:
                 _event = getattr(self.contract.events, self.filter_name)
                 entries = await _event.get_logs(
-                    fromBlock=from_block_number, toBlock=to_block_number
+                    from_block=from_block_number, to_block=to_block_number
                 )
             except ABIEventFunctionNotFound:
                 entries = []

--- a/batch/processor_Notifications_Token.py
+++ b/batch/processor_Notifications_Token.py
@@ -167,7 +167,7 @@ class Watcher:
                         )
                     _event = getattr(token_contract.events, self.filter_name)
                     entries = await _event.get_logs(
-                        fromBlock=from_block_number, toBlock=to_block_number
+                        from_block=from_block_number, to_block=to_block_number
                     )
                 except ABIEventFunctionNotFound:  # Backward compatibility
                     entries = []
@@ -274,7 +274,9 @@ class WatchTransfer(Watcher):
         )
         for entry in log_entries:
             # If the contract address is the source of the transfer, skip the process
-            if (await async_web3.eth.get_code(entry["args"]["from"])).hex() != "0x":
+            if (
+                await async_web3.eth.get_code(entry["args"]["from"])
+            ).to_0x_hex() != "0x":
                 continue
 
             company = company_list.find(token_owner_address)

--- a/poetry.lock
+++ b/poetry.lock
@@ -1108,13 +1108,13 @@ tools = ["hypothesis (>=4.18.2,<5.0.0)"]
 
 [[package]]
 name = "eth-account"
-version = "0.11.2"
+version = "0.13.0"
 description = "eth-account: Sign Ethereum transactions and messages with local private keys"
 optional = false
 python-versions = "<4,>=3.8"
 files = [
-    {file = "eth-account-0.11.2.tar.gz", hash = "sha256:b43daf2c0ae43f2a24ba754d66889f043fae4d3511559cb26eb0122bae9afbbd"},
-    {file = "eth_account-0.11.2-py3-none-any.whl", hash = "sha256:95157c262a9823c1e08be826d4bc304bf32f0c32e80afb38c126a325a64f651a"},
+    {file = "eth_account-0.13.0-py3-none-any.whl", hash = "sha256:84d27664038c68e6bee28fa5de803c3b629dc5d97cd61d12e5f442c561a5b8af"},
+    {file = "eth_account-0.13.0.tar.gz", hash = "sha256:ccea4383d9d37b46e17c977b0a5ea397cef1ac1ad3330431ae4b0c10b62d4fcd"},
 ]
 
 [package.dependencies]
@@ -1123,14 +1123,15 @@ ckzg = ">=0.4.3"
 eth-abi = ">=4.0.0-b.2"
 eth-keyfile = ">=0.6.0"
 eth-keys = ">=0.4.0"
-eth-rlp = ">=0.3.0"
+eth-rlp = ">=2.1.0"
 eth-utils = ">=2.0.0"
-hexbytes = ">=0.1.0,<0.4.0"
+hexbytes = ">=1.2.0"
+pydantic = ">=2.0.0"
 rlp = ">=1.0.0"
 
 [package.extras]
-dev = ["build (>=0.9.0)", "bumpversion (>=0.5.3)", "coverage", "hypothesis (>=4.18.0,<5)", "ipython", "pre-commit (>=3.4.0)", "pytest (>=7.0.0)", "pytest-xdist (>=2.4.0)", "sphinx (>=6.0.0)", "sphinx-rtd-theme (>=1.0.0)", "towncrier (>=21,<22)", "tox (>=4.0.0)", "twine", "wheel"]
-docs = ["sphinx (>=6.0.0)", "sphinx-rtd-theme (>=1.0.0)", "towncrier (>=21,<22)"]
+dev = ["build (>=0.9.0)", "bumpversion (>=0.5.3)", "coverage", "hypothesis (>=4.18.0,<5)", "ipython", "pre-commit (>=3.4.0)", "pytest (>=7.0.0)", "pytest-xdist (>=2.4.0)", "sphinx (>=6.0.0)", "sphinx-autobuild (>=2021.3.14)", "sphinx-rtd-theme (>=1.0.0)", "towncrier (>=21,<22)", "tox (>=4.0.0)", "twine", "wheel"]
+docs = ["sphinx (>=6.0.0)", "sphinx-autobuild (>=2021.3.14)", "sphinx-rtd-theme (>=1.0.0)", "towncrier (>=21,<22)"]
 test = ["coverage", "hypothesis (>=4.18.0,<5)", "pytest (>=7.0.0)", "pytest-xdist (>=2.4.0)"]
 
 [[package]]
@@ -1198,18 +1199,18 @@ test = ["asn1tools (>=0.146.2)", "eth-hash[pysha3]", "factory-boy (>=3.0.1)", "h
 
 [[package]]
 name = "eth-rlp"
-version = "1.0.1"
+version = "2.1.0"
 description = "eth-rlp: RLP definitions for common Ethereum objects in Python"
 optional = false
 python-versions = ">=3.8, <4"
 files = [
-    {file = "eth-rlp-1.0.1.tar.gz", hash = "sha256:d61dbda892ee1220f28fb3663c08f6383c305db9f1f5624dc585c9cd05115027"},
-    {file = "eth_rlp-1.0.1-py3-none-any.whl", hash = "sha256:dd76515d71654277377d48876b88e839d61553aaf56952e580bb7cebef2b1517"},
+    {file = "eth-rlp-2.1.0.tar.gz", hash = "sha256:d5b408a8cd20ed496e8e66d0559560d29bc21cee482f893936a1f05d0dddc4a0"},
+    {file = "eth_rlp-2.1.0-py3-none-any.whl", hash = "sha256:6f476eb7e37d81feaba5d98aed887e467be92648778c44b19fe594aea209cde1"},
 ]
 
 [package.dependencies]
 eth-utils = ">=2.0.0"
-hexbytes = ">=0.1.0,<1"
+hexbytes = ">=1.2.0"
 rlp = ">=0.6.0"
 
 [package.extras]
@@ -1621,20 +1622,19 @@ files = [
 
 [[package]]
 name = "hexbytes"
-version = "0.3.1"
+version = "1.2.0"
 description = "hexbytes: Python `bytes` subclass that decodes hex, with a readable console output"
 optional = false
-python-versions = ">=3.7, <4"
+python-versions = ">=3.8, <4"
 files = [
-    {file = "hexbytes-0.3.1-py3-none-any.whl", hash = "sha256:383595ad75026cf00abd570f44b368c6cdac0c6becfae5c39ff88829877f8a59"},
-    {file = "hexbytes-0.3.1.tar.gz", hash = "sha256:a3fe35c6831ee8fafd048c4c086b986075fc14fd46258fa24ecb8d65745f9a9d"},
+    {file = "hexbytes-1.2.0-py3-none-any.whl", hash = "sha256:bb243ab58b8d8390e3a753fbc9e3616f0f958df43d874e19ae0e4b746722a7e9"},
+    {file = "hexbytes-1.2.0.tar.gz", hash = "sha256:965f1cc712e7b263c41fdf3fb36cf671ba6f59b895937cf33941a5c996ec3a5c"},
 ]
 
 [package.extras]
-dev = ["black (>=22)", "bumpversion (>=0.5.3)", "eth-utils (>=1.0.1,<3)", "flake8 (==6.0.0)", "flake8-bugbear (==23.3.23)", "hypothesis (>=3.44.24,<=6.31.6)", "ipython", "isort (>=5.10.1)", "mypy (==0.971)", "pydocstyle (>=5.0.0)", "pytest (>=7.0.0)", "pytest-watch (>=4.1.0)", "pytest-xdist (>=2.4.0)", "sphinx (>=5.0.0)", "sphinx-rtd-theme (>=1.0.0)", "towncrier (>=21,<22)", "tox (>=4.0.0)", "twine", "wheel"]
-doc = ["sphinx (>=5.0.0)", "sphinx-rtd-theme (>=1.0.0)", "towncrier (>=21,<22)"]
-lint = ["black (>=22)", "flake8 (==6.0.0)", "flake8-bugbear (==23.3.23)", "isort (>=5.10.1)", "mypy (==0.971)", "pydocstyle (>=5.0.0)"]
-test = ["eth-utils (>=1.0.1,<3)", "hypothesis (>=3.44.24,<=6.31.6)", "pytest (>=7.0.0)", "pytest-xdist (>=2.4.0)"]
+dev = ["build (>=0.9.0)", "bumpversion (>=0.5.3)", "eth-utils (>=2.0.0)", "hypothesis (>=3.44.24,<=6.31.6)", "ipython", "pre-commit (>=3.4.0)", "pytest (>=7.0.0)", "pytest-xdist (>=2.4.0)", "sphinx (>=5.3.0)", "sphinx-rtd-theme (>=1.0.0)", "towncrier (>=21,<22)", "tox (>=4.0.0)", "twine", "wheel"]
+docs = ["sphinx (>=5.3.0)", "sphinx-rtd-theme (>=1.0.0)", "towncrier (>=21,<22)"]
+test = ["eth-utils (>=2.0.0)", "hypothesis (>=3.44.24,<=6.31.6)", "pytest (>=7.0.0)", "pytest-xdist (>=2.4.0)"]
 
 [[package]]
 name = "httpcore"
@@ -1851,41 +1851,6 @@ files = [
 ]
 
 [[package]]
-name = "jsonschema"
-version = "4.22.0"
-description = "An implementation of JSON Schema validation for Python"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "jsonschema-4.22.0-py3-none-any.whl", hash = "sha256:ff4cfd6b1367a40e7bc6411caec72effadd3db0bbe5017de188f2d6108335802"},
-    {file = "jsonschema-4.22.0.tar.gz", hash = "sha256:5b22d434a45935119af990552c862e5d6d564e8f6601206b305a61fdf661a2b7"},
-]
-
-[package.dependencies]
-attrs = ">=22.2.0"
-jsonschema-specifications = ">=2023.03.6"
-referencing = ">=0.28.4"
-rpds-py = ">=0.7.1"
-
-[package.extras]
-format = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-validator", "rfc3987", "uri-template", "webcolors (>=1.11)"]
-format-nongpl = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-validator", "rfc3986-validator (>0.1.0)", "uri-template", "webcolors (>=1.11)"]
-
-[[package]]
-name = "jsonschema-specifications"
-version = "2023.12.1"
-description = "The JSON Schema meta-schemas and vocabularies, exposed as a Registry"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "jsonschema_specifications-2023.12.1-py3-none-any.whl", hash = "sha256:87e4fdf3a94858b8a2ba2778d9ba57d8a9cafca7c7489c46ba0d30a8bc6a9c3c"},
-    {file = "jsonschema_specifications-2023.12.1.tar.gz", hash = "sha256:48a76787b3e70f5ed53f1160d2b81f586e4ca6d1548c5de7085d1682674764cc"},
-]
-
-[package.dependencies]
-referencing = ">=0.31.0"
-
-[[package]]
 name = "linkify-it-py"
 version = "2.0.3"
 description = "Links recognition library with FULL unicode support."
@@ -1923,100 +1888,6 @@ msgpack = ">=0.4.2"
 pyzmq = ">=16.0.2"
 requests = ">=2.9.1"
 six = ">=1.10.0"
-
-[[package]]
-name = "lru-dict"
-version = "1.2.0"
-description = "An Dict like LRU container."
-optional = false
-python-versions = "*"
-files = [
-    {file = "lru-dict-1.2.0.tar.gz", hash = "sha256:13c56782f19d68ddf4d8db0170041192859616514c706b126d0df2ec72a11bd7"},
-    {file = "lru_dict-1.2.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:de906e5486b5c053d15b7731583c25e3c9147c288ac8152a6d1f9bccdec72641"},
-    {file = "lru_dict-1.2.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:604d07c7604b20b3130405d137cae61579578b0e8377daae4125098feebcb970"},
-    {file = "lru_dict-1.2.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:203b3e78d03d88f491fa134f85a42919020686b6e6f2d09759b2f5517260c651"},
-    {file = "lru_dict-1.2.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:020b93870f8c7195774cbd94f033b96c14f51c57537969965c3af300331724fe"},
-    {file = "lru_dict-1.2.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1184d91cfebd5d1e659d47f17a60185bbf621635ca56dcdc46c6a1745d25df5c"},
-    {file = "lru_dict-1.2.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:fc42882b554a86e564e0b662da47b8a4b32fa966920bd165e27bb8079a323bc1"},
-    {file = "lru_dict-1.2.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:18ee88ada65bd2ffd483023be0fa1c0a6a051ef666d1cd89e921dcce134149f2"},
-    {file = "lru_dict-1.2.0-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:756230c22257597b7557eaef7f90484c489e9ba78e5bb6ab5a5bcfb6b03cb075"},
-    {file = "lru_dict-1.2.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:c4da599af36618881748b5db457d937955bb2b4800db891647d46767d636c408"},
-    {file = "lru_dict-1.2.0-cp310-cp310-win32.whl", hash = "sha256:35a142a7d1a4fd5d5799cc4f8ab2fff50a598d8cee1d1c611f50722b3e27874f"},
-    {file = "lru_dict-1.2.0-cp310-cp310-win_amd64.whl", hash = "sha256:6da5b8099766c4da3bf1ed6e7d7f5eff1681aff6b5987d1258a13bd2ed54f0c9"},
-    {file = "lru_dict-1.2.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b20b7c9beb481e92e07368ebfaa363ed7ef61e65ffe6e0edbdbaceb33e134124"},
-    {file = "lru_dict-1.2.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:22147367b296be31cc858bf167c448af02435cac44806b228c9be8117f1bfce4"},
-    {file = "lru_dict-1.2.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:34a3091abeb95e707f381a8b5b7dc8e4ee016316c659c49b726857b0d6d1bd7a"},
-    {file = "lru_dict-1.2.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:877801a20f05c467126b55338a4e9fa30e2a141eb7b0b740794571b7d619ee11"},
-    {file = "lru_dict-1.2.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7d3336e901acec897bcd318c42c2b93d5f1d038e67688f497045fc6bad2c0be7"},
-    {file = "lru_dict-1.2.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:8dafc481d2defb381f19b22cc51837e8a42631e98e34b9e0892245cc96593deb"},
-    {file = "lru_dict-1.2.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:87bbad3f5c3de8897b8c1263a9af73bbb6469fb90e7b57225dad89b8ef62cd8d"},
-    {file = "lru_dict-1.2.0-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:25f9e0bc2fe8f41c2711ccefd2871f8a5f50a39e6293b68c3dec576112937aad"},
-    {file = "lru_dict-1.2.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:ae301c282a499dc1968dd633cfef8771dd84228ae9d40002a3ea990e4ff0c469"},
-    {file = "lru_dict-1.2.0-cp311-cp311-win32.whl", hash = "sha256:c9617583173a29048e11397f165501edc5ae223504a404b2532a212a71ecc9ed"},
-    {file = "lru_dict-1.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:6b7a031e47421d4b7aa626b8c91c180a9f037f89e5d0a71c4bb7afcf4036c774"},
-    {file = "lru_dict-1.2.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:ea2ac3f7a7a2f32f194c84d82a034e66780057fd908b421becd2f173504d040e"},
-    {file = "lru_dict-1.2.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cd46c94966f631a81ffe33eee928db58e9fbee15baba5923d284aeadc0e0fa76"},
-    {file = "lru_dict-1.2.0-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:086ce993414f0b28530ded7e004c77dc57c5748fa6da488602aa6e7f79e6210e"},
-    {file = "lru_dict-1.2.0-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:df25a426446197488a6702954dcc1de511deee20c9db730499a2aa83fddf0df1"},
-    {file = "lru_dict-1.2.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c53b12b89bd7a6c79f0536ff0d0a84fdf4ab5f6252d94b24b9b753bd9ada2ddf"},
-    {file = "lru_dict-1.2.0-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:f9484016e6765bd295708cccc9def49f708ce07ac003808f69efa386633affb9"},
-    {file = "lru_dict-1.2.0-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:d0f7ec902a0097ac39f1922c89be9eaccf00eb87751e28915320b4f72912d057"},
-    {file = "lru_dict-1.2.0-cp36-cp36m-musllinux_1_1_ppc64le.whl", hash = "sha256:981ef3edc82da38d39eb60eae225b88a538d47b90cce2e5808846fd2cf64384b"},
-    {file = "lru_dict-1.2.0-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:e25b2e90a032dc248213af7f3f3e975e1934b204f3b16aeeaeaff27a3b65e128"},
-    {file = "lru_dict-1.2.0-cp36-cp36m-win32.whl", hash = "sha256:59f3df78e94e07959f17764e7fa7ca6b54e9296953d2626a112eab08e1beb2db"},
-    {file = "lru_dict-1.2.0-cp36-cp36m-win_amd64.whl", hash = "sha256:de24b47159e07833aeab517d9cb1c3c5c2d6445cc378b1c2f1d8d15fb4841d63"},
-    {file = "lru_dict-1.2.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:d0dd4cd58220351233002f910e35cc01d30337696b55c6578f71318b137770f9"},
-    {file = "lru_dict-1.2.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a87bdc291718bbdf9ea4be12ae7af26cbf0706fa62c2ac332748e3116c5510a7"},
-    {file = "lru_dict-1.2.0-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:05fb8744f91f58479cbe07ed80ada6696ec7df21ea1740891d4107a8dd99a970"},
-    {file = "lru_dict-1.2.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:00f6e8a3fc91481b40395316a14c94daa0f0a5de62e7e01a7d589f8d29224052"},
-    {file = "lru_dict-1.2.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5b172fce0a0ffc0fa6d282c14256d5a68b5db1e64719c2915e69084c4b6bf555"},
-    {file = "lru_dict-1.2.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:e707d93bae8f0a14e6df1ae8b0f076532b35f00e691995f33132d806a88e5c18"},
-    {file = "lru_dict-1.2.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:b9ec7a4a0d6b8297102aa56758434fb1fca276a82ed7362e37817407185c3abb"},
-    {file = "lru_dict-1.2.0-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:f404dcc8172da1f28da9b1f0087009578e608a4899b96d244925c4f463201f2a"},
-    {file = "lru_dict-1.2.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:1171ad3bff32aa8086778be4a3bdff595cc2692e78685bcce9cb06b96b22dcc2"},
-    {file = "lru_dict-1.2.0-cp37-cp37m-win32.whl", hash = "sha256:0c316dfa3897fabaa1fe08aae89352a3b109e5f88b25529bc01e98ac029bf878"},
-    {file = "lru_dict-1.2.0-cp37-cp37m-win_amd64.whl", hash = "sha256:5919dd04446bc1ee8d6ecda2187deeebfff5903538ae71083e069bc678599446"},
-    {file = "lru_dict-1.2.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:fbf36c5a220a85187cacc1fcb7dd87070e04b5fc28df7a43f6842f7c8224a388"},
-    {file = "lru_dict-1.2.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:712e71b64da181e1c0a2eaa76cd860265980cd15cb0e0498602b8aa35d5db9f8"},
-    {file = "lru_dict-1.2.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f54908bf91280a9b8fa6a8c8f3c2f65850ce6acae2852bbe292391628ebca42f"},
-    {file = "lru_dict-1.2.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3838e33710935da2ade1dd404a8b936d571e29268a70ff4ca5ba758abb3850df"},
-    {file = "lru_dict-1.2.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f5d5a5f976b39af73324f2b793862859902ccb9542621856d51a5993064f25e4"},
-    {file = "lru_dict-1.2.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:8bda3a9afd241ee0181661decaae25e5336ce513ac268ab57da737eacaa7871f"},
-    {file = "lru_dict-1.2.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:bd2cd1b998ea4c8c1dad829fc4fa88aeed4dee555b5e03c132fc618e6123f168"},
-    {file = "lru_dict-1.2.0-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:b55753ee23028ba8644fd22e50de7b8f85fa60b562a0fafaad788701d6131ff8"},
-    {file = "lru_dict-1.2.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:7e51fa6a203fa91d415f3b2900e5748ec8e06ad75777c98cc3aeb3983ca416d7"},
-    {file = "lru_dict-1.2.0-cp38-cp38-win32.whl", hash = "sha256:cd6806313606559e6c7adfa0dbeb30fc5ab625f00958c3d93f84831e7a32b71e"},
-    {file = "lru_dict-1.2.0-cp38-cp38-win_amd64.whl", hash = "sha256:5d90a70c53b0566084447c3ef9374cc5a9be886e867b36f89495f211baabd322"},
-    {file = "lru_dict-1.2.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:a3ea7571b6bf2090a85ff037e6593bbafe1a8598d5c3b4560eb56187bcccb4dc"},
-    {file = "lru_dict-1.2.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:287c2115a59c1c9ed0d5d8ae7671e594b1206c36ea9df2fca6b17b86c468ff99"},
-    {file = "lru_dict-1.2.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b5ccfd2291c93746a286c87c3f895165b697399969d24c54804ec3ec559d4e43"},
-    {file = "lru_dict-1.2.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b710f0f4d7ec4f9fa89dfde7002f80bcd77de8024017e70706b0911ea086e2ef"},
-    {file = "lru_dict-1.2.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5345bf50e127bd2767e9fd42393635bbc0146eac01f6baf6ef12c332d1a6a329"},
-    {file = "lru_dict-1.2.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:291d13f85224551913a78fe695cde04cbca9dcb1d84c540167c443eb913603c9"},
-    {file = "lru_dict-1.2.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:d5bb41bc74b321789803d45b124fc2145c1b3353b4ad43296d9d1d242574969b"},
-    {file = "lru_dict-1.2.0-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:0facf49b053bf4926d92d8d5a46fe07eecd2af0441add0182c7432d53d6da667"},
-    {file = "lru_dict-1.2.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:987b73a06bcf5a95d7dc296241c6b1f9bc6cda42586948c9dabf386dc2bef1cd"},
-    {file = "lru_dict-1.2.0-cp39-cp39-win32.whl", hash = "sha256:231d7608f029dda42f9610e5723614a35b1fff035a8060cf7d2be19f1711ace8"},
-    {file = "lru_dict-1.2.0-cp39-cp39-win_amd64.whl", hash = "sha256:71da89e134747e20ed5b8ad5b4ee93fc5b31022c2b71e8176e73c5a44699061b"},
-    {file = "lru_dict-1.2.0-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:21b3090928c7b6cec509e755cc3ab742154b33660a9b433923bd12c37c448e3e"},
-    {file = "lru_dict-1.2.0-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aaecd7085212d0aa4cd855f38b9d61803d6509731138bf798a9594745953245b"},
-    {file = "lru_dict-1.2.0-pp37-pypy37_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ead83ac59a29d6439ddff46e205ce32f8b7f71a6bd8062347f77e232825e3d0a"},
-    {file = "lru_dict-1.2.0-pp37-pypy37_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:312b6b2a30188586fe71358f0f33e4bac882d33f5e5019b26f084363f42f986f"},
-    {file = "lru_dict-1.2.0-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:b30122e098c80e36d0117810d46459a46313421ce3298709170b687dc1240b02"},
-    {file = "lru_dict-1.2.0-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:f010cfad3ab10676e44dc72a813c968cd586f37b466d27cde73d1f7f1ba158c2"},
-    {file = "lru_dict-1.2.0-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:20f5f411f7751ad9a2c02e80287cedf69ae032edd321fe696e310d32dd30a1f8"},
-    {file = "lru_dict-1.2.0-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:afdadd73304c9befaed02eb42f5f09fdc16288de0a08b32b8080f0f0f6350aa6"},
-    {file = "lru_dict-1.2.0-pp38-pypy38_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d7ab0c10c4fa99dc9e26b04e6b62ac32d2bcaea3aad9b81ec8ce9a7aa32b7b1b"},
-    {file = "lru_dict-1.2.0-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:edad398d5d402c43d2adada390dd83c74e46e020945ff4df801166047013617e"},
-    {file = "lru_dict-1.2.0-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:91d577a11b84387013815b1ad0bb6e604558d646003b44c92b3ddf886ad0f879"},
-    {file = "lru_dict-1.2.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bb12f19cdf9c4f2d9aa259562e19b188ff34afab28dd9509ff32a3f1c2c29326"},
-    {file = "lru_dict-1.2.0-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9e4c85aa8844bdca3c8abac3b7f78da1531c74e9f8b3e4890c6e6d86a5a3f6c0"},
-    {file = "lru_dict-1.2.0-pp39-pypy39_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5c6acbd097b15bead4de8e83e8a1030bb4d8257723669097eac643a301a952f0"},
-    {file = "lru_dict-1.2.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:b6613daa851745dd22b860651de930275be9d3e9373283a2164992abacb75b62"},
-]
-
-[package.extras]
-test = ["pytest"]
 
 [[package]]
 name = "mako"
@@ -2602,26 +2473,6 @@ identify = ">=1.0.0"
 nodeenv = ">=0.11.1"
 pyyaml = ">=5.1"
 virtualenv = ">=20.10.0"
-
-[[package]]
-name = "protobuf"
-version = "5.27.0"
-description = ""
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "protobuf-5.27.0-cp310-abi3-win32.whl", hash = "sha256:2f83bf341d925650d550b8932b71763321d782529ac0eaf278f5242f513cc04e"},
-    {file = "protobuf-5.27.0-cp310-abi3-win_amd64.whl", hash = "sha256:b276e3f477ea1eebff3c2e1515136cfcff5ac14519c45f9b4aa2f6a87ea627c4"},
-    {file = "protobuf-5.27.0-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:744489f77c29174328d32f8921566fb0f7080a2f064c5137b9d6f4b790f9e0c1"},
-    {file = "protobuf-5.27.0-cp38-abi3-manylinux2014_aarch64.whl", hash = "sha256:f51f33d305e18646f03acfdb343aac15b8115235af98bc9f844bf9446573827b"},
-    {file = "protobuf-5.27.0-cp38-abi3-manylinux2014_x86_64.whl", hash = "sha256:56937f97ae0dcf4e220ff2abb1456c51a334144c9960b23597f044ce99c29c89"},
-    {file = "protobuf-5.27.0-cp38-cp38-win32.whl", hash = "sha256:a17f4d664ea868102feaa30a674542255f9f4bf835d943d588440d1f49a3ed15"},
-    {file = "protobuf-5.27.0-cp38-cp38-win_amd64.whl", hash = "sha256:aabbbcf794fbb4c692ff14ce06780a66d04758435717107c387f12fb477bf0d8"},
-    {file = "protobuf-5.27.0-cp39-cp39-win32.whl", hash = "sha256:587be23f1212da7a14a6c65fd61995f8ef35779d4aea9e36aad81f5f3b80aec5"},
-    {file = "protobuf-5.27.0-cp39-cp39-win_amd64.whl", hash = "sha256:7cb65fc8fba680b27cf7a07678084c6e68ee13cab7cace734954c25a43da6d0f"},
-    {file = "protobuf-5.27.0-py3-none-any.whl", hash = "sha256:673ad60f1536b394b4fa0bcd3146a4130fcad85bfe3b60eaa86d6a0ace0fa374"},
-    {file = "protobuf-5.27.0.tar.gz", hash = "sha256:07f2b9a15255e3cf3f137d884af7972407b556a7a220912b252f26dc3121e6bf"},
-]
 
 [[package]]
 name = "psycopg"
@@ -3239,21 +3090,6 @@ files = [
 cffi = {version = "*", markers = "implementation_name == \"pypy\""}
 
 [[package]]
-name = "referencing"
-version = "0.35.1"
-description = "JSON Referencing + Python"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "referencing-0.35.1-py3-none-any.whl", hash = "sha256:eda6d3234d62814d1c64e305c1331c9a3a6132da475ab6382eaa997b21ee75de"},
-    {file = "referencing-0.35.1.tar.gz", hash = "sha256:25b42124a6c8b632a425174f24087783efb348a6f1e0008e63cd4466fedf703c"},
-]
-
-[package.dependencies]
-attrs = ">=22.2.0"
-rpds-py = ">=0.7.0"
-
-[[package]]
 name = "regex"
 version = "2024.5.15"
 description = "Alternative regular expression module, to replace re."
@@ -3399,114 +3235,6 @@ dev = ["build (>=0.9.0)", "bumpversion (>=0.5.3)", "hypothesis (==5.19.0)", "ipy
 docs = ["sphinx (>=6.0.0)", "sphinx-autobuild (>=2021.3.14)", "sphinx-rtd-theme (>=1.0.0)", "towncrier (>=21,<22)"]
 rust-backend = ["rusty-rlp (>=0.2.1)"]
 test = ["hypothesis (==5.19.0)", "pytest (>=7.0.0)", "pytest-xdist (>=2.4.0)"]
-
-[[package]]
-name = "rpds-py"
-version = "0.18.1"
-description = "Python bindings to Rust's persistent data structures (rpds)"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "rpds_py-0.18.1-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:d31dea506d718693b6b2cffc0648a8929bdc51c70a311b2770f09611caa10d53"},
-    {file = "rpds_py-0.18.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:732672fbc449bab754e0b15356c077cc31566df874964d4801ab14f71951ea80"},
-    {file = "rpds_py-0.18.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4a98a1f0552b5f227a3d6422dbd61bc6f30db170939bd87ed14f3c339aa6c7c9"},
-    {file = "rpds_py-0.18.1-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7f1944ce16401aad1e3f7d312247b3d5de7981f634dc9dfe90da72b87d37887d"},
-    {file = "rpds_py-0.18.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:38e14fb4e370885c4ecd734f093a2225ee52dc384b86fa55fe3f74638b2cfb09"},
-    {file = "rpds_py-0.18.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:08d74b184f9ab6289b87b19fe6a6d1a97fbfea84b8a3e745e87a5de3029bf944"},
-    {file = "rpds_py-0.18.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d70129cef4a8d979caa37e7fe957202e7eee8ea02c5e16455bc9808a59c6b2f0"},
-    {file = "rpds_py-0.18.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ce0bb20e3a11bd04461324a6a798af34d503f8d6f1aa3d2aa8901ceaf039176d"},
-    {file = "rpds_py-0.18.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:81c5196a790032e0fc2464c0b4ab95f8610f96f1f2fa3d4deacce6a79852da60"},
-    {file = "rpds_py-0.18.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:f3027be483868c99b4985fda802a57a67fdf30c5d9a50338d9db646d590198da"},
-    {file = "rpds_py-0.18.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:d44607f98caa2961bab4fa3c4309724b185b464cdc3ba6f3d7340bac3ec97cc1"},
-    {file = "rpds_py-0.18.1-cp310-none-win32.whl", hash = "sha256:c273e795e7a0f1fddd46e1e3cb8be15634c29ae8ff31c196debb620e1edb9333"},
-    {file = "rpds_py-0.18.1-cp310-none-win_amd64.whl", hash = "sha256:8352f48d511de5f973e4f2f9412736d7dea76c69faa6d36bcf885b50c758ab9a"},
-    {file = "rpds_py-0.18.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:6b5ff7e1d63a8281654b5e2896d7f08799378e594f09cf3674e832ecaf396ce8"},
-    {file = "rpds_py-0.18.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:8927638a4d4137a289e41d0fd631551e89fa346d6dbcfc31ad627557d03ceb6d"},
-    {file = "rpds_py-0.18.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:154bf5c93d79558b44e5b50cc354aa0459e518e83677791e6adb0b039b7aa6a7"},
-    {file = "rpds_py-0.18.1-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:07f2139741e5deb2c5154a7b9629bc5aa48c766b643c1a6750d16f865a82c5fc"},
-    {file = "rpds_py-0.18.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8c7672e9fba7425f79019db9945b16e308ed8bc89348c23d955c8c0540da0a07"},
-    {file = "rpds_py-0.18.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:489bdfe1abd0406eba6b3bb4fdc87c7fa40f1031de073d0cfb744634cc8fa261"},
-    {file = "rpds_py-0.18.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3c20f05e8e3d4fc76875fc9cb8cf24b90a63f5a1b4c5b9273f0e8225e169b100"},
-    {file = "rpds_py-0.18.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:967342e045564cef76dfcf1edb700b1e20838d83b1aa02ab313e6a497cf923b8"},
-    {file = "rpds_py-0.18.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:2cc7c1a47f3a63282ab0f422d90ddac4aa3034e39fc66a559ab93041e6505da7"},
-    {file = "rpds_py-0.18.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:f7afbfee1157e0f9376c00bb232e80a60e59ed716e3211a80cb8506550671e6e"},
-    {file = "rpds_py-0.18.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:9e6934d70dc50f9f8ea47081ceafdec09245fd9f6032669c3b45705dea096b88"},
-    {file = "rpds_py-0.18.1-cp311-none-win32.whl", hash = "sha256:c69882964516dc143083d3795cb508e806b09fc3800fd0d4cddc1df6c36e76bb"},
-    {file = "rpds_py-0.18.1-cp311-none-win_amd64.whl", hash = "sha256:70a838f7754483bcdc830444952fd89645569e7452e3226de4a613a4c1793fb2"},
-    {file = "rpds_py-0.18.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3dd3cd86e1db5aadd334e011eba4e29d37a104b403e8ca24dcd6703c68ca55b3"},
-    {file = "rpds_py-0.18.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:05f3d615099bd9b13ecf2fc9cf2d839ad3f20239c678f461c753e93755d629ee"},
-    {file = "rpds_py-0.18.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:35b2b771b13eee8729a5049c976197ff58a27a3829c018a04341bcf1ae409b2b"},
-    {file = "rpds_py-0.18.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ee17cd26b97d537af8f33635ef38be873073d516fd425e80559f4585a7b90c43"},
-    {file = "rpds_py-0.18.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b646bf655b135ccf4522ed43d6902af37d3f5dbcf0da66c769a2b3938b9d8184"},
-    {file = "rpds_py-0.18.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:19ba472b9606c36716062c023afa2484d1e4220548751bda14f725a7de17b4f6"},
-    {file = "rpds_py-0.18.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6e30ac5e329098903262dc5bdd7e2086e0256aa762cc8b744f9e7bf2a427d3f8"},
-    {file = "rpds_py-0.18.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d58ad6317d188c43750cb76e9deacf6051d0f884d87dc6518e0280438648a9ac"},
-    {file = "rpds_py-0.18.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e1735502458621921cee039c47318cb90b51d532c2766593be6207eec53e5c4c"},
-    {file = "rpds_py-0.18.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:f5bab211605d91db0e2995a17b5c6ee5edec1270e46223e513eaa20da20076ac"},
-    {file = "rpds_py-0.18.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2fc24a329a717f9e2448f8cd1f960f9dac4e45b6224d60734edeb67499bab03a"},
-    {file = "rpds_py-0.18.1-cp312-none-win32.whl", hash = "sha256:1805d5901779662d599d0e2e4159d8a82c0b05faa86ef9222bf974572286b2b6"},
-    {file = "rpds_py-0.18.1-cp312-none-win_amd64.whl", hash = "sha256:720edcb916df872d80f80a1cc5ea9058300b97721efda8651efcd938a9c70a72"},
-    {file = "rpds_py-0.18.1-cp38-cp38-macosx_10_12_x86_64.whl", hash = "sha256:c827576e2fa017a081346dce87d532a5310241648eb3700af9a571a6e9fc7e74"},
-    {file = "rpds_py-0.18.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:aa3679e751408d75a0b4d8d26d6647b6d9326f5e35c00a7ccd82b78ef64f65f8"},
-    {file = "rpds_py-0.18.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0abeee75434e2ee2d142d650d1e54ac1f8b01e6e6abdde8ffd6eeac6e9c38e20"},
-    {file = "rpds_py-0.18.1-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ed402d6153c5d519a0faf1bb69898e97fb31613b49da27a84a13935ea9164dfc"},
-    {file = "rpds_py-0.18.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:338dee44b0cef8b70fd2ef54b4e09bb1b97fc6c3a58fea5db6cc083fd9fc2724"},
-    {file = "rpds_py-0.18.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7750569d9526199c5b97e5a9f8d96a13300950d910cf04a861d96f4273d5b104"},
-    {file = "rpds_py-0.18.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:607345bd5912aacc0c5a63d45a1f73fef29e697884f7e861094e443187c02be5"},
-    {file = "rpds_py-0.18.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:207c82978115baa1fd8d706d720b4a4d2b0913df1c78c85ba73fe6c5804505f0"},
-    {file = "rpds_py-0.18.1-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:6d1e42d2735d437e7e80bab4d78eb2e459af48c0a46e686ea35f690b93db792d"},
-    {file = "rpds_py-0.18.1-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:5463c47c08630007dc0fe99fb480ea4f34a89712410592380425a9b4e1611d8e"},
-    {file = "rpds_py-0.18.1-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:06d218939e1bf2ca50e6b0ec700ffe755e5216a8230ab3e87c059ebb4ea06afc"},
-    {file = "rpds_py-0.18.1-cp38-none-win32.whl", hash = "sha256:312fe69b4fe1ffbe76520a7676b1e5ac06ddf7826d764cc10265c3b53f96dbe9"},
-    {file = "rpds_py-0.18.1-cp38-none-win_amd64.whl", hash = "sha256:9437ca26784120a279f3137ee080b0e717012c42921eb07861b412340f85bae2"},
-    {file = "rpds_py-0.18.1-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:19e515b78c3fc1039dd7da0a33c28c3154458f947f4dc198d3c72db2b6b5dc93"},
-    {file = "rpds_py-0.18.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a7b28c5b066bca9a4eb4e2f2663012debe680f097979d880657f00e1c30875a0"},
-    {file = "rpds_py-0.18.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:673fdbbf668dd958eff750e500495ef3f611e2ecc209464f661bc82e9838991e"},
-    {file = "rpds_py-0.18.1-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d960de62227635d2e61068f42a6cb6aae91a7fe00fca0e3aeed17667c8a34611"},
-    {file = "rpds_py-0.18.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:352a88dc7892f1da66b6027af06a2e7e5d53fe05924cc2cfc56495b586a10b72"},
-    {file = "rpds_py-0.18.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e0ee01ad8260184db21468a6e1c37afa0529acc12c3a697ee498d3c2c4dcaf3"},
-    {file = "rpds_py-0.18.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e4c39ad2f512b4041343ea3c7894339e4ca7839ac38ca83d68a832fc8b3748ab"},
-    {file = "rpds_py-0.18.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:aaa71ee43a703c321906813bb252f69524f02aa05bf4eec85f0c41d5d62d0f4c"},
-    {file = "rpds_py-0.18.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:6cd8098517c64a85e790657e7b1e509b9fe07487fd358e19431cb120f7d96338"},
-    {file = "rpds_py-0.18.1-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:4adec039b8e2928983f885c53b7cc4cda8965b62b6596501a0308d2703f8af1b"},
-    {file = "rpds_py-0.18.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:32b7daaa3e9389db3695964ce8e566e3413b0c43e3394c05e4b243a4cd7bef26"},
-    {file = "rpds_py-0.18.1-cp39-none-win32.whl", hash = "sha256:2625f03b105328729f9450c8badda34d5243231eef6535f80064d57035738360"},
-    {file = "rpds_py-0.18.1-cp39-none-win_amd64.whl", hash = "sha256:bf18932d0003c8c4d51a39f244231986ab23ee057d235a12b2684ea26a353590"},
-    {file = "rpds_py-0.18.1-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:cbfbea39ba64f5e53ae2915de36f130588bba71245b418060ec3330ebf85678e"},
-    {file = "rpds_py-0.18.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:a3d456ff2a6a4d2adcdf3c1c960a36f4fd2fec6e3b4902a42a384d17cf4e7a65"},
-    {file = "rpds_py-0.18.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7700936ef9d006b7ef605dc53aa364da2de5a3aa65516a1f3ce73bf82ecfc7ae"},
-    {file = "rpds_py-0.18.1-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:51584acc5916212e1bf45edd17f3a6b05fe0cbb40482d25e619f824dccb679de"},
-    {file = "rpds_py-0.18.1-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:942695a206a58d2575033ff1e42b12b2aece98d6003c6bc739fbf33d1773b12f"},
-    {file = "rpds_py-0.18.1-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b906b5f58892813e5ba5c6056d6a5ad08f358ba49f046d910ad992196ea61397"},
-    {file = "rpds_py-0.18.1-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f6f8e3fecca256fefc91bb6765a693d96692459d7d4c644660a9fff32e517843"},
-    {file = "rpds_py-0.18.1-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7732770412bab81c5a9f6d20aeb60ae943a9b36dcd990d876a773526468e7163"},
-    {file = "rpds_py-0.18.1-pp310-pypy310_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:bd1105b50ede37461c1d51b9698c4f4be6e13e69a908ab7751e3807985fc0346"},
-    {file = "rpds_py-0.18.1-pp310-pypy310_pp73-musllinux_1_2_i686.whl", hash = "sha256:618916f5535784960f3ecf8111581f4ad31d347c3de66d02e728de460a46303c"},
-    {file = "rpds_py-0.18.1-pp310-pypy310_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:17c6d2155e2423f7e79e3bb18151c686d40db42d8645e7977442170c360194d4"},
-    {file = "rpds_py-0.18.1-pp38-pypy38_pp73-macosx_10_12_x86_64.whl", hash = "sha256:6c4c4c3f878df21faf5fac86eda32671c27889e13570645a9eea0a1abdd50922"},
-    {file = "rpds_py-0.18.1-pp38-pypy38_pp73-macosx_11_0_arm64.whl", hash = "sha256:fab6ce90574645a0d6c58890e9bcaac8d94dff54fb51c69e5522a7358b80ab64"},
-    {file = "rpds_py-0.18.1-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:531796fb842b53f2695e94dc338929e9f9dbf473b64710c28af5a160b2a8927d"},
-    {file = "rpds_py-0.18.1-pp38-pypy38_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:740884bc62a5e2bbb31e584f5d23b32320fd75d79f916f15a788d527a5e83644"},
-    {file = "rpds_py-0.18.1-pp38-pypy38_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:998125738de0158f088aef3cb264a34251908dd2e5d9966774fdab7402edfab7"},
-    {file = "rpds_py-0.18.1-pp38-pypy38_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e2be6e9dd4111d5b31ba3b74d17da54a8319d8168890fbaea4b9e5c3de630ae5"},
-    {file = "rpds_py-0.18.1-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d0cee71bc618cd93716f3c1bf56653740d2d13ddbd47673efa8bf41435a60daa"},
-    {file = "rpds_py-0.18.1-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2c3caec4ec5cd1d18e5dd6ae5194d24ed12785212a90b37f5f7f06b8bedd7139"},
-    {file = "rpds_py-0.18.1-pp38-pypy38_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:27bba383e8c5231cd559affe169ca0b96ec78d39909ffd817f28b166d7ddd4d8"},
-    {file = "rpds_py-0.18.1-pp38-pypy38_pp73-musllinux_1_2_i686.whl", hash = "sha256:a888e8bdb45916234b99da2d859566f1e8a1d2275a801bb8e4a9644e3c7e7909"},
-    {file = "rpds_py-0.18.1-pp38-pypy38_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:6031b25fb1b06327b43d841f33842b383beba399884f8228a6bb3df3088485ff"},
-    {file = "rpds_py-0.18.1-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:48c2faaa8adfacefcbfdb5f2e2e7bdad081e5ace8d182e5f4ade971f128e6bb3"},
-    {file = "rpds_py-0.18.1-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:d85164315bd68c0806768dc6bb0429c6f95c354f87485ee3593c4f6b14def2bd"},
-    {file = "rpds_py-0.18.1-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6afd80f6c79893cfc0574956f78a0add8c76e3696f2d6a15bca2c66c415cf2d4"},
-    {file = "rpds_py-0.18.1-pp39-pypy39_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fa242ac1ff583e4ec7771141606aafc92b361cd90a05c30d93e343a0c2d82a89"},
-    {file = "rpds_py-0.18.1-pp39-pypy39_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d21be4770ff4e08698e1e8e0bce06edb6ea0626e7c8f560bc08222880aca6a6f"},
-    {file = "rpds_py-0.18.1-pp39-pypy39_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5c45a639e93a0c5d4b788b2613bd637468edd62f8f95ebc6fcc303d58ab3f0a8"},
-    {file = "rpds_py-0.18.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:910e71711d1055b2768181efa0a17537b2622afeb0424116619817007f8a2b10"},
-    {file = "rpds_py-0.18.1-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b9bb1f182a97880f6078283b3505a707057c42bf55d8fca604f70dedfdc0772a"},
-    {file = "rpds_py-0.18.1-pp39-pypy39_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:1d54f74f40b1f7aaa595a02ff42ef38ca654b1469bef7d52867da474243cc633"},
-    {file = "rpds_py-0.18.1-pp39-pypy39_pp73-musllinux_1_2_i686.whl", hash = "sha256:8d2e182c9ee01135e11e9676e9a62dfad791a7a467738f06726872374a83db49"},
-    {file = "rpds_py-0.18.1-pp39-pypy39_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:636a15acc588f70fda1661234761f9ed9ad79ebed3f2125d44be0862708b666e"},
-    {file = "rpds_py-0.18.1.tar.gz", hash = "sha256:dc48b479d540770c811fbd1eb9ba2bb66951863e448efec2e2c102625328e92f"},
-]
 
 [[package]]
 name = "ruamel-yaml"
@@ -4138,26 +3866,24 @@ anyio = ">=3.0.0"
 
 [[package]]
 name = "web3"
-version = "6.19.0"
-description = "web3.py"
+version = "7.0.0b6"
+description = "web3: A Python library for interacting with Ethereum"
 optional = false
-python-versions = ">=3.7.2"
+python-versions = "<4,>=3.8"
 files = [
-    {file = "web3-6.19.0-py3-none-any.whl", hash = "sha256:fb39683d6aa7586ce0ab0be4be392f8acb62c2503958079d61b59f2a0b883718"},
-    {file = "web3-6.19.0.tar.gz", hash = "sha256:d27fbd4ac5aa70d0e0c516bd3e3b802fbe74bc159b407c34052d9301b400f757"},
+    {file = "web3-7.0.0b6-py3-none-any.whl", hash = "sha256:96c424f93df2d543d64cbe1758d2a95191e925579f503023d4fd6479d449a5ed"},
+    {file = "web3-7.0.0b6.tar.gz", hash = "sha256:2e33398652c274f35e2cd432327a58a03cd233bb0721c11e4b95687a6faccd2f"},
 ]
 
 [package.dependencies]
 aiohttp = ">=3.7.4.post0"
-eth-abi = ">=4.0.0"
-eth-account = ">=0.8.0,<0.13"
+eth-abi = ">=5.0.1"
+eth-account = ">=0.12.2"
 eth-hash = {version = ">=0.5.1", extras = ["pycryptodome"]}
-eth-typing = ">=3.0.0,<4.2.0 || >4.2.0"
-eth-utils = ">=2.1.0"
-hexbytes = ">=0.1.0,<0.4.0"
-jsonschema = ">=4.0.0"
-lru-dict = ">=1.1.6,<1.3.0"
-protobuf = ">=4.21.6"
+eth-typing = ">=4.0.0"
+eth-utils = ">=4.0.0"
+hexbytes = ">=1.2.0"
+pydantic = ">=2.4.0"
 pyunormalize = ">=15.0.0"
 pywin32 = {version = ">=223", markers = "platform_system == \"Windows\""}
 requests = ">=2.16.0"
@@ -4165,10 +3891,9 @@ typing-extensions = ">=4.0.1"
 websockets = ">=10.0.0"
 
 [package.extras]
-dev = ["build (>=0.9.0)", "bumpversion", "eth-tester[py-evm] (>=0.11.0b1,<0.12.0b1)", "eth-tester[py-evm] (>=0.9.0b1,<0.10.0b1)", "flaky (>=3.7.0)", "hypothesis (>=3.31.2)", "importlib-metadata (<5.0)", "ipfshttpclient (==0.8.0a2)", "pre-commit (>=2.21.0)", "py-geth (>=3.14.0)", "pytest (>=7.0.0)", "pytest-asyncio (>=0.21.2,<0.23)", "pytest-mock (>=1.10)", "pytest-watch (>=4.2)", "pytest-xdist (>=1.29)", "setuptools (>=38.6.0)", "sphinx (>=5.3.0)", "sphinx-rtd-theme (>=1.0.0)", "towncrier (>=21,<22)", "tox (>=3.18.0)", "tqdm (>4.32)", "twine (>=1.13)", "when-changed (>=0.3.0)"]
-docs = ["sphinx (>=5.3.0)", "sphinx-rtd-theme (>=1.0.0)", "towncrier (>=21,<22)"]
-ipfs = ["ipfshttpclient (==0.8.0a2)"]
-tester = ["eth-tester[py-evm] (>=0.11.0b1,<0.12.0b1)", "eth-tester[py-evm] (>=0.9.0b1,<0.10.0b1)", "py-geth (>=3.14.0)"]
+dev = ["build (>=0.9.0)", "bumpversion (>=0.5.3)", "eth-tester[py-evm] (>=0.11.0b1,<0.12.0b1)", "flaky (>=3.7.0)", "hypothesis (>=3.31.2)", "ipython", "pre-commit (>=3.4.0)", "py-geth (>=4.1.0)", "pytest (>=7.0.0)", "pytest-asyncio (>=0.18.1,<0.23)", "pytest-asyncio (>=0.21.2,<0.23)", "pytest-mock (>=1.10)", "pytest-xdist (>=2.4.0)", "setuptools (>=38.6.0)", "sphinx (>=6.0.0)", "sphinx-autobuild (>=2021.3.14)", "sphinx-rtd-theme (>=1.0.0)", "towncrier (>=21,<22)", "tox (>=4.0.0)", "tqdm (>4.32)", "twine (>=1.13)", "wheel"]
+docs = ["sphinx (>=6.0.0)", "sphinx-autobuild (>=2021.3.14)", "sphinx-rtd-theme (>=1.0.0)", "towncrier (>=21,<22)"]
+test = ["eth-tester[py-evm] (>=0.11.0b1,<0.12.0b1)", "py-geth (>=4.1.0)", "pytest (>=7.0.0)", "pytest-asyncio (>=0.18.1,<0.23)", "pytest-mock (>=1.10)", "pytest-xdist (>=2.4.0)"]
 
 [[package]]
 name = "websockets"
@@ -4463,4 +4188,4 @@ ibet-explorer = ["aiohttp", "async-cache", "ibet-wallet-api-explorer", "textual"
 [metadata]
 lock-version = "2.0"
 python-versions = "3.12.2"
-content-hash = "8824eadf02d78e0609d9e249294bfdf04a20ec4c0d9075040a2d6f5870d1061a"
+content-hash = "7bc5a873a3f5af005f1801e2e2f7252dcd042448a07dde429231322eea261fb1"

--- a/poetry.lock
+++ b/poetry.lock
@@ -405,17 +405,17 @@ files = [
 
 [[package]]
 name = "boto3"
-version = "1.34.116"
+version = "1.34.117"
 description = "The AWS SDK for Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "boto3-1.34.116-py3-none-any.whl", hash = "sha256:e7f5ab2d1f1b90971a2b9369760c2c6bae49dae98c084a5c3f5c78e3968ace15"},
-    {file = "boto3-1.34.116.tar.gz", hash = "sha256:53cb8aeb405afa1cd2b25421e27a951aeb568026675dec020587861fac96ac87"},
+    {file = "boto3-1.34.117-py3-none-any.whl", hash = "sha256:1506589e30566bbb2f4997b60968ff7d4ef8a998836c31eedd36437ac3b7408a"},
+    {file = "boto3-1.34.117.tar.gz", hash = "sha256:c8a383b904d6faaf7eed0c06e31b423db128e4c09ce7bd2afc39d1cd07030a51"},
 ]
 
 [package.dependencies]
-botocore = ">=1.34.116,<1.35.0"
+botocore = ">=1.34.117,<1.35.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.10.0,<0.11.0"
 
@@ -424,13 +424,13 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.34.116"
+version = "1.34.117"
 description = "Low-level, data-driven core of boto 3."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "botocore-1.34.116-py3-none-any.whl", hash = "sha256:ec4d42c816e9b2d87a2439ad277e7dda16a4a614ef6839cf66f4c1a58afa547c"},
-    {file = "botocore-1.34.116.tar.gz", hash = "sha256:269cae7ba99081519a9f87d7298e238d9e68ba94eb4f8ddfa906224c34cb8b6c"},
+    {file = "botocore-1.34.117-py3-none-any.whl", hash = "sha256:26a431997f882bcdd1e835f44c24b2a1752b1c4e5183c2ce62999ce95d518d6c"},
+    {file = "botocore-1.34.117.tar.gz", hash = "sha256:4637ca42e6c51aebc4d9a2d92f97bf4bdb042e3f7985ff31a659a11e4c170e73"},
 ]
 
 [package.dependencies]
@@ -4098,18 +4098,18 @@ multidict = ">=4.0"
 
 [[package]]
 name = "zipp"
-version = "3.19.0"
+version = "3.19.1"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "zipp-3.19.0-py3-none-any.whl", hash = "sha256:96dc6ad62f1441bcaccef23b274ec471518daf4fbbc580341204936a5a3dddec"},
-    {file = "zipp-3.19.0.tar.gz", hash = "sha256:952df858fb3164426c976d9338d3961e8e8b3758e2e059e0f754b8c4262625ee"},
+    {file = "zipp-3.19.1-py3-none-any.whl", hash = "sha256:2828e64edb5386ea6a52e7ba7cdb17bb30a73a858f5eb6eb93d8d36f5ea26091"},
+    {file = "zipp-3.19.1.tar.gz", hash = "sha256:35427f6d5594f4acf82d25541438348c26736fa9b3afa2754bcd63cdb99d8e8f"},
 ]
 
 [package.extras]
-docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-testing = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more-itertools", "pytest (>=6,!=8.1.*)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-ignore-flaky", "pytest-mypy", "pytest-ruff (>=0.2.1)"]
+doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+test = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more-itertools", "pytest (>=6,!=8.1.*)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-ignore-flaky", "pytest-mypy", "pytest-ruff (>=0.2.1)"]
 
 [[package]]
 name = "zope-event"
@@ -4188,4 +4188,4 @@ ibet-explorer = ["aiohttp", "async-cache", "ibet-wallet-api-explorer", "textual"
 [metadata]
 lock-version = "2.0"
 python-versions = "3.12.2"
-content-hash = "7bc5a873a3f5af005f1801e2e2f7252dcd042448a07dde429231322eea261fb1"
+content-hash = "c3685f8ef4fec075abab0f126ac81321fc5e6e6d31178ba035a0e68889c44d25"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ psycopg = {extras = ["c"], version = "^3.1.18"}
 pydantic = {extras = ["email"], version = "~2.7.1"}
 sqlalchemy = {extras = ["asyncio"], version = "^2.0.28"}
 uvicorn = {extras = ["standard"], version = "~0.30.0"}
-web3 = "~7.0.0b6"
+web3 = "7.0.0b6"
 tzdata = "^2024.1"
 alembic = "^1.13.1"
 aiomysql = "0.2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,14 +13,14 @@ eth-keyfile = "0.8.1"
 eth-utils = "~4.1.1"
 fastapi = "~0.111.0"
 gunicorn = "~22.0.0"
-hexbytes = "~0.3.1"
+hexbytes = "~1.2.0"
 orjson = "~3.10.3"
 PyMySQL = {extras = ["rsa"], version = "~1.1.0"}
 psycopg = {extras = ["c"], version = "^3.1.18"}
 pydantic = {extras = ["email"], version = "~2.7.1"}
 sqlalchemy = {extras = ["asyncio"], version = "^2.0.28"}
 uvicorn = {extras = ["standard"], version = "~0.30.0"}
-web3 = "~6.19.0"
+web3 = "~7.0.0b6"
 tzdata = "^2024.1"
 alembic = "^1.13.1"
 aiomysql = "0.2.0"

--- a/tests/app/admin_Tokens_POST_test.py
+++ b/tests/app/admin_Tokens_POST_test.py
@@ -24,7 +24,7 @@ from fastapi.testclient import TestClient
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 from web3 import Web3
-from web3.middleware import geth_poa_middleware
+from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
 from app.contracts import Contract
@@ -33,7 +33,7 @@ from tests.account_config import eth_account
 from tests.contract_modules import issue_bond_token, register_bond_list
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
-web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
 
 
 class TestAdminTokensPOST:

--- a/tests/app/company_info_CompanyInfoList_test.py
+++ b/tests/app/company_info_CompanyInfoList_test.py
@@ -23,7 +23,7 @@ from eth_utils import to_checksum_address
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 from web3 import Web3
-from web3.middleware import geth_poa_middleware
+from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
 from app.contracts import Contract
@@ -48,7 +48,7 @@ from tests.contract_modules import (
 )
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
-web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
 
 
 class TestCompanyInfoCompanyInfoList:

--- a/tests/app/company_info_CompanyTokenList_test.py
+++ b/tests/app/company_info_CompanyTokenList_test.py
@@ -20,7 +20,7 @@ SPDX-License-Identifier: Apache-2.0
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 from web3 import Web3
-from web3.middleware import geth_poa_middleware
+from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
 from app.model.db import Listing
@@ -37,7 +37,7 @@ from tests.contract_modules import (
 )
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
-web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
 
 
 class TestCompanyInfoCompanyTokenList:

--- a/tests/app/dex_orderlist_test.py
+++ b/tests/app/dex_orderlist_test.py
@@ -25,7 +25,7 @@ from tests.contract_modules import *
 from tests.utils import PersonalInfoUtils as pi_utils
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
-web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
 
 
 class TestDEXOrderList:

--- a/tests/app/e2e_message_EncryptionKey_test.py
+++ b/tests/app/e2e_message_EncryptionKey_test.py
@@ -20,14 +20,14 @@ SPDX-License-Identifier: Apache-2.0
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 from web3 import Web3
-from web3.middleware import geth_poa_middleware
+from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
 from app.contracts import Contract
 from tests.account_config import eth_account
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
-web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
 
 
 class TestE2EMessageEncryptionKey:

--- a/tests/app/eth_SendRawTransactionNowait_test.py
+++ b/tests/app/eth_SendRawTransactionNowait_test.py
@@ -24,7 +24,7 @@ from eth_utils import to_checksum_address
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 from web3 import Web3
-from web3.middleware import geth_poa_middleware
+from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
 from app.contracts import Contract
@@ -33,7 +33,7 @@ from tests.account_config import eth_account
 from tests.contract_modules import coupon_register_list, issue_coupon_token
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
-web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
 
 
 def insert_node_data(
@@ -144,7 +144,7 @@ class TestEthSendRawTransactionNoWait:
 
         session.commit()
 
-        request_params = {"raw_tx_hex_list": [signed_tx_1.rawTransaction.hex()]}
+        request_params = {"raw_tx_hex_list": [signed_tx_1.raw_transaction.to_0x_hex()]}
         headers = {"Content-Type": "application/json"}
         resp = client.post(self.apiurl, headers=headers, json=request_params)
 
@@ -270,8 +270,8 @@ class TestEthSendRawTransactionNoWait:
 
         request_params = {
             "raw_tx_hex_list": [
-                signed_tx_1.rawTransaction.hex(),
-                signed_tx_2.rawTransaction.hex(),
+                signed_tx_1.raw_transaction.to_0x_hex(),
+                signed_tx_2.raw_transaction.to_0x_hex(),
             ]
         }
         headers = {"Content-Type": "application/json"}
@@ -364,7 +364,9 @@ class TestEthSendRawTransactionNoWait:
 
             session.commit()
 
-            request_params = {"raw_tx_hex_list": [signed_tx_1.rawTransaction.hex()]}
+            request_params = {
+                "raw_tx_hex_list": [signed_tx_1.raw_transaction.to_0x_hex()]
+            }
             headers = {"Content-Type": "application/json"}
             with mock.patch(
                 "web3.eth.async_eth.AsyncEth.send_raw_transaction",
@@ -457,7 +459,9 @@ class TestEthSendRawTransactionNoWait:
 
             session.commit()
 
-            request_params = {"raw_tx_hex_list": [signed_tx_1.rawTransaction.hex()]}
+            request_params = {
+                "raw_tx_hex_list": [signed_tx_1.raw_transaction.to_0x_hex()]
+            }
             headers = {"Content-Type": "application/json"}
             with mock.patch(
                 "web3.eth.async_eth.AsyncEth.send_raw_transaction",
@@ -690,7 +694,7 @@ class TestEthSendRawTransactionNoWait:
 
         session.commit()
 
-        request_params = {"raw_tx_hex_list": [signed_tx_1.rawTransaction.hex()]}
+        request_params = {"raw_tx_hex_list": [signed_tx_1.raw_transaction.to_0x_hex()]}
         headers = {"Content-Type": "application/json"}
         resp = client.post(self.apiurl, headers=headers, json=request_params)
 
@@ -748,7 +752,7 @@ class TestEthSendRawTransactionNoWait:
         )
         signed_tx_1 = web3.eth.account.sign_transaction(tx, local_account_1.key)
 
-        request_params = {"raw_tx_hex_list": [signed_tx_1.rawTransaction.hex()]}
+        request_params = {"raw_tx_hex_list": [signed_tx_1.raw_transaction.to_0x_hex()]}
         headers = {"Content-Type": "application/json"}
         resp = client.post(self.apiurl, headers=headers, json=request_params)
 
@@ -807,7 +811,7 @@ class TestEthSendRawTransactionNoWait:
 
         session.commit()
 
-        request_params = {"raw_tx_hex_list": [signed_tx_1.rawTransaction.hex()]}
+        request_params = {"raw_tx_hex_list": [signed_tx_1.raw_transaction.to_0x_hex()]}
         headers = {"Content-Type": "application/json"}
 
         with patch(

--- a/tests/app/eth_SendRawTransaction_test.py
+++ b/tests/app/eth_SendRawTransaction_test.py
@@ -29,7 +29,7 @@ from sqlalchemy.orm import Session
 from web3 import Web3
 from web3.datastructures import AttributeDict
 from web3.exceptions import TimeExhausted
-from web3.middleware import geth_poa_middleware
+from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config, log
 from app.api.routers import eth
@@ -39,7 +39,7 @@ from tests.account_config import eth_account
 from tests.contract_modules import coupon_register_list, issue_coupon_token
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
-web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
 
 
 def insert_node_data(
@@ -173,7 +173,9 @@ class TestEthSendRawTransaction:
 
             session.commit()
 
-            request_params = {"raw_tx_hex_list": [signed_tx_1.rawTransaction.hex()]}
+            request_params = {
+                "raw_tx_hex_list": [signed_tx_1.raw_transaction.to_0x_hex()]
+            }
             headers = {"Content-Type": "application/json"}
             resp = client.post(self.apiurl, headers=headers, json=request_params)
 
@@ -297,8 +299,8 @@ class TestEthSendRawTransaction:
 
         request_params = {
             "raw_tx_hex_list": [
-                signed_tx_1.rawTransaction.hex(),
-                signed_tx_2.rawTransaction.hex(),
+                signed_tx_1.raw_transaction.to_0x_hex(),
+                signed_tx_2.raw_transaction.to_0x_hex(),
             ]
         }
         headers = {"Content-Type": "application/json"}
@@ -374,7 +376,7 @@ class TestEthSendRawTransaction:
 
         session.commit()
 
-        request_params = {"raw_tx_hex_list": [signed_tx_1.rawTransaction.hex()]}
+        request_params = {"raw_tx_hex_list": [signed_tx_1.raw_transaction.to_0x_hex()]}
         headers = {"Content-Type": "application/json"}
 
         # タイムアウト
@@ -485,7 +487,9 @@ class TestEthSendRawTransaction:
 
             session.commit()
 
-            request_params = {"raw_tx_hex_list": [signed_tx_1.rawTransaction.hex()]}
+            request_params = {
+                "raw_tx_hex_list": [signed_tx_1.raw_transaction.to_0x_hex()]
+            }
             headers = {"Content-Type": "application/json"}
             with mock.patch(
                 "web3.eth.async_eth.AsyncEth.send_raw_transaction",
@@ -578,7 +582,9 @@ class TestEthSendRawTransaction:
 
             session.commit()
 
-            request_params = {"raw_tx_hex_list": [signed_tx_1.rawTransaction.hex()]}
+            request_params = {
+                "raw_tx_hex_list": [signed_tx_1.raw_transaction.to_0x_hex()]
+            }
             headers = {"Content-Type": "application/json"}
             with mock.patch(
                 "web3.eth.async_eth.AsyncEth.send_raw_transaction",
@@ -813,7 +819,7 @@ class TestEthSendRawTransaction:
         )
         signed_tx_1 = web3.eth.account.sign_transaction(tx, local_account_1.key)
 
-        request_params = {"raw_tx_hex_list": [signed_tx_1.rawTransaction.hex()]}
+        request_params = {"raw_tx_hex_list": [signed_tx_1.raw_transaction.to_0x_hex()]}
         headers = {"Content-Type": "application/json"}
         request_body = json.dumps(request_params)
         with mock.patch(
@@ -894,7 +900,7 @@ class TestEthSendRawTransaction:
 
         session.commit()
 
-        request_params = {"raw_tx_hex_list": [signed_tx_1.rawTransaction.hex()]}
+        request_params = {"raw_tx_hex_list": [signed_tx_1.raw_transaction.to_0x_hex()]}
         headers = {"Content-Type": "application/json"}
 
         resp = client.post(self.apiurl, headers=headers, json=request_params)
@@ -953,7 +959,7 @@ class TestEthSendRawTransaction:
         )
         signed_tx_1 = web3.eth.account.sign_transaction(tx, local_account_1.key)
 
-        request_params = {"raw_tx_hex_list": [signed_tx_1.rawTransaction.hex()]}
+        request_params = {"raw_tx_hex_list": [signed_tx_1.raw_transaction.to_0x_hex()]}
         headers = {"Content-Type": "application/json"}
 
         resp = client.post(self.apiurl, headers=headers, json=request_params)
@@ -1013,7 +1019,7 @@ class TestEthSendRawTransaction:
 
         session.commit()
 
-        request_params = {"raw_tx_hex_list": [signed_tx_1.rawTransaction.hex()]}
+        request_params = {"raw_tx_hex_list": [signed_tx_1.raw_transaction.to_0x_hex()]}
         headers = {"Content-Type": "application/json"}
 
         with mock.patch(
@@ -1086,7 +1092,7 @@ class TestEthSendRawTransaction:
 
         session.commit()
 
-        request_params = {"raw_tx_hex_list": [signed_tx_1.rawTransaction.hex()]}
+        request_params = {"raw_tx_hex_list": [signed_tx_1.raw_transaction.to_0x_hex()]}
         headers = {"Content-Type": "application/json"}
 
         with mock.patch(
@@ -1170,7 +1176,7 @@ class TestEthSendRawTransaction:
 
         session.commit()
 
-        request_params = {"raw_tx_hex_list": [signed_tx_1.rawTransaction.hex()]}
+        request_params = {"raw_tx_hex_list": [signed_tx_1.raw_transaction.to_0x_hex()]}
         headers = {"Content-Type": "application/json"}
 
         with mock.patch(
@@ -1251,7 +1257,7 @@ class TestEthSendRawTransaction:
 
         session.commit()
 
-        request_params = {"raw_tx_hex_list": [signed_tx_1.rawTransaction.hex()]}
+        request_params = {"raw_tx_hex_list": [signed_tx_1.raw_transaction.to_0x_hex()]}
         headers = {"Content-Type": "application/json"}
 
         with mock.patch.object(eth.async_web3.eth, "get_transaction", ConnectionError):
@@ -1325,7 +1331,7 @@ class TestEthSendRawTransaction:
 
         session.commit()
 
-        request_params = {"raw_tx_hex_list": [signed_tx_1.rawTransaction.hex()]}
+        request_params = {"raw_tx_hex_list": [signed_tx_1.raw_transaction.to_0x_hex()]}
         headers = {"Content-Type": "application/json"}
 
         # waitForTransactionReceiptエラー
@@ -1415,7 +1421,7 @@ class TestEthSendRawTransaction:
             web3.eth.account, "recover_transaction", MagicMock(side_effect=Exception())
         )
 
-        request_params = {"raw_tx_hex_list": [signed_tx_1.rawTransaction.hex()]}
+        request_params = {"raw_tx_hex_list": [signed_tx_1.raw_transaction.to_0x_hex()]}
         headers = {"Content-Type": "application/json"}
 
         # タイムアウト
@@ -1495,7 +1501,7 @@ class TestEthSendRawTransaction:
 
         session.commit()
 
-        request_params = {"raw_tx_hex_list": [signed_tx_1.rawTransaction.hex()]}
+        request_params = {"raw_tx_hex_list": [signed_tx_1.raw_transaction.to_0x_hex()]}
         headers = {"Content-Type": "application/json"}
 
         # タイムアウト

--- a/tests/app/eth_WaitForTransactionReceipt_test.py
+++ b/tests/app/eth_WaitForTransactionReceipt_test.py
@@ -23,7 +23,7 @@ from eth_utils import to_checksum_address
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 from web3 import Web3
-from web3.middleware import geth_poa_middleware
+from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
 from app.contracts import Contract
@@ -36,7 +36,7 @@ from tests.contract_modules import (
 )
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
-web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
 
 
 def tokenlist_contract():
@@ -119,7 +119,7 @@ class TestEthWaitForTransactionReceipt:
         tx_hash = web3.eth.send_transaction(tx)
 
         # Request the target API
-        resp = client.get(self.apiurl, params={"transaction_hash": tx_hash.hex()})
+        resp = client.get(self.apiurl, params={"transaction_hash": tx_hash.to_0x_hex()})
 
         # Assertion
         assert resp.status_code == 200
@@ -176,7 +176,9 @@ class TestEthWaitForTransactionReceipt:
         with mock.patch(
             "app.api.routers.eth.inspect_tx_failure", return_value="130401"
         ):
-            resp = client.get(self.apiurl, params={"transaction_hash": tx_hash.hex()})
+            resp = client.get(
+                self.apiurl, params={"transaction_hash": tx_hash.to_0x_hex()}
+            )
 
             # Assertion
             assert resp.status_code == 200

--- a/tests/app/events_E2EMessagingEvents_test.py
+++ b/tests/app/events_E2EMessagingEvents_test.py
@@ -23,14 +23,14 @@ from unittest.mock import ANY
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 from web3 import Web3
-from web3.middleware import geth_poa_middleware
+from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
 from app.contracts import Contract
 from tests.account_config import eth_account
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
-web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
 
 
 class TestEventsE2EMessaging:
@@ -98,7 +98,7 @@ class TestEventsE2EMessaging:
             {
                 "event": "PublicKeyUpdated",
                 "args": {"key": "test_key", "key_type": "test_key_type", "who": user1},
-                "transaction_hash": tx.hex(),
+                "transaction_hash": tx.to_0x_hex(),
                 "block_number": latest_block_number,
                 "block_timestamp": latest_block_timestamp,
                 "log_index": 0,
@@ -145,7 +145,7 @@ class TestEventsE2EMessaging:
                     "time": ANY,
                     "text": "test_message",
                 },
-                "transaction_hash": tx.hex(),
+                "transaction_hash": tx.to_0x_hex(),
                 "block_number": latest_block_number,
                 "block_timestamp": latest_block_timestamp,
                 "log_index": 0,
@@ -182,7 +182,7 @@ class TestEventsE2EMessaging:
             {
                 "event": "PublicKeyUpdated",
                 "args": {"key": "test_key", "key_type": "test_key_type", "who": user1},
-                "transaction_hash": tx.hex(),
+                "transaction_hash": tx.to_0x_hex(),
                 "block_number": latest_block_number,
                 "block_timestamp": latest_block_timestamp,
                 "log_index": 0,
@@ -234,7 +234,7 @@ class TestEventsE2EMessaging:
                     "time": ANY,
                     "text": "test_message",
                 },
-                "transaction_hash": tx_1.hex(),
+                "transaction_hash": tx_1.to_0x_hex(),
                 "block_number": latest_block_number - 1,
                 "block_timestamp": block_timestamp_1,
                 "log_index": 0,
@@ -247,7 +247,7 @@ class TestEventsE2EMessaging:
                     "time": ANY,
                     "text": "test_message",
                 },
-                "transaction_hash": tx_2.hex(),
+                "transaction_hash": tx_2.to_0x_hex(),
                 "block_number": latest_block_number,
                 "block_timestamp": block_timestamp_2,
                 "log_index": 0,
@@ -290,7 +290,7 @@ class TestEventsE2EMessaging:
             {
                 "event": "PublicKeyUpdated",
                 "args": {"key": "test_key", "key_type": "test_key_type", "who": user1},
-                "transaction_hash": tx.hex(),
+                "transaction_hash": tx.to_0x_hex(),
                 "block_number": latest_block_number,
                 "block_timestamp": latest_block_timestamp,
                 "log_index": 0,
@@ -383,7 +383,7 @@ class TestEventsE2EMessaging:
                     "time": ANY,
                     "text": "test_message",
                 },
-                "transaction_hash": tx_1.hex(),
+                "transaction_hash": tx_1.to_0x_hex(),
                 "block_number": block_number_1,
                 "block_timestamp": block_timestamp_1,
                 "log_index": 0,
@@ -391,7 +391,7 @@ class TestEventsE2EMessaging:
             {
                 "event": "PublicKeyUpdated",
                 "args": {"who": user1, "key": "test_key", "key_type": "test_key_type"},
-                "transaction_hash": tx_2.hex(),
+                "transaction_hash": tx_2.to_0x_hex(),
                 "block_number": block_number_2,
                 "block_timestamp": block_timestamp_2,
                 "log_index": 0,
@@ -446,7 +446,7 @@ class TestEventsE2EMessaging:
             {
                 "event": "PublicKeyUpdated",
                 "args": {"who": user1, "key": "test_key", "key_type": "test_key_type"},
-                "transaction_hash": tx_2.hex(),
+                "transaction_hash": tx_2.to_0x_hex(),
                 "block_number": block_number_2,
                 "block_timestamp": block_timestamp_2,
                 "log_index": 0,

--- a/tests/app/events_IbetEscrowEvents_test.py
+++ b/tests/app/events_IbetEscrowEvents_test.py
@@ -22,14 +22,14 @@ import json
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 from web3 import Web3
-from web3.middleware import geth_poa_middleware
+from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
 from tests.account_config import eth_account
 from tests.utils import IbetStandardTokenUtils
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
-web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
 
 
 class TestEventsIbetEscrow:
@@ -99,7 +99,7 @@ class TestEventsIbetEscrow:
             {
                 "event": "Deposited",
                 "args": {"token": token_contract.address, "account": issuer},
-                "transaction_hash": tx_hash.hex(),
+                "transaction_hash": tx_hash.to_0x_hex(),
                 "block_number": latest_block_number,
                 "block_timestamp": latest_block_timestamp,
                 "log_index": 0,
@@ -152,7 +152,7 @@ class TestEventsIbetEscrow:
             {
                 "event": "Withdrawn",
                 "args": {"token": token_contract.address, "account": issuer},
-                "transaction_hash": tx_hash.hex(),
+                "transaction_hash": tx_hash.to_0x_hex(),
                 "block_number": latest_block_number,
                 "block_timestamp": latest_block_timestamp,
                 "log_index": 1,
@@ -216,7 +216,7 @@ class TestEventsIbetEscrow:
                     "agent": agent,
                     "data": "test_data",
                 },
-                "transaction_hash": tx_hash.hex(),
+                "transaction_hash": tx_hash.to_0x_hex(),
                 "block_number": latest_block_number,
                 "block_timestamp": latest_block_timestamp,
                 "log_index": 0,
@@ -283,7 +283,7 @@ class TestEventsIbetEscrow:
                     "amount": 1000,
                     "agent": agent,
                 },
-                "transaction_hash": tx_hash.hex(),
+                "transaction_hash": tx_hash.to_0x_hex(),
                 "block_number": latest_block_number,
                 "block_timestamp": latest_block_timestamp,
                 "log_index": 0,
@@ -350,7 +350,7 @@ class TestEventsIbetEscrow:
                     "amount": 1000,
                     "agent": agent,
                 },
-                "transaction_hash": tx_hash.hex(),
+                "transaction_hash": tx_hash.to_0x_hex(),
                 "block_number": latest_block_number,
                 "block_timestamp": latest_block_timestamp,
                 "log_index": 0,
@@ -404,7 +404,7 @@ class TestEventsIbetEscrow:
             {
                 "event": "Deposited",
                 "args": {"token": token_contract.address, "account": issuer},
-                "transaction_hash": tx_hash.hex(),
+                "transaction_hash": tx_hash.to_0x_hex(),
                 "block_number": latest_block_number,
                 "block_timestamp": latest_block_timestamp,
                 "log_index": 0,
@@ -511,7 +511,7 @@ class TestEventsIbetEscrow:
             {
                 "event": "Deposited",
                 "args": {"token": token_contract.address, "account": issuer},
-                "transaction_hash": tx_hash_1.hex(),
+                "transaction_hash": tx_hash_1.to_0x_hex(),
                 "block_number": block_number_1,
                 "block_timestamp": block_timestamp_1,
                 "log_index": 0,
@@ -519,7 +519,7 @@ class TestEventsIbetEscrow:
             {
                 "event": "Withdrawn",
                 "args": {"token": token_contract.address, "account": issuer},
-                "transaction_hash": tx_hash_2.hex(),
+                "transaction_hash": tx_hash_2.to_0x_hex(),
                 "block_number": block_number_2,
                 "block_timestamp": block_timestamp_2,
                 "log_index": 1,
@@ -572,7 +572,7 @@ class TestEventsIbetEscrow:
             {
                 "event": "Deposited",
                 "args": {"token": token_contract.address, "account": issuer},
-                "transaction_hash": tx_hash.hex(),
+                "transaction_hash": tx_hash.to_0x_hex(),
                 "block_number": latest_block_number,
                 "block_timestamp": latest_block_timestamp,
                 "log_index": 0,

--- a/tests/app/events_IbetSecurityTokenDVPEvents_test.py
+++ b/tests/app/events_IbetSecurityTokenDVPEvents_test.py
@@ -23,14 +23,14 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 from web3 import Web3
-from web3.middleware import geth_poa_middleware
+from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
 from tests.account_config import eth_account
 from tests.utils import IbetShareUtils
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
-web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
 
 
 class TestEventsIbetSecurityTokenDVP:
@@ -107,7 +107,7 @@ class TestEventsIbetSecurityTokenDVP:
             {
                 "event": "Deposited",
                 "args": {"token": token_contract.address, "account": issuer},
-                "transaction_hash": tx_hash.hex(),
+                "transaction_hash": tx_hash.to_0x_hex(),
                 "block_number": latest_block_number,
                 "block_timestamp": latest_block_timestamp,
                 "log_index": 0,
@@ -182,7 +182,7 @@ class TestEventsIbetSecurityTokenDVP:
             {
                 "event": "Withdrawn",
                 "args": {"token": token_contract.address, "account": issuer},
-                "transaction_hash": tx_hash.hex(),
+                "transaction_hash": tx_hash.to_0x_hex(),
                 "block_number": latest_block_number,
                 "block_timestamp": latest_block_timestamp,
                 "log_index": 1,
@@ -273,7 +273,7 @@ class TestEventsIbetSecurityTokenDVP:
                     "agent": agent,
                     "data": "test_data",
                 },
-                "transaction_hash": tx_hash.hex(),
+                "transaction_hash": tx_hash.to_0x_hex(),
                 "block_number": latest_block_number,
                 "block_timestamp": latest_block_timestamp,
                 "log_index": 0,
@@ -370,7 +370,7 @@ class TestEventsIbetSecurityTokenDVP:
                     "amount": 1000,
                     "agent": agent,
                 },
-                "transaction_hash": tx_hash.hex(),
+                "transaction_hash": tx_hash.to_0x_hex(),
                 "block_number": latest_block_number,
                 "block_timestamp": latest_block_timestamp,
                 "log_index": 0,
@@ -467,7 +467,7 @@ class TestEventsIbetSecurityTokenDVP:
                     "amount": 1000,
                     "agent": agent,
                 },
-                "transaction_hash": tx_hash.hex(),
+                "transaction_hash": tx_hash.to_0x_hex(),
                 "block_number": latest_block_number,
                 "block_timestamp": latest_block_timestamp,
                 "log_index": 0,
@@ -571,7 +571,7 @@ class TestEventsIbetSecurityTokenDVP:
                     "amount": 1000,
                     "agent": agent,
                 },
-                "transaction_hash": tx_hash.hex(),
+                "transaction_hash": tx_hash.to_0x_hex(),
                 "block_number": latest_block_number,
                 "block_timestamp": latest_block_timestamp,
                 "log_index": 0,
@@ -675,7 +675,7 @@ class TestEventsIbetSecurityTokenDVP:
                     "amount": 1000,
                     "agent": agent,
                 },
-                "transaction_hash": tx_hash.hex(),
+                "transaction_hash": tx_hash.to_0x_hex(),
                 "block_number": latest_block_number,
                 "block_timestamp": latest_block_timestamp,
                 "log_index": 0,
@@ -736,7 +736,7 @@ class TestEventsIbetSecurityTokenDVP:
             {
                 "event": "Deposited",
                 "args": {"token": token_contract.address, "account": issuer},
-                "transaction_hash": tx_hash.hex(),
+                "transaction_hash": tx_hash.to_0x_hex(),
                 "block_number": latest_block_number,
                 "block_timestamp": latest_block_timestamp,
                 "log_index": 0,
@@ -863,7 +863,7 @@ class TestEventsIbetSecurityTokenDVP:
             {
                 "event": "Deposited",
                 "args": {"token": token_contract.address, "account": issuer},
-                "transaction_hash": tx_hash_1.hex(),
+                "transaction_hash": tx_hash_1.to_0x_hex(),
                 "block_number": block_number_1,
                 "block_timestamp": block_timestamp_1,
                 "log_index": 0,
@@ -879,7 +879,7 @@ class TestEventsIbetSecurityTokenDVP:
                     "agent": agent,
                     "data": "test_data",
                 },
-                "transaction_hash": tx_hash_2.hex(),
+                "transaction_hash": tx_hash_2.to_0x_hex(),
                 "block_number": block_number_2,
                 "block_timestamp": block_timestamp_2,
                 "log_index": 0,
@@ -956,7 +956,7 @@ class TestEventsIbetSecurityTokenDVP:
             {
                 "event": "Deposited",
                 "args": {"token": token_contract.address, "account": issuer},
-                "transaction_hash": tx_hash_1.hex(),
+                "transaction_hash": tx_hash_1.to_0x_hex(),
                 "block_number": block_number_1,
                 "block_timestamp": block_timestamp_1,
                 "log_index": 0,

--- a/tests/app/events_IbetSecurityTokenEscrowEvents_test.py
+++ b/tests/app/events_IbetSecurityTokenEscrowEvents_test.py
@@ -22,14 +22,14 @@ import json
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 from web3 import Web3
-from web3.middleware import geth_poa_middleware
+from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
 from tests.account_config import eth_account
 from tests.utils import IbetShareUtils
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
-web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
 
 
 class TestEventsIbetSecurityTokenEscrow:
@@ -106,7 +106,7 @@ class TestEventsIbetSecurityTokenEscrow:
             {
                 "event": "Deposited",
                 "args": {"token": token_contract.address, "account": issuer},
-                "transaction_hash": tx_hash.hex(),
+                "transaction_hash": tx_hash.to_0x_hex(),
                 "block_number": latest_block_number,
                 "block_timestamp": latest_block_timestamp,
                 "log_index": 0,
@@ -166,7 +166,7 @@ class TestEventsIbetSecurityTokenEscrow:
             {
                 "event": "Withdrawn",
                 "args": {"token": token_contract.address, "account": issuer},
-                "transaction_hash": tx_hash.hex(),
+                "transaction_hash": tx_hash.to_0x_hex(),
                 "block_number": latest_block_number,
                 "block_timestamp": latest_block_timestamp,
                 "log_index": 1,
@@ -242,7 +242,7 @@ class TestEventsIbetSecurityTokenEscrow:
                     "value": 1000,
                     "data": "test_application_data",
                 },
-                "transaction_hash": tx_hash.hex(),
+                "transaction_hash": tx_hash.to_0x_hex(),
                 "block_number": latest_block_number,
                 "block_timestamp": latest_block_timestamp,
                 "log_index": 0,
@@ -258,7 +258,7 @@ class TestEventsIbetSecurityTokenEscrow:
                     "agent": agent,
                     "data": "test_data",
                 },
-                "transaction_hash": tx_hash.hex(),
+                "transaction_hash": tx_hash.to_0x_hex(),
                 "block_number": latest_block_number,
                 "block_timestamp": latest_block_timestamp,
                 "log_index": 1,
@@ -339,7 +339,7 @@ class TestEventsIbetSecurityTokenEscrow:
                     "agent": agent,
                     "data": "test_data",
                 },
-                "transaction_hash": tx_hash.hex(),
+                "transaction_hash": tx_hash.to_0x_hex(),
                 "block_number": latest_block_number,
                 "block_timestamp": latest_block_timestamp,
                 "log_index": 1,
@@ -419,7 +419,7 @@ class TestEventsIbetSecurityTokenEscrow:
                     "value": 1000,
                     "data": "test_application_data",
                 },
-                "transaction_hash": tx_hash.hex(),
+                "transaction_hash": tx_hash.to_0x_hex(),
                 "block_number": latest_block_number,
                 "block_timestamp": latest_block_timestamp,
                 "log_index": 0,
@@ -498,7 +498,7 @@ class TestEventsIbetSecurityTokenEscrow:
                     "from": issuer,
                     "to": user1,
                 },
-                "transaction_hash": tx_hash.hex(),
+                "transaction_hash": tx_hash.to_0x_hex(),
                 "block_number": latest_block_number,
                 "block_timestamp": latest_block_timestamp,
                 "log_index": 0,
@@ -513,7 +513,7 @@ class TestEventsIbetSecurityTokenEscrow:
                     "amount": 1000,
                     "agent": agent,
                 },
-                "transaction_hash": tx_hash.hex(),
+                "transaction_hash": tx_hash.to_0x_hex(),
                 "block_number": latest_block_number,
                 "block_timestamp": latest_block_timestamp,
                 "log_index": 1,
@@ -598,7 +598,7 @@ class TestEventsIbetSecurityTokenEscrow:
                     "amount": 1000,
                     "agent": agent,
                 },
-                "transaction_hash": tx_hash.hex(),
+                "transaction_hash": tx_hash.to_0x_hex(),
                 "block_number": latest_block_number,
                 "block_timestamp": latest_block_timestamp,
                 "log_index": 1,
@@ -681,7 +681,7 @@ class TestEventsIbetSecurityTokenEscrow:
                     "from": issuer,
                     "to": user1,
                 },
-                "transaction_hash": tx_hash.hex(),
+                "transaction_hash": tx_hash.to_0x_hex(),
                 "block_number": latest_block_number,
                 "block_timestamp": latest_block_timestamp,
                 "log_index": 0,
@@ -763,7 +763,7 @@ class TestEventsIbetSecurityTokenEscrow:
                     "agent": agent,
                     "transferApprovalRequired": True,
                 },
-                "transaction_hash": tx_hash.hex(),
+                "transaction_hash": tx_hash.to_0x_hex(),
                 "block_number": latest_block_number,
                 "block_timestamp": latest_block_timestamp,
                 "log_index": 0,
@@ -849,7 +849,7 @@ class TestEventsIbetSecurityTokenEscrow:
                     "agent": agent,
                     "transferApprovalRequired": True,
                 },
-                "transaction_hash": tx_hash.hex(),
+                "transaction_hash": tx_hash.to_0x_hex(),
                 "block_number": latest_block_number,
                 "block_timestamp": latest_block_timestamp,
                 "log_index": 0,
@@ -932,7 +932,7 @@ class TestEventsIbetSecurityTokenEscrow:
                     "token": token_contract.address,
                     "data": "test_approval_data",
                 },
-                "transaction_hash": tx_hash.hex(),
+                "transaction_hash": tx_hash.to_0x_hex(),
                 "block_number": latest_block_number,
                 "block_timestamp": latest_block_timestamp,
                 "log_index": 0,
@@ -1019,7 +1019,7 @@ class TestEventsIbetSecurityTokenEscrow:
                     "token": token_contract.address,
                     "data": "test_approval_data",
                 },
-                "transaction_hash": tx_hash.hex(),
+                "transaction_hash": tx_hash.to_0x_hex(),
                 "block_number": latest_block_number,
                 "block_timestamp": latest_block_timestamp,
                 "log_index": 0,
@@ -1080,7 +1080,7 @@ class TestEventsIbetSecurityTokenEscrow:
             {
                 "event": "Deposited",
                 "args": {"token": token_contract.address, "account": issuer},
-                "transaction_hash": tx_hash.hex(),
+                "transaction_hash": tx_hash.to_0x_hex(),
                 "block_number": latest_block_number,
                 "block_timestamp": latest_block_timestamp,
                 "log_index": 0,
@@ -1208,7 +1208,7 @@ class TestEventsIbetSecurityTokenEscrow:
             {
                 "event": "Deposited",
                 "args": {"token": token_contract.address, "account": issuer},
-                "transaction_hash": tx_hash_1.hex(),
+                "transaction_hash": tx_hash_1.to_0x_hex(),
                 "block_number": block_number_1,
                 "block_timestamp": block_timestamp_1,
                 "log_index": 0,
@@ -1223,7 +1223,7 @@ class TestEventsIbetSecurityTokenEscrow:
                     "value": 1000,
                     "data": "test_application_data",
                 },
-                "transaction_hash": tx_hash_2.hex(),
+                "transaction_hash": tx_hash_2.to_0x_hex(),
                 "block_number": block_number_2,
                 "block_timestamp": block_timestamp_2,
                 "log_index": 0,
@@ -1239,7 +1239,7 @@ class TestEventsIbetSecurityTokenEscrow:
                     "agent": agent,
                     "data": "test_data",
                 },
-                "transaction_hash": tx_hash_2.hex(),
+                "transaction_hash": tx_hash_2.to_0x_hex(),
                 "block_number": block_number_2,
                 "block_timestamp": block_timestamp_2,
                 "log_index": 1,
@@ -1317,7 +1317,7 @@ class TestEventsIbetSecurityTokenEscrow:
             {
                 "event": "Deposited",
                 "args": {"token": token_contract.address, "account": issuer},
-                "transaction_hash": tx_hash_1.hex(),
+                "transaction_hash": tx_hash_1.to_0x_hex(),
                 "block_number": block_number_1,
                 "block_timestamp": block_timestamp_1,
                 "log_index": 0,

--- a/tests/app/events_IbetSecurityTokenInterfaceEvents_test.py
+++ b/tests/app/events_IbetSecurityTokenInterfaceEvents_test.py
@@ -23,7 +23,7 @@ from unittest.mock import ANY
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 from web3 import Web3
-from web3.middleware import geth_poa_middleware
+from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
 from app.contracts import Contract
@@ -52,7 +52,7 @@ from tests.contract_modules import (
 )
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
-web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
 
 
 class TestEventsIbetSecurityTokenInterface:

--- a/tests/app/node_info_BlockSyncStatus_test.py
+++ b/tests/app/node_info_BlockSyncStatus_test.py
@@ -108,7 +108,7 @@ class TestNodeInfoBlockSyncStatus:
 
     # Error_1
     @mock.patch(
-        "web3.providers.async_rpc.AsyncHTTPProvider.make_request",
+        "web3.AsyncWeb3.AsyncHTTPProvider.make_request",
         MagicMock(side_effect=requests.exceptions.ReadTimeout()),
     )
     def test_error_1(self, client: TestClient, session: Session):

--- a/tests/app/position_PositionCouponContractAddress_test.py
+++ b/tests/app/position_PositionCouponContractAddress_test.py
@@ -22,7 +22,7 @@ from unittest import mock
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 from web3 import Web3
-from web3.middleware import geth_poa_middleware
+from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
 from app.contracts import Contract
@@ -37,7 +37,7 @@ from tests.contract_modules import (
 )
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
-web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
 
 
 class TestPositionCouponContractAddress:

--- a/tests/app/position_PositionCoupon_test.py
+++ b/tests/app/position_PositionCoupon_test.py
@@ -22,7 +22,7 @@ from unittest import mock
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 from web3 import Web3
-from web3.middleware import geth_poa_middleware
+from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
 from app.contracts import Contract
@@ -45,7 +45,7 @@ from tests.contract_modules import (
 )
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
-web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
 
 
 class TestPositionCoupon:

--- a/tests/app/position_PositionMembershipContractAddress_test.py
+++ b/tests/app/position_PositionMembershipContractAddress_test.py
@@ -22,7 +22,7 @@ from unittest import mock
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 from web3 import Web3
-from web3.middleware import geth_poa_middleware
+from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
 from app.contracts import Contract
@@ -35,7 +35,7 @@ from tests.contract_modules import (
 )
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
-web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
 
 
 class TestPositionMembershipContractAddress:

--- a/tests/app/position_PositionMembership_test.py
+++ b/tests/app/position_PositionMembership_test.py
@@ -22,7 +22,7 @@ from unittest import mock
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 from web3 import Web3
-from web3.middleware import geth_poa_middleware
+from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
 from app.contracts import Contract
@@ -35,7 +35,7 @@ from tests.contract_modules import (
 )
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
-web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
 
 
 class TestPositionMembership:

--- a/tests/app/position_PositionShare_Lock_test.py
+++ b/tests/app/position_PositionShare_Lock_test.py
@@ -23,13 +23,13 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 from web3 import Web3
-from web3.middleware import geth_poa_middleware
+from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
 from app.model.db import IDXLockedPosition, IDXShareToken
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
-web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
 
 
 class TestPositionShareLock:

--- a/tests/app/position_PositionStraightBondContractAddress_test.py
+++ b/tests/app/position_PositionStraightBondContractAddress_test.py
@@ -22,7 +22,7 @@ from unittest import mock
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 from web3 import Web3
-from web3.middleware import geth_poa_middleware
+from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
 from app.contracts import Contract
@@ -38,7 +38,7 @@ from tests.contract_modules import (
 from tests.utils import PersonalInfoUtils
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
-web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
 
 
 class TestPositionStraightBondContractAddress:

--- a/tests/app/position_PositionStraightBond_Lock_test.py
+++ b/tests/app/position_PositionStraightBond_Lock_test.py
@@ -23,13 +23,13 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 from web3 import Web3
-from web3.middleware import geth_poa_middleware
+from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
 from app.model.db import IDXBondToken, IDXLockedPosition
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
-web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
 
 
 class TestPositionStraightBondLock:

--- a/tests/app/position_PositionStraightBond_test.py
+++ b/tests/app/position_PositionStraightBond_test.py
@@ -22,7 +22,7 @@ from unittest import mock
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 from web3 import Web3
-from web3.middleware import geth_poa_middleware
+from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
 from app.contracts import Contract
@@ -44,7 +44,7 @@ from tests.contract_modules import (
 from tests.utils import PersonalInfoUtils
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
-web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
 
 
 class TestPositionStraightBond:

--- a/tests/app/position_Position_test.py
+++ b/tests/app/position_Position_test.py
@@ -23,7 +23,7 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 from web3 import Web3
-from web3.middleware import geth_poa_middleware
+from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
 from app.model.db import (
@@ -40,7 +40,7 @@ from tests.app.position_PositionShare_test import TestPositionShare
 from tests.app.position_PositionStraightBond_test import TestPositionStraightBond
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
-web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
 
 
 class TestPosition:

--- a/tests/app/token_LockCount.py
+++ b/tests/app/token_LockCount.py
@@ -23,14 +23,14 @@ from datetime import datetime, timedelta
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 from web3 import Web3
-from web3.middleware import geth_poa_middleware
+from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
 from app.database import engine
 from app.model.db import IDXLockedPosition
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
-web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
 
 
 class TestTokenLockCount:

--- a/tests/app/token_Lock_test.py
+++ b/tests/app/token_Lock_test.py
@@ -23,14 +23,14 @@ from datetime import datetime, timedelta
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 from web3 import Web3
-from web3.middleware import geth_poa_middleware
+from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
 from app.database import engine
 from app.model.db import IDXLockedPosition
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
-web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
 
 
 class TestTokenLock:

--- a/tests/app/token_TokenHoldersCollectionId_test.py
+++ b/tests/app/token_TokenHoldersCollectionId_test.py
@@ -25,7 +25,7 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 from web3 import Web3
-from web3.middleware import geth_poa_middleware
+from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
 from app.contracts import Contract
@@ -33,7 +33,7 @@ from app.model.db import Listing, TokenHolderBatchStatus, TokenHoldersList
 from batch.indexer_Token_Holders import Processor
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
-web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
 
 from tests.account_config import eth_account
 from tests.contract_modules import (
@@ -249,19 +249,7 @@ class TestTokenTokenHoldersCollectionId:
         )
         resp = client.get(apiurl)
 
-        holders = [
-            {
-                "account_address": self.trader["account_address"],
-                "hold_balance": 27000,
-                "locked_balance": 2000,
-            },
-            {
-                "account_address": self.user1["account_address"],
-                "hold_balance": 51000,
-                "locked_balance": 0,
-            },
-        ]
-
+        # Assertion
         assert resp.status_code == 200
         assert resp.json()["meta"] == {"code": 200, "message": "OK"}
         assert resp.json()["data"]["status"] == TokenHolderBatchStatus.DONE.value

--- a/tests/app/token_TokenHoldersCollection_test.py
+++ b/tests/app/token_TokenHoldersCollection_test.py
@@ -24,7 +24,7 @@ from unittest import mock
 import pytest
 from fastapi.testclient import TestClient
 from web3 import Web3
-from web3.middleware import geth_poa_middleware
+from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
 from app.contracts import Contract
@@ -32,7 +32,7 @@ from app.model.db import Listing, TokenHolderBatchStatus, TokenHoldersList
 from batch.indexer_Token_Holders import Processor
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
-web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
 from sqlalchemy.orm import Session
 
 from tests.account_config import eth_account

--- a/tests/app/token_TokenStatus_test.py
+++ b/tests/app/token_TokenStatus_test.py
@@ -21,7 +21,7 @@ from eth_utils import to_checksum_address
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 from web3 import Web3
-from web3.middleware import geth_poa_middleware
+from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
 from app.contracts import Contract
@@ -47,7 +47,7 @@ from tests.contract_modules import (
 )
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
-web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
 
 
 class TestTokenTokenStatus:

--- a/tests/app/token_bond_StraightBondTokenAddresses_test.py
+++ b/tests/app/token_bond_StraightBondTokenAddresses_test.py
@@ -24,7 +24,7 @@ from eth_utils import to_checksum_address
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 from web3 import Web3
-from web3.middleware import geth_poa_middleware
+from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
 from app.contracts import Contract
@@ -35,7 +35,7 @@ from tests.account_config import eth_account
 from tests.contract_modules import issue_bond_token, register_bond_list
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
-web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
 
 
 @pytest.fixture(scope="session")

--- a/tests/app/token_bond_StraightBondTokenDetails_test.py
+++ b/tests/app/token_bond_StraightBondTokenDetails_test.py
@@ -23,7 +23,7 @@ from eth_utils import to_checksum_address
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 from web3 import Web3
-from web3.middleware import geth_poa_middleware
+from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
 from app.contracts import Contract
@@ -32,7 +32,7 @@ from tests.account_config import eth_account
 from tests.contract_modules import bond_invalidate, issue_bond_token, register_bond_list
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
-web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
 
 
 class TestTokenStraightBondTokenDetails:

--- a/tests/app/token_bond_StraightBondTokens_test.py
+++ b/tests/app/token_bond_StraightBondTokens_test.py
@@ -24,7 +24,7 @@ from eth_utils import to_checksum_address
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 from web3 import Web3
-from web3.middleware import geth_poa_middleware
+from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
 from app.contracts import Contract
@@ -35,7 +35,7 @@ from tests.account_config import eth_account
 from tests.contract_modules import issue_bond_token, register_bond_list
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
-web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
 
 
 @pytest.fixture(scope="session")

--- a/tests/app/token_coupon_CouponTokenAddresses_test.py
+++ b/tests/app/token_coupon_CouponTokenAddresses_test.py
@@ -24,7 +24,7 @@ from eth_utils import to_checksum_address
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 from web3 import Web3
-from web3.middleware import geth_poa_middleware
+from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
 from app.contracts import Contract
@@ -35,7 +35,7 @@ from tests.account_config import eth_account
 from tests.contract_modules import coupon_register_list, issue_coupon_token
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
-web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
 
 
 @pytest.fixture(scope="session")

--- a/tests/app/token_coupon_CouponTokenDetails_test.py
+++ b/tests/app/token_coupon_CouponTokenDetails_test.py
@@ -23,7 +23,7 @@ from eth_utils import to_checksum_address
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 from web3 import Web3
-from web3.middleware import geth_poa_middleware
+from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
 from app.contracts import Contract
@@ -36,7 +36,7 @@ from tests.contract_modules import (
 )
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
-web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
 
 
 class TestTokenCouponTokenDetails:

--- a/tests/app/token_coupon_CouponTokens_test.py
+++ b/tests/app/token_coupon_CouponTokens_test.py
@@ -24,7 +24,7 @@ from eth_utils import to_checksum_address
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 from web3 import Web3
-from web3.middleware import geth_poa_middleware
+from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
 from app.contracts import Contract
@@ -35,7 +35,7 @@ from tests.account_config import eth_account
 from tests.contract_modules import coupon_register_list, issue_coupon_token
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
-web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
 
 
 @pytest.fixture(scope="session")

--- a/tests/app/token_membership_MembershipTokenAddresses_test.py
+++ b/tests/app/token_membership_MembershipTokenAddresses_test.py
@@ -24,7 +24,7 @@ from eth_utils import to_checksum_address
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 from web3 import Web3
-from web3.middleware import geth_poa_middleware
+from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
 from app.contracts import Contract
@@ -35,7 +35,7 @@ from tests.account_config import eth_account
 from tests.contract_modules import membership_issue, membership_register_list
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
-web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
 
 
 @pytest.fixture(scope="session")

--- a/tests/app/token_membership_MembershipTokenDetails_test.py
+++ b/tests/app/token_membership_MembershipTokenDetails_test.py
@@ -23,7 +23,7 @@ from eth_utils import to_checksum_address
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 from web3 import Web3
-from web3.middleware import geth_poa_middleware
+from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
 from app.contracts import Contract
@@ -36,7 +36,7 @@ from tests.contract_modules import (
 )
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
-web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
 
 
 class TestTokenMembershipTokenDetails:

--- a/tests/app/token_membership_MembershipTokens_test.py
+++ b/tests/app/token_membership_MembershipTokens_test.py
@@ -24,7 +24,7 @@ from eth_utils import to_checksum_address
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 from web3 import Web3
-from web3.middleware import geth_poa_middleware
+from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
 from app.contracts import Contract
@@ -35,7 +35,7 @@ from tests.account_config import eth_account
 from tests.contract_modules import membership_issue, membership_register_list
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
-web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
 
 
 @pytest.fixture(scope="session")

--- a/tests/app/token_share_ShareTokenAddresses_test.py
+++ b/tests/app/token_share_ShareTokenAddresses_test.py
@@ -24,7 +24,7 @@ from eth_utils import to_checksum_address
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 from web3 import Web3
-from web3.middleware import geth_poa_middleware
+from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
 from app.contracts import Contract
@@ -35,7 +35,7 @@ from tests.account_config import eth_account
 from tests.contract_modules import issue_share_token, register_share_list
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
-web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
 
 
 @pytest.fixture(scope="session")

--- a/tests/app/token_share_ShareTokenDetails_test.py
+++ b/tests/app/token_share_ShareTokenDetails_test.py
@@ -23,7 +23,7 @@ from eth_utils import to_checksum_address
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 from web3 import Web3
-from web3.middleware import geth_poa_middleware
+from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
 from app.contracts import Contract
@@ -36,7 +36,7 @@ from tests.contract_modules import (
 )
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
-web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
 
 
 class TestTokenShareTokenDetails:

--- a/tests/app/token_share_ShareTokens_test.py
+++ b/tests/app/token_share_ShareTokens_test.py
@@ -24,7 +24,7 @@ from eth_utils import to_checksum_address
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 from web3 import Web3
-from web3.middleware import geth_poa_middleware
+from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
 from app.contracts import Contract
@@ -35,7 +35,7 @@ from tests.account_config import eth_account
 from tests.contract_modules import issue_share_token, register_share_list
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
-web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
 
 
 @pytest.fixture(scope="session")

--- a/tests/batch/indexer_DEX_test.py
+++ b/tests/batch/indexer_DEX_test.py
@@ -29,7 +29,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 from web3 import Web3
 from web3.exceptions import ABIEventFunctionNotFound
-from web3.middleware import geth_poa_middleware
+from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
 from app.errors import ServiceUnavailable
@@ -55,7 +55,7 @@ from tests.contract_modules import (
 )
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
-web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
 
 
 @pytest.fixture(scope="function")
@@ -201,7 +201,7 @@ class TestProcessor:
 
         block = web3.eth.get_block(block_number)
         _order = _order_list[0]
-        assert _order.transaction_hash == block["transactions"][0].hex()
+        assert _order.transaction_hash == block["transactions"][0].to_0x_hex()
         assert _order.token_address == token["address"]
         assert _order.order_id == 1
         assert _order.unique_order_id == f"{exchange_contract_address}_1"
@@ -256,7 +256,7 @@ class TestProcessor:
 
         block = web3.eth.get_block(block_number)
         _order = _order_list[0]
-        assert _order.transaction_hash == block["transactions"][0].hex()
+        assert _order.transaction_hash == block["transactions"][0].to_0x_hex()
         assert _order.token_address == token["address"]
         assert _order.order_id == 1
         assert _order.unique_order_id == f"{exchange_contract_address}_1"
@@ -313,7 +313,7 @@ class TestProcessor:
         block = web3.eth.get_block(block_number)
         _order = _order_list[0]
         assert _order.id == 1
-        assert _order.transaction_hash == block["transactions"][0].hex()
+        assert _order.transaction_hash == block["transactions"][0].to_0x_hex()
         assert _order.token_address == token["address"]
         assert _order.order_id == 1
         assert _order.unique_order_id == f"{exchange_contract_address}_1"
@@ -333,7 +333,7 @@ class TestProcessor:
 
         block2 = web3.eth.get_block(block_number2)
         _agreement = _agreement_list[0]
-        assert _agreement.transaction_hash == block2["transactions"][0].hex()
+        assert _agreement.transaction_hash == block2["transactions"][0].to_0x_hex()
         assert _agreement.exchange_address == exchange_contract_address
         assert _agreement.order_id == 1
         assert _agreement.agreement_id == 1
@@ -387,7 +387,7 @@ class TestProcessor:
         block = web3.eth.get_block(block_number)
         _order = _order_list[0]
         assert _order.id == 1
-        assert _order.transaction_hash == block["transactions"][0].hex()
+        assert _order.transaction_hash == block["transactions"][0].to_0x_hex()
         assert _order.token_address == token["address"]
         assert _order.order_id == 1
         assert _order.unique_order_id == f"{exchange_contract_address}_1"
@@ -407,7 +407,7 @@ class TestProcessor:
 
         block2 = web3.eth.get_block(block_number2)
         _agreement = _agreement_list[0]
-        assert _agreement.transaction_hash == block2["transactions"][0].hex()
+        assert _agreement.transaction_hash == block2["transactions"][0].to_0x_hex()
         assert _agreement.exchange_address == exchange_contract_address
         assert _agreement.order_id == 1
         assert _agreement.agreement_id == 1
@@ -463,7 +463,7 @@ class TestProcessor:
         block = web3.eth.get_block(block_number)
         _order = _order_list[0]
         assert _order.id == 1
-        assert _order.transaction_hash == block["transactions"][0].hex()
+        assert _order.transaction_hash == block["transactions"][0].to_0x_hex()
         assert _order.token_address == token["address"]
         assert _order.order_id == 1
         assert _order.unique_order_id == f"{exchange_contract_address}_1"
@@ -483,7 +483,7 @@ class TestProcessor:
 
         block2 = web3.eth.get_block(block_number2)
         _agreement = _agreement_list[0]
-        assert _agreement.transaction_hash == block2["transactions"][0].hex()
+        assert _agreement.transaction_hash == block2["transactions"][0].to_0x_hex()
         assert _agreement.exchange_address == exchange_contract_address
         assert _agreement.order_id == 1
         assert _agreement.agreement_id == 1
@@ -539,7 +539,7 @@ class TestProcessor:
         block = web3.eth.get_block(block_number)
         _order = _order_list[0]
         assert _order.id == 1
-        assert _order.transaction_hash == block["transactions"][0].hex()
+        assert _order.transaction_hash == block["transactions"][0].to_0x_hex()
         assert _order.token_address == token["address"]
         assert _order.order_id == 1
         assert _order.unique_order_id == f"{exchange_contract_address}_1"
@@ -559,7 +559,7 @@ class TestProcessor:
 
         block2 = web3.eth.get_block(block_number2)
         _agreement = _agreement_list[0]
-        assert _agreement.transaction_hash == block2["transactions"][0].hex()
+        assert _agreement.transaction_hash == block2["transactions"][0].to_0x_hex()
         assert _agreement.exchange_address == exchange_contract_address
         assert _agreement.order_id == 1
         assert _agreement.agreement_id == 1
@@ -655,7 +655,7 @@ class TestProcessor:
         block = web3.eth.get_block(membership_block_number)
         _order = _order_list[0]
         assert _order.id == 1
-        assert _order.transaction_hash == block["transactions"][0].hex()
+        assert _order.transaction_hash == block["transactions"][0].to_0x_hex()
         assert _order.token_address == membership_token["address"]
         assert _order.order_id == 1
         assert _order.unique_order_id == f"{membership_exchange_contract_address}_1"
@@ -671,7 +671,7 @@ class TestProcessor:
         block = web3.eth.get_block(coupon_block_number)
         _order = _order_list[1]
         assert _order.id == 2
-        assert _order.transaction_hash == block["transactions"][0].hex()
+        assert _order.transaction_hash == block["transactions"][0].to_0x_hex()
         assert _order.token_address == coupon_token["address"]
         assert _order.order_id == 1
         assert _order.unique_order_id == f"{coupon_exchange_contract_address}_1"
@@ -691,7 +691,7 @@ class TestProcessor:
 
         block2 = web3.eth.get_block(membership_block_number2)
         _agreement = _agreement_list[0]
-        assert _agreement.transaction_hash == block2["transactions"][0].hex()
+        assert _agreement.transaction_hash == block2["transactions"][0].to_0x_hex()
         assert _agreement.exchange_address == membership_exchange_contract_address
         assert _agreement.order_id == 1
         assert _agreement.agreement_id == 1
@@ -706,7 +706,7 @@ class TestProcessor:
 
         block2 = web3.eth.get_block(coupon_block_number2)
         _agreement = _agreement_list[1]
-        assert _agreement.transaction_hash == block2["transactions"][0].hex()
+        assert _agreement.transaction_hash == block2["transactions"][0].to_0x_hex()
         assert _agreement.exchange_address == coupon_exchange_contract_address
         assert _agreement.order_id == 1
         assert _agreement.agreement_id == 1
@@ -967,7 +967,7 @@ class TestProcessor:
         block_number_bf = processor.latest_block
         # Expect that initial_sync() raises ServiceUnavailable.
         with mock.patch(
-            "web3.providers.async_rpc.AsyncHTTPProvider.make_request",
+            "web3.AsyncWeb3.AsyncHTTPProvider.make_request",
             MagicMock(side_effect=ServiceUnavailable()),
         ), pytest.raises(ServiceUnavailable):
             asyncio.run(processor.initial_sync())
@@ -993,7 +993,7 @@ class TestProcessor:
         block_number_bf = processor.latest_block
         # Expect that sync_new_logs() raises ServiceUnavailable.
         with mock.patch(
-            "web3.providers.async_rpc.AsyncHTTPProvider.make_request",
+            "web3.AsyncWeb3.AsyncHTTPProvider.make_request",
             MagicMock(side_effect=ServiceUnavailable()),
         ), pytest.raises(ServiceUnavailable):
             asyncio.run(processor.sync_new_logs())
@@ -1089,7 +1089,7 @@ class TestProcessor:
         with mock.patch("batch.indexer_DEX.asyncio", asyncio_mock), mock.patch(
             "batch.indexer_DEX.Processor.initial_sync", return_value=True
         ), mock.patch(
-            "web3.providers.async_rpc.AsyncHTTPProvider.make_request",
+            "web3.AsyncWeb3.AsyncHTTPProvider.make_request",
             MagicMock(side_effect=ServiceUnavailable()),
         ), pytest.raises(
             TypeError

--- a/tests/batch/indexer_Position_Bond_test.py
+++ b/tests/batch/indexer_Position_Bond_test.py
@@ -30,7 +30,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 from web3 import Web3
 from web3.exceptions import ABIEventFunctionNotFound
-from web3.middleware import geth_poa_middleware
+from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
 from app.contracts import Contract
@@ -70,7 +70,7 @@ from tests.contract_modules import (
 from tests.utils import PersonalInfoUtils
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
-web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
 
 
 @pytest.fixture(scope="session")
@@ -1577,7 +1577,7 @@ class TestProcessor:
         # Get events for token address
         events = Contract.get_contract(
             "IbetStraightBond", token["address"]
-        ).events.Transfer.get_logs(fromBlock=from_block, toBlock=to_block)
+        ).events.Transfer.get_logs(from_block=from_block, to_block=to_block)
         # Ensure 5 events squashed to 2 events
         assert len(events) == 5
         filtered_events = processor.remove_duplicate_event_by_token_account_desc(
@@ -2019,7 +2019,7 @@ class TestProcessor:
 
         # Expect that initial_sync() raises ServiceUnavailable.
         with mock.patch(
-            "web3.providers.async_rpc.AsyncHTTPProvider.make_request",
+            "web3.AsyncWeb3.AsyncHTTPProvider.make_request",
             MagicMock(side_effect=ServiceUnavailable()),
         ), pytest.raises(ServiceUnavailable):
             asyncio.run(processor.initial_sync())
@@ -2049,7 +2049,7 @@ class TestProcessor:
 
         # Expect that sync_new_logs() raises ServiceUnavailable.
         with mock.patch(
-            "web3.providers.async_rpc.AsyncHTTPProvider.make_request",
+            "web3.AsyncWeb3.AsyncHTTPProvider.make_request",
             MagicMock(side_effect=ServiceUnavailable()),
         ), pytest.raises(ServiceUnavailable):
             asyncio.run(processor.sync_new_logs())
@@ -2171,7 +2171,7 @@ class TestProcessor:
         ), mock.patch(
             "batch.indexer_Position_Bond.Processor.initial_sync", return_value=True
         ), mock.patch(
-            "web3.providers.async_rpc.AsyncHTTPProvider.make_request",
+            "web3.AsyncWeb3.AsyncHTTPProvider.make_request",
             MagicMock(side_effect=ServiceUnavailable()),
         ), pytest.raises(
             TypeError

--- a/tests/batch/indexer_Position_Membership_test.py
+++ b/tests/batch/indexer_Position_Membership_test.py
@@ -29,7 +29,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 from web3 import Web3
 from web3.exceptions import ABIEventFunctionNotFound
-from web3.middleware import geth_poa_middleware
+from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
 from app.contracts import Contract
@@ -56,7 +56,7 @@ from tests.contract_modules import (
 )
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
-web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
 
 
 @pytest.fixture(scope="session")
@@ -706,7 +706,7 @@ class TestProcessor:
         # Get events for token address
         events = Contract.get_contract(
             "IbetMembership", token["address"]
-        ).events.Transfer.get_logs(fromBlock=from_block, toBlock=to_block)
+        ).events.Transfer.get_logs(from_block=from_block, to_block=to_block)
         # Ensure 5 events squashed to 2 events
         assert len(events) == 5
         filtered_events = processor.remove_duplicate_event_by_token_account_desc(
@@ -1112,7 +1112,7 @@ class TestProcessor:
 
         # Expect that initial_sync() raises ServiceUnavailable.
         with mock.patch(
-            "web3.providers.async_rpc.AsyncHTTPProvider.make_request",
+            "web3.AsyncWeb3.AsyncHTTPProvider.make_request",
             MagicMock(side_effect=ServiceUnavailable()),
         ), pytest.raises(ServiceUnavailable):
             asyncio.run(processor.initial_sync())
@@ -1141,7 +1141,7 @@ class TestProcessor:
         )
         # Expect that sync_new_logs() raises ServiceUnavailable.
         with mock.patch(
-            "web3.providers.async_rpc.AsyncHTTPProvider.make_request",
+            "web3.AsyncWeb3.AsyncHTTPProvider.make_request",
             MagicMock(side_effect=ServiceUnavailable()),
         ), pytest.raises(ServiceUnavailable):
             asyncio.run(processor.sync_new_logs())
@@ -1254,7 +1254,7 @@ class TestProcessor:
             "batch.indexer_Position_Membership.Processor.initial_sync",
             return_value=True,
         ), mock.patch(
-            "web3.providers.async_rpc.AsyncHTTPProvider.make_request",
+            "web3.AsyncWeb3.AsyncHTTPProvider.make_request",
             MagicMock(side_effect=ServiceUnavailable()),
         ), pytest.raises(
             TypeError

--- a/tests/batch/indexer_Position_Share_test.py
+++ b/tests/batch/indexer_Position_Share_test.py
@@ -29,7 +29,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 from web3 import Web3
 from web3.exceptions import ABIEventFunctionNotFound
-from web3.middleware import geth_poa_middleware
+from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
 from app.contracts import Contract
@@ -69,7 +69,7 @@ from tests.contract_modules import (
 from tests.utils import PersonalInfoUtils
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
-web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
 
 
 @pytest.fixture(scope="session")
@@ -1555,7 +1555,7 @@ class TestProcessor:
         # Get events for token address
         events = Contract.get_contract(
             "IbetShare", token["address"]
-        ).events.Transfer.get_logs(fromBlock=from_block, toBlock=to_block)
+        ).events.Transfer.get_logs(from_block=from_block, to_block=to_block)
         # Ensure 5 events squashed to 2 events
         assert len(events) == 5
         filtered_events = processor.remove_duplicate_event_by_token_account_desc(
@@ -2009,7 +2009,7 @@ class TestProcessor:
 
         # Expect that initial_sync() raises ServiceUnavailable.
         with mock.patch(
-            "web3.providers.async_rpc.AsyncHTTPProvider.make_request",
+            "web3.AsyncWeb3.AsyncHTTPProvider.make_request",
             MagicMock(side_effect=ServiceUnavailable()),
         ), pytest.raises(ServiceUnavailable):
             asyncio.run(processor.initial_sync())
@@ -2039,7 +2039,7 @@ class TestProcessor:
 
         # Expect that sync_new_logs() raises ServiceUnavailable.
         with mock.patch(
-            "web3.providers.async_rpc.AsyncHTTPProvider.make_request",
+            "web3.AsyncWeb3.AsyncHTTPProvider.make_request",
             MagicMock(side_effect=ServiceUnavailable()),
         ), pytest.raises(ServiceUnavailable):
             asyncio.run(processor.sync_new_logs())
@@ -2161,7 +2161,7 @@ class TestProcessor:
         ), mock.patch(
             "batch.indexer_Position_Share.Processor.initial_sync", return_value=True
         ), mock.patch(
-            "web3.providers.async_rpc.AsyncHTTPProvider.make_request",
+            "web3.AsyncWeb3.AsyncHTTPProvider.make_request",
             MagicMock(side_effect=ServiceUnavailable()),
         ), pytest.raises(
             TypeError

--- a/tests/batch/indexer_Token_Detail_ShortTerm_test.py
+++ b/tests/batch/indexer_Token_Detail_ShortTerm_test.py
@@ -30,7 +30,7 @@ from sqlalchemy import select
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 from web3 import Web3
-from web3.middleware import geth_poa_middleware
+from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
 from app.contracts import Contract
@@ -59,7 +59,7 @@ from tests.contract_modules import (
 )
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
-web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
 
 
 @pytest.fixture(scope="session")
@@ -782,7 +782,7 @@ class TestProcessor:
 
         # Expect that process() raises ServiceUnavailable.
         with mock.patch(
-            "web3.providers.async_rpc.AsyncHTTPProvider.make_request",
+            "web3.AsyncWeb3.AsyncHTTPProvider.make_request",
             MagicMock(side_effect=ServiceUnavailable()),
         ), pytest.raises(ServiceUnavailable):
             await processor.process()
@@ -810,7 +810,7 @@ class TestProcessor:
 
         # Expect that process() raises ServiceUnavailable.
         with mock.patch(
-            "web3.providers.async_rpc.AsyncHTTPProvider.make_request",
+            "web3.AsyncWeb3.AsyncHTTPProvider.make_request",
             MagicMock(side_effect=ServiceUnavailable()),
         ), pytest.raises(ServiceUnavailable):
             await processor.process()
@@ -910,7 +910,7 @@ class TestProcessor:
         with mock.patch(
             "batch.indexer_Token_Detail_ShortTerm.asyncio", time_mock
         ), mock.patch(
-            "web3.providers.async_rpc.AsyncHTTPProvider.make_request",
+            "web3.AsyncWeb3.AsyncHTTPProvider.make_request",
             MagicMock(side_effect=ServiceUnavailable()),
         ), pytest.raises(
             TypeError

--- a/tests/batch/indexer_Token_Detail_test.py
+++ b/tests/batch/indexer_Token_Detail_test.py
@@ -31,7 +31,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 from web3 import Web3
-from web3.middleware import geth_poa_middleware
+from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
 from app.errors import ServiceUnavailable
@@ -59,7 +59,7 @@ from tests.contract_modules import (
 )
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
-web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
 
 
 @pytest.fixture(scope="session")
@@ -399,7 +399,7 @@ class TestProcessor:
 
         # Expect that process() raises ServiceUnavailable.
         with mock.patch(
-            "web3.providers.async_rpc.AsyncHTTPProvider.make_request",
+            "web3.AsyncWeb3.AsyncHTTPProvider.make_request",
             MagicMock(side_effect=ServiceUnavailable()),
         ), pytest.raises(ServiceUnavailable):
             asyncio.run(processor.process())
@@ -417,7 +417,7 @@ class TestProcessor:
 
         # Expect that process() raises ServiceUnavailable.
         with mock.patch(
-            "web3.providers.async_rpc.AsyncHTTPProvider.make_request",
+            "web3.AsyncWeb3.AsyncHTTPProvider.make_request",
             MagicMock(side_effect=ServiceUnavailable()),
         ), pytest.raises(ServiceUnavailable):
             asyncio.run(processor.process())
@@ -510,7 +510,7 @@ class TestProcessor:
 
         # Run mainloop once and fail with web3 utils error
         with mock.patch("batch.indexer_Token_Detail.asyncio", time_mock), mock.patch(
-            "web3.providers.async_rpc.AsyncHTTPProvider.make_request",
+            "web3.AsyncWeb3.AsyncHTTPProvider.make_request",
             MagicMock(side_effect=[ServiceUnavailable()]),
         ), pytest.raises(TypeError):
             # Expect that process() raises ServiceUnavailable and handled in mainloop.

--- a/tests/batch/indexer_Token_Holders_test.py
+++ b/tests/batch/indexer_Token_Holders_test.py
@@ -28,7 +28,7 @@ from sqlalchemy import and_, select
 from sqlalchemy.orm import Session
 from web3 import Web3
 from web3.exceptions import ABIEventFunctionNotFound
-from web3.middleware import geth_poa_middleware
+from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
 from app.config import ZERO_ADDRESS
@@ -89,7 +89,7 @@ from tests.contract_modules import (
 )
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
-web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
 
 
 @pytest.fixture(scope="session")

--- a/tests/batch/indexer_Token_List_test.py
+++ b/tests/batch/indexer_Token_List_test.py
@@ -28,7 +28,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 from web3 import Web3
 from web3.exceptions import ABIEventFunctionNotFound
-from web3.middleware import geth_poa_middleware
+from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
 from app.contracts import Contract
@@ -49,7 +49,7 @@ from tests.contract_modules import (
 )
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
-web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
 
 
 @pytest.fixture(scope="session")
@@ -712,7 +712,7 @@ class TestProcessor:
         ).first()
         # Expect that process() raises ServiceUnavailable.
         with mock.patch(
-            "web3.providers.async_rpc.AsyncHTTPProvider.make_request",
+            "web3.AsyncWeb3.AsyncHTTPProvider.make_request",
             MagicMock(side_effect=ServiceUnavailable()),
         ), pytest.raises(ServiceUnavailable):
             asyncio.run(processor.process())
@@ -741,7 +741,7 @@ class TestProcessor:
 
         # Expect that process() raises ServiceUnavailable.
         with mock.patch(
-            "web3.providers.async_rpc.AsyncHTTPProvider.make_request",
+            "web3.AsyncWeb3.AsyncHTTPProvider.make_request",
             MagicMock(side_effect=ServiceUnavailable()),
         ), pytest.raises(ServiceUnavailable):
             asyncio.run(processor.process())
@@ -860,7 +860,7 @@ class TestProcessor:
 
         # Run mainloop once and fail with web3 utils error
         with mock.patch("batch.indexer_Token_List.asyncio", asyncio_mock), mock.patch(
-            "web3.providers.async_rpc.AsyncHTTPProvider.make_request",
+            "web3.AsyncWeb3.AsyncHTTPProvider.make_request",
             MagicMock(side_effect=ServiceUnavailable()),
         ), pytest.raises(TypeError):
             # Expect that process() raises ServiceUnavailable and handled in mainloop.

--- a/tests/batch/indexer_TransferApproval_test.py
+++ b/tests/batch/indexer_TransferApproval_test.py
@@ -30,7 +30,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 from web3 import Web3
 from web3.exceptions import ABIEventFunctionNotFound
-from web3.middleware import geth_poa_middleware
+from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
 from app.contracts import Contract
@@ -47,7 +47,7 @@ from tests.contract_modules import (
 from tests.utils import PersonalInfoUtils
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
-web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
 
 
 @pytest.fixture(scope="session")
@@ -1193,7 +1193,7 @@ class TestProcessor:
 
         # Expect that initial_sync() raises ServiceUnavailable.
         with mock.patch(
-            "web3.providers.async_rpc.AsyncHTTPProvider.make_request",
+            "web3.AsyncWeb3.AsyncHTTPProvider.make_request",
             MagicMock(side_effect=ServiceUnavailable()),
         ), pytest.raises(ServiceUnavailable):
             asyncio.run(processor.sync_new_logs())
@@ -1218,7 +1218,7 @@ class TestProcessor:
 
         # Expect that sync_new_logs() raises ServiceUnavailable.
         with mock.patch(
-            "web3.providers.async_rpc.AsyncHTTPProvider.make_request",
+            "web3.AsyncWeb3.AsyncHTTPProvider.make_request",
             MagicMock(side_effect=ServiceUnavailable()),
         ), pytest.raises(ServiceUnavailable):
             asyncio.run(processor.sync_new_logs())
@@ -1338,7 +1338,7 @@ class TestProcessor:
         ), mock.patch(
             "batch.indexer_TransferApproval.Processor.initial_sync", return_value=True
         ), mock.patch(
-            "web3.providers.async_rpc.AsyncHTTPProvider.make_request",
+            "web3.AsyncWeb3.AsyncHTTPProvider.make_request",
             MagicMock(side_effect=ServiceUnavailable()),
         ), pytest.raises(
             TypeError

--- a/tests/batch/indexer_Transfer_test.py
+++ b/tests/batch/indexer_Transfer_test.py
@@ -30,7 +30,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 from web3 import Web3
 from web3.exceptions import ABIEventFunctionNotFound
-from web3.middleware import geth_poa_middleware
+from web3.middleware import ExtraDataToPOAMiddleware
 from web3.types import RPCEndpoint
 
 from app import config
@@ -63,7 +63,7 @@ from tests.contract_modules import (
 from tests.utils import PersonalInfoUtils
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
-web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
 
 
 @pytest.fixture(scope="session")
@@ -287,7 +287,7 @@ class TestProcessor:
         block1 = web3.eth.get_block(block_number_1)
         idx_transfer: IDXTransfer = idx_transfer_list[0]
         assert idx_transfer.id == 1
-        assert idx_transfer.transaction_hash == block1["transactions"][0].hex()
+        assert idx_transfer.transaction_hash == block1["transactions"][0].to_0x_hex()
         assert idx_transfer.token_address == share_token["address"]
         assert idx_transfer.from_address == self.issuer["account_address"]
         assert idx_transfer.to_address == self.trader["account_address"]
@@ -300,7 +300,7 @@ class TestProcessor:
         block2 = web3.eth.get_block(block_number_2)
         idx_transfer: IDXTransfer = idx_transfer_list[1]
         assert idx_transfer.id == 2
-        assert idx_transfer.transaction_hash == block2["transactions"][0].hex()
+        assert idx_transfer.transaction_hash == block2["transactions"][0].to_0x_hex()
         assert idx_transfer.token_address == share_token["address"]
         assert idx_transfer.from_address == self.trader["account_address"]
         assert idx_transfer.to_address == self.trader2["account_address"]
@@ -467,7 +467,7 @@ class TestProcessor:
         block = web3.eth.get_block(block_number_1)
         idx_transfer = idx_transfer_list[0]
         assert idx_transfer.id == 1
-        assert idx_transfer.transaction_hash == block["transactions"][0].hex()
+        assert idx_transfer.transaction_hash == block["transactions"][0].to_0x_hex()
         assert idx_transfer.token_address == share_token["address"]
         assert idx_transfer.from_address == self.issuer["account_address"]
         assert idx_transfer.to_address == self.trader["account_address"]
@@ -480,7 +480,7 @@ class TestProcessor:
         block = web3.eth.get_block(block_number_2)
         idx_transfer = idx_transfer_list[1]
         assert idx_transfer.id == 2
-        assert idx_transfer.transaction_hash == block["transactions"][0].hex()
+        assert idx_transfer.transaction_hash == block["transactions"][0].to_0x_hex()
         assert idx_transfer.token_address == share_token["address"]
         assert idx_transfer.from_address == self.issuer["account_address"]
         assert idx_transfer.to_address == self.trader2["account_address"]
@@ -493,7 +493,7 @@ class TestProcessor:
         block = web3.eth.get_block(block_number_3)
         idx_transfer = idx_transfer_list[2]
         assert idx_transfer.id == 3
-        assert idx_transfer.transaction_hash == block["transactions"][0].hex()
+        assert idx_transfer.transaction_hash == block["transactions"][0].to_0x_hex()
         assert idx_transfer.token_address == share_token["address"]
         assert idx_transfer.from_address == self.trader["account_address"]
         assert idx_transfer.to_address == self.trader2["account_address"]
@@ -506,7 +506,7 @@ class TestProcessor:
         block = web3.eth.get_block(block_number_4)
         idx_transfer = idx_transfer_list[3]
         assert idx_transfer.id == 4
-        assert idx_transfer.transaction_hash == block["transactions"][0].hex()
+        assert idx_transfer.transaction_hash == block["transactions"][0].to_0x_hex()
         assert idx_transfer.token_address == share_token["address"]
         assert idx_transfer.from_address == self.trader["account_address"]
         assert idx_transfer.to_address == self.trader2["account_address"]
@@ -586,7 +586,7 @@ class TestProcessor:
         block = web3.eth.get_block(bond_block_number)
         idx_transfer = idx_transfer_list[0]
         assert idx_transfer.id == 1
-        assert idx_transfer.transaction_hash == block["transactions"][0].hex()
+        assert idx_transfer.transaction_hash == block["transactions"][0].to_0x_hex()
         assert idx_transfer.token_address == bond_token["address"]
         assert idx_transfer.from_address == self.issuer["account_address"]
         assert idx_transfer.to_address == self.trader["account_address"]
@@ -599,7 +599,7 @@ class TestProcessor:
         block = web3.eth.get_block(membership_block_number)
         idx_transfer = idx_transfer_list[1]
         assert idx_transfer.id == 2
-        assert idx_transfer.transaction_hash == block["transactions"][0].hex()
+        assert idx_transfer.transaction_hash == block["transactions"][0].to_0x_hex()
         assert idx_transfer.token_address == membership_token["address"]
         assert idx_transfer.from_address == self.issuer["account_address"]
         assert idx_transfer.to_address == self.trader["account_address"]
@@ -612,7 +612,7 @@ class TestProcessor:
         block = web3.eth.get_block(coupon_block_number)
         idx_transfer = idx_transfer_list[2]
         assert idx_transfer.id == 3
-        assert idx_transfer.transaction_hash == block["transactions"][0].hex()
+        assert idx_transfer.transaction_hash == block["transactions"][0].to_0x_hex()
         assert idx_transfer.token_address == coupon_token["address"]
         assert idx_transfer.from_address == self.issuer["account_address"]
         assert idx_transfer.to_address == self.trader["account_address"]
@@ -688,7 +688,7 @@ class TestProcessor:
         block = web3.eth.get_block(block_number_1)
         _transfer = _transfer_list[0]
         assert _transfer.id == 1
-        assert _transfer.transaction_hash == block["transactions"][0].hex()
+        assert _transfer.transaction_hash == block["transactions"][0].to_0x_hex()
         assert _transfer.token_address == share_token["address"]
         assert _transfer.from_address == self.issuer["account_address"]
         assert _transfer.to_address == self.trader["account_address"]
@@ -779,7 +779,7 @@ class TestProcessor:
         block = web3.eth.get_block(block_number_1)
         _transfer = _transfer_list[0]
         assert _transfer.id == 1
-        assert _transfer.transaction_hash == block["transactions"][0].hex()
+        assert _transfer.transaction_hash == block["transactions"][0].to_0x_hex()
         assert _transfer.token_address == share_token["address"]
         assert _transfer.from_address == self.issuer["account_address"]
         assert _transfer.to_address == self.trader["account_address"]
@@ -873,7 +873,7 @@ class TestProcessor:
         block = web3.eth.get_block(block_number_1)
         _transfer = _transfer_list[0]
         assert _transfer.id == 1
-        assert _transfer.transaction_hash == block["transactions"][0].hex()
+        assert _transfer.transaction_hash == block["transactions"][0].to_0x_hex()
         assert _transfer.token_address == share_token["address"]
         assert _transfer.from_address == self.issuer["account_address"]
         assert _transfer.to_address == self.trader["account_address"]
@@ -962,7 +962,7 @@ class TestProcessor:
 
         idx_transfer = IDXTransfer()
         idx_transfer.id = 1
-        idx_transfer.transaction_hash = block["transactions"][0].hex()
+        idx_transfer.transaction_hash = block["transactions"][0].to_0x_hex()
         idx_transfer.from_address = self.issuer["account_address"]
         idx_transfer.to_address = self.issuer["account_address"]
         idx_transfer.value = 100000
@@ -1201,7 +1201,7 @@ class TestProcessor:
 
         # Execute batch processing
         with mock.patch(
-            "web3.providers.async_rpc.AsyncHTTPProvider.make_request",
+            "web3.AsyncWeb3.AsyncHTTPProvider.make_request",
             MagicMock(side_effect=ServiceUnavailable()),
         ), pytest.raises(ServiceUnavailable):
             asyncio.run(processor.sync_new_logs())

--- a/tests/batch/processor_Block_Sync_Status_test.py
+++ b/tests/batch/processor_Block_Sync_Status_test.py
@@ -24,14 +24,14 @@ from unittest.mock import MagicMock
 import pytest
 from sqlalchemy import select
 from web3 import Web3
-from web3.middleware import geth_poa_middleware
+from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
 from app.model.db import Node
 from batch.processor_Block_Sync_Status import Processor
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
-web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
 
 
 @pytest.fixture(scope="function")

--- a/tests/batch/processor_Notifications_Coupon_Exchange_test.py
+++ b/tests/batch/processor_Notifications_Coupon_Exchange_test.py
@@ -25,7 +25,7 @@ from unittest.mock import MagicMock
 import pytest
 from sqlalchemy import and_, select
 from web3 import Web3
-from web3.middleware import geth_poa_middleware
+from web3.middleware import ExtraDataToPOAMiddleware
 from web3.types import RPCEndpoint
 
 from app import config
@@ -45,7 +45,7 @@ from tests.contract_modules import (
 )
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
-web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
 
 
 @pytest.fixture(scope="function")

--- a/tests/batch/processor_Notifications_Membership_Exchange_test.py
+++ b/tests/batch/processor_Notifications_Membership_Exchange_test.py
@@ -25,7 +25,7 @@ from unittest.mock import MagicMock
 import pytest
 from sqlalchemy import and_, select
 from web3 import Web3
-from web3.middleware import geth_poa_middleware
+from web3.middleware import ExtraDataToPOAMiddleware
 from web3.types import RPCEndpoint
 
 from app import config
@@ -45,7 +45,7 @@ from tests.contract_modules import (
 )
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
-web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
 
 
 @pytest.fixture(scope="function")

--- a/tests/batch/processor_Notifications_Token_test.py
+++ b/tests/batch/processor_Notifications_Token_test.py
@@ -30,7 +30,7 @@ from sqlalchemy import and_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 from web3 import Web3
-from web3.middleware import geth_poa_middleware
+from web3.middleware import ExtraDataToPOAMiddleware
 from web3.types import RPCEndpoint
 
 from app import config
@@ -63,7 +63,7 @@ if TYPE_CHECKING:
     from batch.processor_Notifications_Token import Watcher
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
-web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
 
 
 @pytest.fixture(scope="function")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,7 @@ from sqlalchemy import text
 from sqlalchemy.orm import Session
 from web3 import Web3
 from web3.eth import Contract as Web3Contract
-from web3.middleware import geth_poa_middleware
+from web3.middleware import ExtraDataToPOAMiddleware
 from web3.types import ChecksumAddress, RPCEndpoint
 
 from app import config
@@ -47,7 +47,7 @@ from app.utils.web3_utils import AsyncFailOverHTTPProvider
 from tests.account_config import eth_account
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
-web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
 
 
 class DeployedContract(TypedDict):

--- a/tests/contract_modules.py
+++ b/tests/contract_modules.py
@@ -21,7 +21,7 @@ import json
 
 from eth_utils import to_checksum_address
 from web3 import Web3
-from web3.middleware import geth_poa_middleware
+from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
 from app.contracts import Contract
@@ -29,7 +29,7 @@ from tests.account_config import eth_account
 from tests.conftest import DeployedContract, UnitTestAccount
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
-web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
 
 
 # 名簿用個人情報登録

--- a/tests/loadtest/locustfile.py
+++ b/tests/loadtest/locustfile.py
@@ -81,8 +81,7 @@ class LoadTestTaskSet(TaskSet):
 
         signed_txn = w3.eth.account.signTransaction(txn, private_key=private_key)
 
-        raw_tx_hex_list = []
-        raw_tx_hex_list.append(str(signed_txn.rawTransaction.hex()))
+        raw_tx_hex_list = [str(signed_txn.raw_transaction.to_0x_hex())]
 
         payload = {"raw_tx_hex_list": raw_tx_hex_list}
         headers = {"content-type": "application/json"}

--- a/tests/utils/personal_info.py
+++ b/tests/utils/personal_info.py
@@ -18,13 +18,13 @@ SPDX-License-Identifier: Apache-2.0
 """
 
 from web3 import Web3
-from web3.middleware import geth_poa_middleware
+from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
 from app.contracts import Contract
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
-web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
 
 
 class PersonalInfoUtils:

--- a/tests/utils/share_token.py
+++ b/tests/utils/share_token.py
@@ -20,14 +20,14 @@ SPDX-License-Identifier: Apache-2.0
 from typing import Dict
 
 from web3 import Web3
-from web3.middleware import geth_poa_middleware
+from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
 from app.contracts import Contract
 from tests.account_config import eth_account
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
-web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
 
 
 class IbetShareUtils:

--- a/tests/utils/standard_token.py
+++ b/tests/utils/standard_token.py
@@ -20,13 +20,13 @@ SPDX-License-Identifier: Apache-2.0
 from typing import Dict
 
 from web3 import Web3
-from web3.middleware import geth_poa_middleware
+from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
 from app.contracts import Contract
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
-web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
 
 
 class IbetStandardTokenUtils:


### PR DESCRIPTION
Upgrade web3 python to v7 beta.

Ref: Migration guide
- https://web3py.readthedocs.io/en/v7.0.0-beta.6/migration.html#migrating-from-v6-to-v7

##  1. hex() -> to_0x_hex()

Doc: None(?)

The return value of the function changes as follows:

- v6
  ```
  >>> hex_test = HexBytes("0x")
  >>> hex_test.hex()
  '0x'
  ```

- v7
  ```
  >>> hex_test = HexBytes("0x")
  >>> hex_test.hex()
  ''
  >>> hex_test.to_0x_hex()
  '0x'
  ```

## 2. (get_logs) fromBlock -> from_block, toBlock -> to_block
The parameter names of `get_logs` is changed.
- `fromBlock` -> `from_block`
- `toBlock` -> `to_block`.

Doc: https://web3py.readthedocs.io/en/v7.0.0-beta.6/migration.html#remaining-camelcase-snake-case-updates

## 3. geth_poa_middleware, async_geth_poa_middleware -> ExtraDataToPOAMiddleware
Doc: https://web3py.readthedocs.io/en/v7.0.0-beta.6/migration.html#middleware-renaming-and-removals

## 4. The way to implement CustomMiddleware has changed
[Implementation changes](https://github.com/BoostryJP/ibet-Wallet-API/pull/1516/files#diff-c108a1c3e1e5e6f823d08a8a4c4cdb310cc6eb35ebacb924b3f3d8a675ee3006R45-R63)

Doc: https://web3py.readthedocs.io/en/v7.0.0-beta.6/middleware.html#creating-custom-middleware

##  5. Performance improvement
In v6, there is an issue where unnecessary memory space is allocated when importing ABIEventFunctionNotFound. Upgrading to v7 will resolve this issue.
- https://github.com/ethereum/web3.py/commit/e24363e8eaafcf82931c4cbbc6af8c93a6519fe1

v6: indexer_Transfer.py
<img width="1669" alt="image" src="https://github.com/BoostryJP/ibet-Wallet-API/assets/963333/706452ff-957a-4522-8ab9-7d54a26ca51b">

v7: indexer_Transfer.py
<img width="1673" alt="image" src="https://github.com/BoostryJP/ibet-Wallet-API/assets/963333/eb226a4c-45e7-4bff-9e1d-87b8c78b2dee">

## 6. Misc
- Since v7 is currently in beta, I made sure to pin the installation version via poetry.
