### PR TITLE
feat: Allow fetching owner(issuer) address from /{token_address}/Status

### DIFF
--- a/app/api/routers/token.py
+++ b/app/api/routers/token.py
@@ -101,8 +101,8 @@ async def get_token_status(
         args=(token_address,),
         default_returns=(config.ZERO_ADDRESS, "", config.ZERO_ADDRESS),
     )
-
     token_template = token[1]
+    owner_address = token[2]
     try:
         # Token-Contractへの接続
         token_contract = AsyncContract.get_contract(token_template, token_address)
@@ -128,6 +128,7 @@ async def get_token_status(
 
     response_json = {
         "token_template": token_template,
+        "owner_address": owner_address,
         "name": name,
         "status": status,
         "transferable": transferable,

--- a/app/model/schema/token.py
+++ b/app/model/schema/token.py
@@ -345,6 +345,7 @@ class TokenTemplateResponse(BaseModel):
 
 class TokenStatusResponse(BaseModel):
     token_template: TokenType = Field(examples=["IbetStraightBond"])
+    owner_address: ValidatedEthereumAddress
     name: str
     status: bool
     transferable: bool

--- a/docs/ibet_wallet_api.yaml
+++ b/docs/ibet_wallet_api.yaml
@@ -10724,6 +10724,9 @@ components:
             - $ref: '#/components/schemas/TokenType'
           examples:
             - IbetStraightBond
+        owner_address:
+          type: string
+          title: Owner Address
         name:
           type: string
           title: Name
@@ -10736,6 +10739,7 @@ components:
       type: object
       required:
         - token_template
+        - owner_address
         - name
         - status
         - transferable

--- a/tests/app/token_TokenStatus_test.py
+++ b/tests/app/token_TokenStatus_test.py
@@ -202,6 +202,7 @@ class TestTokenTokenStatus:
         assumed_body = {
             "name": "テスト債券",
             "token_template": "IbetStraightBond",
+            "owner_address": issuer["account_address"],
             "status": True,
             "transferable": True,
         }
@@ -246,6 +247,7 @@ class TestTokenTokenStatus:
         assumed_body = {
             "name": "テスト債券",
             "token_template": "IbetStraightBond",
+            "owner_address": issuer["account_address"],
             "status": False,
             "transferable": True,
         }
@@ -290,6 +292,7 @@ class TestTokenTokenStatus:
         assumed_body = {
             "name": "テスト債券",
             "token_template": "IbetStraightBond",
+            "owner_address": issuer["account_address"],
             "status": True,
             "transferable": False,
         }
@@ -331,6 +334,7 @@ class TestTokenTokenStatus:
         assumed_body = {
             "name": "テスト株式",
             "token_template": "IbetShare",
+            "owner_address": issuer["account_address"],
             "status": True,
             "transferable": True,
         }
@@ -375,6 +379,7 @@ class TestTokenTokenStatus:
         assumed_body = {
             "name": "テスト株式",
             "token_template": "IbetShare",
+            "owner_address": issuer["account_address"],
             "status": False,
             "transferable": True,
         }
@@ -419,6 +424,7 @@ class TestTokenTokenStatus:
         assumed_body = {
             "name": "テスト株式",
             "token_template": "IbetShare",
+            "owner_address": issuer["account_address"],
             "status": True,
             "transferable": False,
         }
@@ -457,6 +463,7 @@ class TestTokenTokenStatus:
         assumed_body = {
             "name": "テスト会員権",
             "token_template": "IbetMembership",
+            "owner_address": issuer["account_address"],
             "status": True,
             "transferable": True,
         }
@@ -498,6 +505,7 @@ class TestTokenTokenStatus:
         assumed_body = {
             "name": "テスト会員権",
             "token_template": "IbetMembership",
+            "owner_address": issuer["account_address"],
             "status": False,
             "transferable": True,
         }
@@ -539,6 +547,7 @@ class TestTokenTokenStatus:
         assumed_body = {
             "name": "テスト会員権",
             "token_template": "IbetMembership",
+            "owner_address": issuer["account_address"],
             "status": True,
             "transferable": False,
         }
@@ -577,6 +586,7 @@ class TestTokenTokenStatus:
         assumed_body = {
             "name": "テストクーポン",
             "token_template": "IbetCoupon",
+            "owner_address": issuer["account_address"],
             "status": True,
             "transferable": True,
         }
@@ -618,6 +628,7 @@ class TestTokenTokenStatus:
         assumed_body = {
             "name": "テストクーポン",
             "token_template": "IbetCoupon",
+            "owner_address": issuer["account_address"],
             "status": False,
             "transferable": True,
         }
@@ -659,6 +670,7 @@ class TestTokenTokenStatus:
         assumed_body = {
             "name": "テストクーポン",
             "token_template": "IbetCoupon",
+            "owner_address": issuer["account_address"],
             "status": True,
             "transferable": False,
         }


### PR DESCRIPTION
Close #1565 

- add `owner_address`  to `/{token_address}/Status` response
- `owner_address` is retrieved from `TokenList.getTokenByAddress`