### PR TITLE
Fix invalid escape sequence by using raw string

### DIFF
--- a/app/model/schema/base/base.py
+++ b/app/model/schema/base/base.py
@@ -25,7 +25,6 @@ from annotated_types import Timezone
 from fastapi import Query
 from pydantic import AfterValidator, BaseModel, Field, WrapValidator, constr
 from pydantic.dataclasses import dataclass
-from pydantic_core.core_schema import ValidatorFunctionWrapHandler
 
 from app.validator import ethereum_address_validator
 

--- a/app/model/schema/position.py
+++ b/app/model/schema/position.py
@@ -156,7 +156,7 @@ class LockEvent(BaseModel):
     category: LockEventCategory = Field(description="history item category")
     transaction_hash: str = Field(description="Transaction hash")
     msg_sender: Optional[ValidatedEthereumAddress] = Field(
-        description="Message sender", nullable=True
+        ..., description="Message sender"
     )
     token_address: ValidatedEthereumAddress = Field(description="Token address")
     lock_address: ValidatedEthereumAddress = Field(description="Lock address")

--- a/docs/ibet_wallet_api.yaml
+++ b/docs/ibet_wallet_api.yaml
@@ -8129,7 +8129,6 @@ components:
             - type: 'null'
           title: Msg Sender
           description: Message sender
-          nullable: true
         token_address:
           type: string
           title: Token Address
@@ -8204,7 +8203,6 @@ components:
             - type: 'null'
           title: Msg Sender
           description: Message sender
-          nullable: true
         token_address:
           type: string
           title: Token Address
@@ -8269,7 +8267,6 @@ components:
             - type: 'null'
           title: Msg Sender
           description: Message sender
-          nullable: true
         token_address:
           type: string
           title: Token Address

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -128,9 +128,11 @@ if "--autogenerate" in argv:
             if "get_db_schema())" not in new_line:
                 # Set schema of migration exec-environment
                 if "schema=" not in new_line:
-                    new_line = re.sub("\)$", ", schema=get_db_schema())", line)
+                    new_line = re.sub(r"\)$", ", schema=get_db_schema())", line)
                 else:  # If local environment has a schema set
-                    new_line = re.sub("schema=(.)*\)$", "schema=get_db_schema())", line)
+                    new_line = re.sub(
+                        r"schema=(.)*\)$", "schema=get_db_schema())", line
+                    )
             new_lines.append(new_line)
         return new_lines
 

--- a/tests/app/token_TransferHistory_test.py
+++ b/tests/app/token_TransferHistory_test.py
@@ -947,7 +947,6 @@ class TestTokenTransferHistory:
     # Normal_4_7
     # Transferイベントあり : 2件
     # Filter(created_from)
-    @pytest.mark.aysincio
     @pytest.mark.parametrize(
         "created_from", ["2023-11-06T23:00:00+09:00", "2023-11-06T14:00:00+00:00"]
     )
@@ -1016,7 +1015,6 @@ class TestTokenTransferHistory:
     # Normal_4_8
     # Transferイベントあり : 2件
     # Filter(created_to)
-    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "created_to", ["2023-11-06T23:00:00+09:00", "2023-11-06T14:00:00+00:00"]
     )


### PR DESCRIPTION
- Resolve warnings in test output by addressing escape sequence issues.
  - [actions log](https://github.com/BoostryJP/ibet-Wallet-API/actions/runs/10553595251/job/29234241892)

```bash
=============================== warnings summary ===============================
../../home/apl/.pyenv/versions/3.12.2/lib/python3.12/site-packages/pydantic/fields.py:804
  /home/apl/.pyenv/versions/3.12.2/lib/python3.12/site-packages/pydantic/fields.py:804: PydanticDeprecatedSince20: Using extra keyword arguments on `Field` is deprecated and will be removed. Use `json_schema_extra` instead. (Extra keys: 'nullable'). Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.7/migration/
    warn(

tests/app/token_TransferHistory_test.py:950
  /app/ibet-Wallet-API/tests/app/token_TransferHistory_test.py:950: PytestUnknownMarkWarning: Unknown pytest.mark.aysincio - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.aysincio

tests/app/token_TransferHistory_test.py::TestTokenTransferHistory::test_normal_4_8[2023-11-06T23:00:00+09:00]
  tests/app/token_TransferHistory_test.py:1019: PytestWarning: The test <Function test_normal_4_8[2023-11-06T23:00:00+09:00]> is marked with '@pytest.mark.asyncio' but it is not an async function. Please remove the asyncio mark. If the test is not marked explicitly, check for global marks applied via 'pytestmark'.
    @pytest.mark.asyncio

tests/app/token_TransferHistory_test.py::TestTokenTransferHistory::test_normal_4_8[2023-11-06T14:00:00+00:00]
  tests/app/token_TransferHistory_test.py:1019: PytestWarning: The test <Function test_normal_4_8[2023-11-06T14:00:00+00:00]> is marked with '@pytest.mark.asyncio' but it is not an async function. Please remove the asyncio mark. If the test is not marked explicitly, check for global marks applied via 'pytestmark'.
    @pytest.mark.asyncio

tests/migrations/downgrade_test.py::TestMigrationsDowngrade::test_downgrade_from_v23_6
  /app/ibet-Wallet-API/migrations/env.py:131: SyntaxWarning: invalid escape sequence '\)'
    new_line = re.sub("\)$", ", schema=get_db_schema())", line)

tests/migrations/downgrade_test.py::TestMigrationsDowngrade::test_downgrade_from_v23_6
  /app/ibet-Wallet-API/migrations/env.py:133: SyntaxWarning: invalid escape sequence '\)'
    new_line = re.sub("schema=(.)*\)$", "schema=get_db_schema())", line)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
------------- generated xml file: /app/ibet-Wallet-API/pytest.xml --------------
```