### PR TITLE
Change the default value of TXPOOL_THRESHOLD_FOR_TX_PAUSE

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -177,7 +177,7 @@ TRANSACTION_WAIT_POLL_LATENCY = (
 TXPOOL_THRESHOLD_FOR_TX_PAUSE = (
     int(os.environ.get("TXPOOL_THRESHOLD_FOR_TX_PAUSE"))
     if os.environ.get("TXPOOL_THRESHOLD_FOR_TX_PAUSE")
-    else 20
+    else 200
 )
 
 # Fail over settings


### PR DESCRIPTION
For normal network usage, the current settings are too restrictive, so I think it would be better to increase the default values.
- `TXPOOL_THRESHOLD_FOR_TX_PAUSE`: 20 -> 200