### PR TITLE
[Feature]Add date range filtering to Transfer History API #1544

### DIFF
--- a/app/api/routers/token.py
+++ b/app/api/routers/token.py
@@ -800,13 +800,6 @@ async def list_all_transfer_histories(
         )
         .order_by(IDXTransfer.id)
     )
-    if request_query.created_from:
-        created_from = datetime.fromisoformat(request_query.created_from)
-        created_from_utc = created_from.astimezone(timezone.utc)
-        stmt = stmt.where(IDXTransfer.created >= created_from_utc)
-
-    if request_query.created_to is not None:
-        stmt = stmt.where(IDXTransfer.created <= request_query.created_to)
 
     if request_query.account_tag is not None:
         stmt = stmt.where(
@@ -838,6 +831,14 @@ async def list_all_transfer_histories(
     if request_query.to_address is not None:
         stmt = stmt.where(
             IDXTransfer.to_address.like("%" + request_query.to_address + "%")
+        )
+
+    if request_query.created_from:
+        created_from = datetime.fromisoformat(request_query.created_from)
+    stmt = stmt.where(IDXTransfer.created >= created_from)
+    if request_query.created_to is not None:
+        stmt = stmt.where(
+            IDXTransfer.created <= request_query.created_to.astimezone(timezone.utc)
         )
     if request_query.value is not None and request_query.value_operator is not None:
         match request_query.value_operator:
@@ -925,10 +926,6 @@ async def search_transfer_histories(
     if data.to_address is not None:
         stmt = stmt.where(IDXTransfer.to_address.like("%" + data.to_address + "%"))
     if data.created_from is not None:
-        created_fromSee = data.created_from
-        print(created_fromSee)
-        convertedcreated_from = data.created_from.astimezone((timezone.utc))
-        print(convertedcreated_from)
         stmt = stmt.where(
             IDXTransfer.created >= data.created_from.astimezone(timezone.utc)
         )

--- a/app/api/routers/token.py
+++ b/app/api/routers/token.py
@@ -800,6 +800,14 @@ async def list_all_transfer_histories(
         )
         .order_by(IDXTransfer.id)
     )
+
+    # Filtering by created_from and created_to
+    if request_query.created_from is not None:
+        stmt = stmt.where(IDXTransfer.created >= request_query.created_from)
+
+    if request_query.created_to is not None:
+        stmt = stmt.where(IDXTransfer.created <= request_query.created_to)
+
     if request_query.account_tag is not None:
         stmt = stmt.where(
             or_(

--- a/app/api/routers/token.py
+++ b/app/api/routers/token.py
@@ -832,14 +832,12 @@ async def list_all_transfer_histories(
         stmt = stmt.where(
             IDXTransfer.to_address.like("%" + request_query.to_address + "%")
         )
-
-    if request_query.created_from:
+    if request_query.created_from is not None:
         created_from = datetime.fromisoformat(request_query.created_from)
-    stmt = stmt.where(IDXTransfer.created >= created_from)
+        stmt = stmt.where(IDXTransfer.created >= created_from)
     if request_query.created_to is not None:
-        stmt = stmt.where(
-            IDXTransfer.created <= request_query.created_to.astimezone(timezone.utc)
-        )
+        created_to = datetime.fromisoformat(request_query.created_to)
+        stmt = stmt.where(IDXTransfer.created <= created_to)
     if request_query.value is not None and request_query.value_operator is not None:
         match request_query.value_operator:
             case ValueOperator.EQUAL:

--- a/app/api/routers/token.py
+++ b/app/api/routers/token.py
@@ -17,7 +17,7 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
-from datetime import datetime, timezone
+from datetime import timezone
 from typing import Annotated, Optional, Sequence
 
 from fastapi import APIRouter, Depends, Path
@@ -833,11 +833,9 @@ async def list_all_transfer_histories(
             IDXTransfer.to_address.like("%" + request_query.to_address + "%")
         )
     if request_query.created_from is not None:
-        created_from = datetime.fromisoformat(request_query.created_from)
-        stmt = stmt.where(IDXTransfer.created >= created_from)
+        stmt = stmt.where(IDXTransfer.created >= request_query.created_from)
     if request_query.created_to is not None:
-        created_to = datetime.fromisoformat(request_query.created_to)
-        stmt = stmt.where(IDXTransfer.created <= created_to)
+        stmt = stmt.where(IDXTransfer.created <= request_query.created_to)
     if request_query.value is not None and request_query.value_operator is not None:
         match request_query.value_operator:
             case ValueOperator.EQUAL:

--- a/app/api/routers/token.py
+++ b/app/api/routers/token.py
@@ -17,7 +17,7 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
-from datetime import timezone
+from datetime import datetime, timezone
 from typing import Annotated, Optional, Sequence
 
 from fastapi import APIRouter, Depends, Path
@@ -800,10 +800,10 @@ async def list_all_transfer_histories(
         )
         .order_by(IDXTransfer.id)
     )
-
-    # Filtering by created_from and created_to
-    if request_query.created_from is not None:
-        stmt = stmt.where(IDXTransfer.created >= request_query.created_from)
+    if request_query.created_from:
+        created_from = datetime.fromisoformat(request_query.created_from)
+        created_from_utc = created_from.astimezone(timezone.utc)
+        stmt = stmt.where(IDXTransfer.created >= created_from_utc)
 
     if request_query.created_to is not None:
         stmt = stmt.where(IDXTransfer.created <= request_query.created_to)
@@ -925,6 +925,10 @@ async def search_transfer_histories(
     if data.to_address is not None:
         stmt = stmt.where(IDXTransfer.to_address.like("%" + data.to_address + "%"))
     if data.created_from is not None:
+        created_fromSee = data.created_from
+        print(created_fromSee)
+        convertedcreated_from = data.created_from.astimezone((timezone.utc))
+        print(convertedcreated_from)
         stmt = stmt.where(
             IDXTransfer.created >= data.created_from.astimezone(timezone.utc)
         )

--- a/app/model/schema/base/__init__.py
+++ b/app/model/schema/base/__init__.py
@@ -26,5 +26,6 @@ from .base import (
     SuccessResponse,
     TokenType,
     ValidatedEthereumAddress,
+    ValidatedNaiveUTCDatetime,
     ValueOperator,
 )

--- a/app/model/schema/base/base.py
+++ b/app/model/schema/base/base.py
@@ -54,10 +54,10 @@ ValidatedEthereumAddress = Annotated[str, WrapValidator(ethereum_address_validat
 
 def datetime_string_validator(
     value: Any, handler: ValidatorFunctionWrapHandler, *args, **kwargs
-):
+) -> str | None:
     """Validate string datetime format
 
-    - %Y/%m/%d %H:%M:%S
+    - %Y-%m-%dT%H:%M:%S.%f
     """
     if value is not None:
         if not isinstance(value, str):
@@ -72,17 +72,14 @@ def datetime_string_validator(
             # Convert JST to UTC
             dt_utc = dt.astimezone(timezone.utc)
 
-            # Strip timezone info and return as string
-            return dt_utc.replace(tzinfo=None).strftime("%Y-%m-%d %H:%M:%S")
+            # Strip timezone info and return as iso format string
+            return dt_utc.replace(tzinfo=None).strftime("%Y-%m-%dT%H:%M:%S.%f")
         except ValueError as e:
             raise ValueError(f"Invalid datetime format: {str(e)}")
     return value
 
 
 ValidatedDatetimeStr = Annotated[str, WrapValidator(datetime_string_validator)]
-
-
-print(ValidatedDatetimeStr)
 
 
 ############################

--- a/app/model/schema/base/base.py
+++ b/app/model/schema/base/base.py
@@ -73,7 +73,7 @@ def datetime_string_validator(
             dt_utc = dt.astimezone(timezone.utc)
 
             # Strip timezone info and return as iso format string
-            return dt_utc.replace(tzinfo=None).strftime("%Y-%m-%dT%H:%M:%S.%f")
+            return dt_utc.replace(tzinfo=None).strftime("%Y-%m-%d %H:%M:%S:%f")
         except ValueError as e:
             raise ValueError(f"Invalid datetime format: {str(e)}")
     return value

--- a/app/model/schema/base/base.py
+++ b/app/model/schema/base/base.py
@@ -55,22 +55,17 @@ ValidatedEthereumAddress = Annotated[str, WrapValidator(ethereum_address_validat
 NaiveUTCDatetime = Annotated[datetime, Timezone(None)]
 
 
-def naive_utc_datetime_validator(
-    value: Any, handler: ValidatorFunctionWrapHandler, *args, **kwargs
-) -> NaiveUTCDatetime | None:
-    """Validate string datetime format
-
-    - %Y-%m-%dT%H:%M:%S.%f
-    """
+def naive_utc_datetime_validator(value: Any) -> NaiveUTCDatetime | None:
+    """Validate datetime"""
     if value is not None:
         try:
-            # Ensure the datetime has timezone info
             if value.tzinfo is None:
+                # Return the datetime as is if it has no timezone info
                 return value
             # Convert timezone to UTC
             dt_utc = value.astimezone(timezone.utc)
 
-            # Strip timezone info and return as iso format
+            # Return naive UTC datetime
             return dt_utc.replace(tzinfo=None)
         except ValueError as e:
             raise ValueError(f"Invalid datetime format: {str(e)}")

--- a/app/model/schema/token.py
+++ b/app/model/schema/token.py
@@ -199,6 +199,13 @@ class ListAllTransferHistoryQuery:
         ),
     ] = ValueOperator.EQUAL
 
+    created_from: Annotated[
+        Optional[datetime], Query(description="created from datetime")
+    ] = None
+    created_to: Annotated[
+        Optional[datetime], Query(description="created to datetime")
+    ] = None
+
 
 class SearchTransferHistorySortItem(StrEnum):
     from_account_address_list = "from_account_address_list"

--- a/app/model/schema/token.py
+++ b/app/model/schema/token.py
@@ -198,13 +198,8 @@ class ListAllTransferHistoryQuery:
             description="value filter condition(0: equal, 1: greater than, 2: less than)"
         ),
     ] = ValueOperator.EQUAL
-
-    created_from: Annotated[
-        Optional[datetime], Query(description="created from datetime")
-    ] = None
-    created_to: Annotated[
-        Optional[datetime], Query(description="created to datetime")
-    ] = None
+    created_from: Optional[str] = Query(None, description="created from datetime")
+    created_to: Optional[str] = Query(None, description="created to datetime")
 
 
 class SearchTransferHistorySortItem(StrEnum):

--- a/app/model/schema/token.py
+++ b/app/model/schema/token.py
@@ -32,6 +32,7 @@ from app.model.schema.base import (
     ValidatedEthereumAddress,
     ValueOperator,
 )
+from app.model.schema.base.base import ValidatedDatetimeStr
 
 
 ############################
@@ -198,8 +199,12 @@ class ListAllTransferHistoryQuery:
             description="value filter condition(0: equal, 1: greater than, 2: less than)"
         ),
     ] = ValueOperator.EQUAL
-    created_from: Optional[str] = Query(None, description="created from datetime")
-    created_to: Optional[str] = Query(None, description="created to datetime")
+    created_from: Annotated[
+        Optional[ValidatedDatetimeStr], Query(description="created datetime (From)")
+    ] = None
+    created_to: Annotated[
+        Optional[ValidatedDatetimeStr], Query(description="created datetime (To)")
+    ] = None
 
 
 class SearchTransferHistorySortItem(StrEnum):

--- a/app/model/schema/token.py
+++ b/app/model/schema/token.py
@@ -30,9 +30,9 @@ from app.model.schema.base import (
     SortOrder,
     TokenType,
     ValidatedEthereumAddress,
+    ValidatedNaiveUTCDatetime,
     ValueOperator,
 )
-from app.model.schema.base.base import ValidatedDatetimeStr
 
 
 ############################
@@ -200,10 +200,11 @@ class ListAllTransferHistoryQuery:
         ),
     ] = ValueOperator.EQUAL
     created_from: Annotated[
-        Optional[ValidatedDatetimeStr], Query(description="created datetime (From)")
+        Optional[ValidatedNaiveUTCDatetime],
+        Query(description="created datetime (From)"),
     ] = None
     created_to: Annotated[
-        Optional[ValidatedDatetimeStr], Query(description="created datetime (To)")
+        Optional[ValidatedNaiveUTCDatetime], Query(description="created datetime (To)")
     ] = None
 
 

--- a/tests/app/token_TransferHistory_test.py
+++ b/tests/app/token_TransferHistory_test.py
@@ -944,6 +944,157 @@ class TestTokenTransferHistory:
         assert data[0]["source_event"] == IDXTransferSourceEventType.TRANSFER.value
         assert data[0]["data"] is None
 
+        # Normal_4_7
+        # Transferイベントあり : 2件
+        # Filter(created_from)
+
+    @pytest.mark.freeze_time(datetime(2023, 11, 6, 14, 0, 0, tzinfo=timezone.utc))
+    @pytest.mark.parametrize(
+        "created_from", ["2023-11-06T23:00:00+09:00", "2023-11-06T14:00:00+00:00"]
+    )
+    def test_normal_4_7(self, created_from: str, client: TestClient, session: Session):
+        listing = {
+            "token_address": self.token_address,
+            "is_public": True,
+        }
+        self.insert_listing(session, listing=listing)
+
+        # １件目
+        transfer_event_1 = {
+            "transaction_hash": self.transaction_hash,
+            "token_address": self.token_address,
+            "from_address": self.from_address,
+            "to_address": self.to_address,
+            "value": 10,
+        }
+        created_time1 = datetime.now(UTC).replace(tzinfo=None)
+        self.insert_transfer_event(
+            session=session,
+            transfer_event=transfer_event_1,
+            transfer_source_event=IDXTransferSourceEventType.TRANSFER,
+            transfer_event_data=None,
+            created=created_time1,
+        )
+        print(f"Event 1 created at: {created_time1}")
+        print(created_time1)
+        # 2件目
+        transfer_event_2 = {
+            "transaction_hash": self.transaction_hash,
+            "token_address": self.token_address,
+            "from_address": self.from_address,
+            "to_address": self.to_address,
+            "value": 20,
+        }
+        created_time2 = datetime.now(UTC).replace(tzinfo=None) - timedelta(seconds=1)
+        self.insert_transfer_event(
+            session=session,
+            transfer_event=transfer_event_2,
+            transfer_source_event=IDXTransferSourceEventType.UNLOCK,
+            transfer_event_data={"message": "unlock"},
+            created=created_time2,
+        )
+
+        print(f"Event 1 created at: {created_time2}")
+        print(created_time2)
+        session.commit()
+
+        apiurl = self.apiurl_base.format(contract_address=self.token_address)
+        resp = client.get(apiurl, params={"created_from": created_from})
+
+        assert resp.status_code == 200
+        assert resp.json()["meta"] == {"code": 200, "message": "OK"}
+        print(resp.json()["data"]["result_set"])
+        assert resp.json()["data"]["result_set"] == {
+            "count": 1,
+            "offset": None,
+            "limit": None,
+            "total": 2,
+        }
+        data = resp.json()["data"]["transfer_history"]
+        assert len(data) == 1
+        assert data[0]["transaction_hash"] == transfer_event_1["transaction_hash"]
+        assert data[0]["token_address"] == transfer_event_1["token_address"]
+        assert data[0]["from_address"] == transfer_event_1["from_address"]
+        assert data[0]["to_address"] == transfer_event_1["to_address"]
+        assert data[0]["value"] == transfer_event_1["value"]
+        assert data[0]["source_event"] == IDXTransferSourceEventType.TRANSFER.value
+        assert data[0]["data"] is None
+
+    # Normal_4_8
+    # Transferイベントあり : 2件
+    # Filter(created_from)
+    @pytest.mark.freeze_time(datetime(2023, 11, 6, 14, 0, 0, tzinfo=timezone.utc))
+    @pytest.mark.parametrize(
+        "created_to", ["2023-11-06T23:00:00+09:00", "2023-11-06T14:00:00+00:00"]
+    )
+    def test_normal_4_8(self, created_to: str, client: TestClient, session: Session):
+        listing = {
+            "token_address": self.token_address,
+            "is_public": True,
+        }
+        self.insert_listing(session, listing=listing)
+
+        # １件目
+        transfer_event_1 = {
+            "transaction_hash": self.transaction_hash,
+            "token_address": self.token_address,
+            "from_address": self.from_address,
+            "to_address": self.to_address,
+            "value": 10,
+        }
+        created_time1 = datetime.now(UTC).replace(tzinfo=None)
+        self.insert_transfer_event(
+            session=session,
+            transfer_event=transfer_event_1,
+            transfer_source_event=IDXTransferSourceEventType.TRANSFER,
+            transfer_event_data=None,
+            created=created_time1,
+        )
+        print(f"Event 1 created at: {created_time1}")
+        print(created_time1)
+        # 2件目
+        transfer_event_2 = {
+            "transaction_hash": self.transaction_hash,
+            "token_address": self.token_address,
+            "from_address": self.from_address,
+            "to_address": self.to_address,
+            "value": 20,
+        }
+        created_time2 = datetime.now(UTC).replace(tzinfo=None) - timedelta(seconds=1)
+        self.insert_transfer_event(
+            session=session,
+            transfer_event=transfer_event_2,
+            transfer_source_event=IDXTransferSourceEventType.UNLOCK,
+            transfer_event_data={"message": "unlock"},
+            created=created_time2,
+        )
+
+        print(f"Event 1 created at: {created_time2}")
+        print(created_time2)
+        session.commit()
+
+        apiurl = self.apiurl_base.format(contract_address=self.token_address)
+        resp = client.get(apiurl, params={"created_from": created_to})
+
+        assert resp.status_code == 200
+        assert resp.json()["meta"] == {"code": 200, "message": "OK"}
+        print(resp.json()["data"]["result_set"])
+        assert resp.json()["data"]["result_set"] == {
+            "count": 1,
+            "offset": None,
+            "limit": None,
+            "total": 2,
+        }
+        data = resp.json()["data"]["transfer_history"]
+        assert len(data) == 1
+        assert data[0]["transaction_hash"] == transfer_event_1["transaction_hash"]
+        assert data[0]["token_address"] == transfer_event_1["token_address"]
+        assert data[0]["from_address"] == transfer_event_1["from_address"]
+        assert data[0]["to_address"] == transfer_event_1["to_address"]
+        assert data[0]["value"] == transfer_event_1["value"]
+        assert data[0]["source_event"] == IDXTransferSourceEventType.TRANSFER.value
+        assert data[0]["data"] is None
+
     # Normal_5_1
     # offset=1, limit=設定なし
     # Transferイベントあり：2件
@@ -1139,81 +1290,6 @@ class TestTokenTransferHistory:
         data = resp.json()["data"]["transfer_history"]
         assert len(data) == 1
 
-        assert data[0]["transaction_hash"] == transfer_event_1["transaction_hash"]
-        assert data[0]["token_address"] == transfer_event_1["token_address"]
-        assert data[0]["from_address"] == transfer_event_1["from_address"]
-        assert data[0]["to_address"] == transfer_event_1["to_address"]
-        assert data[0]["value"] == transfer_event_1["value"]
-        assert data[0]["source_event"] == IDXTransferSourceEventType.TRANSFER.value
-        assert data[0]["data"] is None
-
-    # Normal_6_1
-    # Transferイベントあり : 2件
-    # Filter(created_from)
-    @pytest.mark.freeze_time(datetime(2023, 11, 6, 14, 0, 0, tzinfo=timezone.utc))
-    @pytest.mark.parametrize(
-        "created_from", ["2023-11-06T23:00:00+09:00", "2023-11-06T14:00:00+00:00"]
-    )
-    def test_normal_6_1(self, created_from: str, client: TestClient, session: Session):
-        listing = {
-            "token_address": self.token_address,
-            "is_public": True,
-        }
-        self.insert_listing(session, listing=listing)
-
-        # １件目
-        transfer_event_1 = {
-            "transaction_hash": self.transaction_hash,
-            "token_address": self.token_address,
-            "from_address": self.from_address,
-            "to_address": self.to_address,
-            "value": 10,
-        }
-        created_time1 = datetime.now(UTC).replace(tzinfo=None)
-        self.insert_transfer_event(
-            session=session,
-            transfer_event=transfer_event_1,
-            transfer_source_event=IDXTransferSourceEventType.TRANSFER,
-            transfer_event_data=None,
-            created=created_time1,
-        )
-        print(f"Event 1 created at: {created_time1}")
-        print(created_time1)
-        # 2件目
-        transfer_event_2 = {
-            "transaction_hash": self.transaction_hash,
-            "token_address": self.token_address,
-            "from_address": self.from_address,
-            "to_address": self.to_address,
-            "value": 20,
-        }
-        created_time2 = datetime.now(UTC).replace(tzinfo=None) - timedelta(seconds=1)
-        self.insert_transfer_event(
-            session=session,
-            transfer_event=transfer_event_2,
-            transfer_source_event=IDXTransferSourceEventType.UNLOCK,
-            transfer_event_data={"message": "unlock"},
-            created=created_time2,
-        )
-
-        print(f"Event 1 created at: {created_time2}")
-        print(created_time2)
-        session.commit()
-
-        apiurl = self.apiurl_base.format(contract_address=self.token_address)
-        resp = client.get(apiurl, params={"created_from": created_from})
-
-        assert resp.status_code == 200
-        assert resp.json()["meta"] == {"code": 200, "message": "OK"}
-        print(resp.json()["data"]["result_set"])
-        assert resp.json()["data"]["result_set"] == {
-            "count": 1,
-            "offset": None,
-            "limit": None,
-            "total": 2,
-        }
-        data = resp.json()["data"]["transfer_history"]
-        assert len(data) == 1
         assert data[0]["transaction_hash"] == transfer_event_1["transaction_hash"]
         assert data[0]["token_address"] == transfer_event_1["token_address"]
         assert data[0]["from_address"] == transfer_event_1["from_address"]

--- a/tests/app/token_TransferHistory_test.py
+++ b/tests/app/token_TransferHistory_test.py
@@ -1141,6 +1141,16 @@ class TestTokenTransferHistory:
         assert data[0]["source_event"] == IDXTransferSourceEventType.TRANSFER.value
         assert data[0]["data"] is None
 
+    # Normal_6_1
+    # Transferイベントあり : 2件
+    # Filter(created_from)
+    def test_normal_6_1(self, client: TestClient, session: Session):
+        listing = {
+            "token_adress": self.token_address,
+            "is_public": True,
+        }
+        self.insert_listing(session, listing=listing)
+
     ####################################################################
     # Error
     ####################################################################

--- a/tests/app/token_TransferHistory_test.py
+++ b/tests/app/token_TransferHistory_test.py
@@ -17,6 +17,9 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
+from datetime import UTC, datetime, timedelta, timezone
+
+import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
@@ -51,6 +54,7 @@ class TestTokenTransferHistory:
         transfer_event: dict,
         transfer_source_event: IDXTransferSourceEventType = IDXTransferSourceEventType.TRANSFER,
         transfer_event_data: dict | None = None,
+        created: datetime | None = None,
     ):
         _transfer = IDXTransfer()
         _transfer.transaction_hash = transfer_event["transaction_hash"]
@@ -1144,12 +1148,77 @@ class TestTokenTransferHistory:
     # Normal_6_1
     # Transferイベントあり : 2件
     # Filter(created_from)
-    def test_normal_6_1(self, client: TestClient, session: Session):
+    @pytest.mark.freeze_time(datetime(2023, 11, 6, 14, 0, 0, tzinfo=timezone.utc))
+    @pytest.mark.parametrize(
+        "created_from", ["2023-11-06T23:00:00+09:00", "2023-11-06T14:00:00+00:00"]
+    )
+    def test_normal_6_1(self, created_from: str, client: TestClient, session: Session):
         listing = {
-            "token_adress": self.token_address,
+            "token_address": self.token_address,
             "is_public": True,
         }
         self.insert_listing(session, listing=listing)
+
+        # １件目
+        transfer_event_1 = {
+            "transaction_hash": self.transaction_hash,
+            "token_address": self.token_address,
+            "from_address": self.from_address,
+            "to_address": self.to_address,
+            "value": 10,
+        }
+        created_time1 = datetime.now(UTC).replace(tzinfo=None)
+        self.insert_transfer_event(
+            session=session,
+            transfer_event=transfer_event_1,
+            transfer_source_event=IDXTransferSourceEventType.TRANSFER,
+            transfer_event_data=None,
+            created=created_time1,
+        )
+        print(f"Event 1 created at: {created_time1}")
+        print(created_time1)
+        # 2件目
+        transfer_event_2 = {
+            "transaction_hash": self.transaction_hash,
+            "token_address": self.token_address,
+            "from_address": self.from_address,
+            "to_address": self.to_address,
+            "value": 20,
+        }
+        created_time2 = datetime.now(UTC).replace(tzinfo=None) - timedelta(seconds=1)
+        self.insert_transfer_event(
+            session=session,
+            transfer_event=transfer_event_2,
+            transfer_source_event=IDXTransferSourceEventType.UNLOCK,
+            transfer_event_data={"message": "unlock"},
+            created=created_time2,
+        )
+
+        print(f"Event 1 created at: {created_time2}")
+        print(created_time2)
+        session.commit()
+
+        apiurl = self.apiurl_base.format(contract_address=self.token_address)
+        resp = client.get(apiurl, params={"created_from": created_from})
+
+        assert resp.status_code == 200
+        assert resp.json()["meta"] == {"code": 200, "message": "OK"}
+        print(resp.json()["data"]["result_set"])
+        assert resp.json()["data"]["result_set"] == {
+            "count": 2,
+            "offset": None,
+            "limit": None,
+            "total": 2,
+        }
+        data = resp.json()["data"]["transfer_history"]
+        assert len(data) == 2
+        assert data[0]["transaction_hash"] == transfer_event_1["transaction_hash"]
+        assert data[0]["token_address"] == transfer_event_1["token_address"]
+        assert data[0]["from_address"] == transfer_event_1["from_address"]
+        assert data[0]["to_address"] == transfer_event_1["to_address"]
+        assert data[0]["value"] == transfer_event_1["value"]
+        assert data[0]["source_event"] == IDXTransferSourceEventType.TRANSFER.value
+        assert data[0]["data"] is None
 
     ####################################################################
     # Error

--- a/tests/app/token_TransferHistory_test.py
+++ b/tests/app/token_TransferHistory_test.py
@@ -64,6 +64,8 @@ class TestTokenTransferHistory:
         _transfer.value = transfer_event["value"]
         _transfer.source_event = transfer_source_event.value
         _transfer.data = transfer_event_data
+        if created is not None:
+            _transfer.created = created
         session.add(_transfer)
 
     ####################################################################
@@ -1205,13 +1207,13 @@ class TestTokenTransferHistory:
         assert resp.json()["meta"] == {"code": 200, "message": "OK"}
         print(resp.json()["data"]["result_set"])
         assert resp.json()["data"]["result_set"] == {
-            "count": 2,
+            "count": 1,
             "offset": None,
             "limit": None,
             "total": 2,
         }
         data = resp.json()["data"]["transfer_history"]
-        assert len(data) == 2
+        assert len(data) == 1
         assert data[0]["transaction_hash"] == transfer_event_1["transaction_hash"]
         assert data[0]["token_address"] == transfer_event_1["token_address"]
         assert data[0]["from_address"] == transfer_event_1["from_address"]


### PR DESCRIPTION
### This PR implements date range filtering for the transfer list API by:
- close #1544 
- Adding `created_from` and `created_to` query parameters to `GET: /Token/{token_address}/TransferHistory`
- Implementing a datetime string validator that:
  - Accepts ISO 8601 format with timezone information
  - Converts input to UTC
  - Returns a consistent datetime format
- Updating the query builder to filter transfers based on the validated date range
- Introducing `ValidatedDatetimeStr` type for improved type checking

These changes align the GET endpoint's functionality with the existing `POST: /Token/{token_address}/TransferHistory/Search` endpoint, providing a consistent API experience for date range filtering across both methods.