### PR TITLE
Fix error handling of send_raw_transaction

### DIFF
--- a/app/api/routers/eth.py
+++ b/app/api/routers/eth.py
@@ -253,6 +253,10 @@ async def send_raw_transaction(
                 result.append({"id": i + 1, "status": 0, "transaction_hash": None})
                 LOG.error(f"Send transaction failed: {err}")
             continue
+        except Exception as err:
+            result.append({"id": i + 1, "status": 0, "transaction_hash": None})
+            LOG.error(f"Send transaction failed: {err}")
+            continue
 
         # Handling a transaction execution result
         try:
@@ -454,6 +458,10 @@ async def send_raw_transaction_no_wait(
             else:
                 result.append({"id": i + 1, "status": 0, "transaction_hash": None})
                 LOG.error(f"Send transaction failed: {err}")
+            continue
+        except Exception as err:
+            result.append({"id": i + 1, "status": 0, "transaction_hash": None})
+            LOG.error(f"Send transaction failed: {err}")
             continue
 
         result.append(

--- a/app/api/routers/eth.py
+++ b/app/api/routers/eth.py
@@ -27,7 +27,7 @@ from fastapi import APIRouter, Depends
 from hexbytes import HexBytes
 from rlp import decode
 from sqlalchemy import select
-from web3.exceptions import ContractLogicError, TimeExhausted
+from web3.exceptions import ContractLogicError, TimeExhausted, Web3RPCError
 from web3.types import TxReceipt
 
 from app import config, log
@@ -241,18 +241,14 @@ async def send_raw_transaction(
         # Send raw transaction
         try:
             tx_hash = await async_web3.eth.send_raw_transaction(raw_tx_hex)
-        except Exception as err:
-            if len(err.args) > 0:
-                error_msg = err.args[0].get("message")
-                if "nonce too low" in error_msg:
-                    result.append({"id": i + 1, "status": 3, "transaction_hash": None})
-                    LOG.warning(f"Sent transaction nonce is too low: {err}")
-                elif "already known" in error_msg:
-                    result.append({"id": i + 1, "status": 4, "transaction_hash": None})
-                    LOG.warning(f"Sent transaction has been already known: {err}")
-                else:
-                    result.append({"id": i + 1, "status": 0, "transaction_hash": None})
-                    LOG.error(f"Send transaction failed: {err}")
+        except Web3RPCError as err:
+            error_msg = err.message
+            if "nonce too low" in error_msg:
+                result.append({"id": i + 1, "status": 3, "transaction_hash": None})
+                LOG.warning(f"Sent transaction nonce is too low: {err}")
+            elif "already known" in error_msg:
+                result.append({"id": i + 1, "status": 4, "transaction_hash": None})
+                LOG.warning(f"Sent transaction has been already known: {err}")
             else:
                 result.append({"id": i + 1, "status": 0, "transaction_hash": None})
                 LOG.error(f"Send transaction failed: {err}")
@@ -447,18 +443,14 @@ async def send_raw_transaction_no_wait(
         # Send raw transaction
         try:
             transaction_hash = await async_web3.eth.send_raw_transaction(raw_tx_hex)
-        except Exception as err:
-            if len(err.args) > 0:
-                error_msg = err.args[0].get("message")
-                if "nonce too low" in error_msg:
-                    result.append({"id": i + 1, "status": 3, "transaction_hash": None})
-                    LOG.warning(f"Sent transaction nonce is too low: {err}")
-                elif "already known" in error_msg:
-                    result.append({"id": i + 1, "status": 4, "transaction_hash": None})
-                    LOG.warning(f"Sent transaction has been already known: {err}")
-                else:
-                    result.append({"id": i + 1, "status": 0, "transaction_hash": None})
-                    LOG.error(f"Send transaction failed: {err}")
+        except Web3RPCError as err:
+            error_msg = err.message
+            if "nonce too low" in error_msg:
+                result.append({"id": i + 1, "status": 3, "transaction_hash": None})
+                LOG.warning(f"Sent transaction nonce is too low: {err}")
+            elif "already known" in error_msg:
+                result.append({"id": i + 1, "status": 4, "transaction_hash": None})
+                LOG.warning(f"Sent transaction has been already known: {err}")
             else:
                 result.append({"id": i + 1, "status": 0, "transaction_hash": None})
                 LOG.error(f"Send transaction failed: {err}")

--- a/tests/app/eth_SendRawTransactionNowait_test.py
+++ b/tests/app/eth_SendRawTransactionNowait_test.py
@@ -25,6 +25,7 @@ from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 from web3 import Web3
 from web3.datastructures import AttributeDict
+from web3.exceptions import Web3RPCError
 from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
@@ -383,8 +384,8 @@ class TestEthSendRawTransactionNoWait:
             with mock.patch(
                 "web3.eth.async_eth.AsyncEth.send_raw_transaction",
                 MagicMock(
-                    side_effect=ValueError(
-                        {"code": -320000, "message": "nonce too low"}
+                    side_effect=Web3RPCError(
+                        message="{'code': -32000, 'message': 'nonce too low'}",
                     )
                 ),
             ):
@@ -478,8 +479,8 @@ class TestEthSendRawTransactionNoWait:
             with mock.patch(
                 "web3.eth.async_eth.AsyncEth.send_raw_transaction",
                 MagicMock(
-                    side_effect=ValueError(
-                        {"code": -320000, "message": "already known"}
+                    side_effect=Web3RPCError(
+                        message="{'code': -32000, 'message': 'already known'}",
                     )
                 ),
             ):

--- a/tests/app/eth_SendRawTransaction_test.py
+++ b/tests/app/eth_SendRawTransaction_test.py
@@ -28,8 +28,9 @@ from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 from web3 import Web3
 from web3.datastructures import AttributeDict
-from web3.exceptions import TimeExhausted
+from web3.exceptions import TimeExhausted, Web3RPCError
 from web3.middleware import ExtraDataToPOAMiddleware
+from web3.types import RPCError, RPCResponse
 
 from app import config, log
 from app.api.routers import eth
@@ -494,8 +495,8 @@ class TestEthSendRawTransaction:
             with mock.patch(
                 "web3.eth.async_eth.AsyncEth.send_raw_transaction",
                 MagicMock(
-                    side_effect=ValueError(
-                        {"code": -320000, "message": "nonce too low"}
+                    side_effect=Web3RPCError(
+                        message="{'code': -32000, 'message': 'nonce too low'}",
                     )
                 ),
             ):
@@ -589,8 +590,8 @@ class TestEthSendRawTransaction:
             with mock.patch(
                 "web3.eth.async_eth.AsyncEth.send_raw_transaction",
                 MagicMock(
-                    side_effect=ValueError(
-                        {"code": -320000, "message": "already known"}
+                    side_effect=Web3RPCError(
+                        message="{'code': -32000, 'message': 'already known'}",
                     )
                 ),
             ):


### PR DESCRIPTION
Close: #1519

- Verified that the error handling of `Web3RPCError` works in local network.

```bash
[2024-06-05 15:10:15 +0000] [204] [WARNING] [APP-LOG] Sent transaction has been already known: {'code': -32000, 'message': 'already known'} [in /app/ibet-Wallet-API/app/api/routers/eth.py:453]
```