### PR TITLE
Add "NOTICE" logging level

### DIFF
--- a/app/api/routers/company_info.py
+++ b/app/api/routers/company_info.py
@@ -156,7 +156,7 @@ async def list_all_companies(
             )
             listing_owner_set.add(owner_address)
         except Exception as e:
-            LOG.warning(e)
+            LOG.notice(e)
 
     has_listing_owner_function = has_listing_owner_function_creator(listing_owner_set)
     filtered_company_list = filter(has_listing_owner_function, company_list)

--- a/app/api/routers/eth.py
+++ b/app/api/routers/eth.py
@@ -166,7 +166,7 @@ async def send_raw_transaction(
             raw_tx = decode(HexBytes(raw_tx_hex))
             to_contract_address = to_checksum_address(raw_tx[3].to_0x_hex())
         except Exception as err:
-            LOG.warning(f"RLP decoding failed: {err}")
+            LOG.notice(f"RLP decoding failed: {err}")
             continue
 
         listed_token = (
@@ -190,7 +190,7 @@ async def send_raw_transaction(
                         contract_name=token_attribute[1], address=to_contract_address
                     )
                 except Exception as err:
-                    LOG.warning(f"Could not get token status: {err}")
+                    LOG.notice(f"Could not get token status: {err}")
                     continue
                 if (
                     await AsyncContract.call_function(
@@ -292,7 +292,7 @@ async def send_raw_transaction(
                         "error_msg": message,
                     }
                 )
-                LOG.warning(
+                LOG.notice(
                     f"Contract revert detected: code: {str(code)} message: {message}"
                 )
                 continue
@@ -320,7 +320,7 @@ async def send_raw_transaction(
             result.append(
                 {"id": i + 1, "status": status, "transaction_hash": tx_hash.to_0x_hex()}
             )
-            LOG.warning(f"Transaction receipt timeout: {time_exhausted_err}")
+            LOG.notice(f"Transaction receipt timeout: {time_exhausted_err}")
             continue
         except Exception as err:
             result.append(
@@ -371,7 +371,7 @@ async def send_raw_transaction_no_wait(
             raw_tx = decode(HexBytes(raw_tx_hex))
             to_contract_address = to_checksum_address(raw_tx[3].to_0x_hex())
         except Exception as err:
-            LOG.warning(f"RLP decoding failed: {err}")
+            LOG.notice(f"RLP decoding failed: {err}")
             continue
 
         listed_token = (
@@ -396,7 +396,7 @@ async def send_raw_transaction_no_wait(
                         contract_name=token_attribute[1], address=to_contract_address
                     )
                 except Exception as err:
-                    LOG.warning(f"Could not get token status: {err}")
+                    LOG.notice(f"Could not get token status: {err}")
                     continue
                 if (
                     await AsyncContract.call_function(

--- a/app/api/routers/position.py
+++ b/app/api/routers/position.py
@@ -516,7 +516,7 @@ class BasePosition:
                     position["token_address"] = token_address
                 return position
         except ServiceUnavailable as e:
-            LOG.warning(e)
+            LOG.notice(e)
             return None
         except Exception as e:
             LOG.error(e)
@@ -639,7 +639,7 @@ class BasePositionShare(BasePosition):
                     position["token_address"] = token_address
                 return position
         except ServiceUnavailable as e:
-            LOG.warning(e)
+            LOG.notice(e)
             return None
         except Exception as e:
             LOG.error(e)
@@ -744,7 +744,7 @@ class BasePositionStraightBond(BasePosition):
                     position["token_address"] = token_address
                 return position
         except ServiceUnavailable as e:
-            LOG.warning(e)
+            LOG.notice(e)
             return None
         except Exception as e:
             LOG.error(e)
@@ -1044,7 +1044,7 @@ class BasePositionCoupon(BasePosition):
                     position["token_address"] = token_address
                 return position
         except ServiceUnavailable as e:
-            LOG.warning(e)
+            LOG.notice(e)
             return None
         except Exception as e:
             LOG.error(e)

--- a/app/api/routers/token.py
+++ b/app/api/routers/token.py
@@ -120,7 +120,7 @@ async def get_token_status(
         )
         name, status, transferable = [task.result() for task in tasks]
     except* ServiceUnavailable as e:
-        LOG.warning(e)
+        LOG.notice(e)
         raise DataNotExistsError("token_address: %s" % token_address)
     except* Exception as e:
         LOG.error(e)

--- a/app/api/routers/token_bond.py
+++ b/app/api/routers/token_bond.py
@@ -332,7 +332,7 @@ async def retrieve_straight_bond_token(
             async_session=async_session, token_address=token_address
         )
     except ServiceUnavailable as e:
-        LOG.warning(e)
+        LOG.notice(e)
         raise DataNotExistsError("token_address: %s" % token_address) from None
     except Exception as e:
         LOG.error(e)

--- a/app/api/routers/token_coupon.py
+++ b/app/api/routers/token_coupon.py
@@ -314,7 +314,7 @@ async def retrieve_coupon_token(
             async_session=async_session, token_address=token_address
         )
     except ServiceUnavailable as e:
-        LOG.warning(e)
+        LOG.notice(e)
         raise DataNotExistsError("token_address: %s" % token_address) from None
     except Exception as e:
         LOG.error(e)

--- a/app/api/routers/token_membership.py
+++ b/app/api/routers/token_membership.py
@@ -316,7 +316,7 @@ async def retrieve_membership_token(
             async_session=async_session, token_address=token_address
         )
     except ServiceUnavailable as e:
-        LOG.warning(e)
+        LOG.notice(e)
         raise DataNotExistsError("token_address: %s" % token_address) from None
     except Exception as e:
         LOG.error(e)

--- a/app/api/routers/token_share.py
+++ b/app/api/routers/token_share.py
@@ -330,7 +330,7 @@ async def retrieve_share_token(
             async_session=async_session, token_address=token_address
         )
     except ServiceUnavailable as e:
-        LOG.warning(e)
+        LOG.notice(e)
         raise DataNotExistsError("token_address: %s" % token_address) from None
     except Exception as e:
         LOG.error(e)

--- a/app/log.py
+++ b/app/log.py
@@ -20,13 +20,15 @@ SPDX-License-Identifier: Apache-2.0
 import logging
 
 from app import config
+from logger import SystemLogger
 
+logging.setLoggerClass(SystemLogger)
 logging.basicConfig(level=config.LOG_LEVEL)
 LOG = logging.getLogger("ibet_wallet_app")
 LOG.propagate = False
+
 logging.getLogger("httpx").setLevel(logging.WARNING)
 logging.getLogger("httpcore").setLevel(logging.WARNING)
-
 logging.getLogger("web3.manager.RequestManager").propagate = False
 logging.getLogger("web3.manager.RequestManager").addHandler(logging.NullHandler())
 

--- a/app/log.py
+++ b/app/log.py
@@ -18,13 +18,14 @@ SPDX-License-Identifier: Apache-2.0
 """
 
 import logging
+from typing import cast
 
 from app import config
 from logger import SystemLogger
 
 logging.setLoggerClass(SystemLogger)
 logging.basicConfig(level=config.LOG_LEVEL)
-LOG = logging.getLogger("ibet_wallet_app")
+LOG = cast(SystemLogger, logging.getLogger("ibet_wallet_app"))
 LOG.propagate = False
 
 logging.getLogger("httpx").setLevel(logging.WARNING)

--- a/app/model/blockchain/token.py
+++ b/app/model/blockchain/token.py
@@ -429,7 +429,7 @@ class BondToken(TokenBase):
                     "interestPaymentDate12", ""
                 )
         except Exception:
-            LOG.warning("Failed to load interestPaymentDate")
+            LOG.notice("Failed to load interestPaymentDate")
 
         try:
             if _raw_base_fx_rate is not None and _raw_base_fx_rate != "":

--- a/app/utils/web3_utils.py
+++ b/app/utils/web3_utils.py
@@ -162,7 +162,7 @@ class FailOverHTTPProvider(HTTPProvider):
                             # NOTE:
                             #  JSONDecodeError will be raised if a request is sent
                             #  while Quorum is terminating.
-                            LOG.warning(
+                            LOG.notice(
                                 f"Retry web3 request due to connection fail: method={method}, params={params}"
                             )
                             counter += 1
@@ -223,7 +223,7 @@ class AsyncFailOverHTTPProvider(AsyncHTTPProvider):
                             # NOTE:
                             #  JSONDecodeError will be raised if a request is sent
                             #  while Quorum is terminating.
-                            LOG.warning(
+                            LOG.notice(
                                 f"Retry web3 request due to connection fail: method={method}, params={params}"
                             )
                             counter += 1

--- a/batch/indexer_Block_Tx_Data.py
+++ b/batch/indexer_Block_Tx_Data.py
@@ -154,7 +154,7 @@ async def main():
         try:
             await processor.process()
         except ServiceUnavailable:
-            LOG.warning("An external service was unavailable")
+            LOG.notice("An external service was unavailable")
         except SQLAlchemyError as sa_err:
             LOG.error(f"A database error has occurred: code={sa_err.code}\n{sa_err}")
         except Exception:

--- a/batch/indexer_CompanyList.py
+++ b/batch/indexer_CompanyList.py
@@ -91,15 +91,13 @@ class Processor:
                     or not isinstance(rsa_publickey, str)
                     or not isinstance(homepage, str)
                 ):
-                    LOG.warning(f"type error: index={i}")
+                    LOG.notice(f"Invalid type: index={i}")
                     continue
                 if address and corporate_name and rsa_publickey:
                     try:
                         address = to_checksum_address(address)
                     except ValueError:
-                        LOG.warning(
-                            f"invalid address error: index={i} address={address}"
-                        )
+                        LOG.notice(f"Invalid address: index={i} address={address}")
                         continue
                     try:
                         await self.__sink_on_company(
@@ -110,12 +108,10 @@ class Processor:
                             homepage=homepage,
                         )
                     except IntegrityError:
-                        LOG.warning(
-                            f"duplicate address error: index={i} address={address}"
-                        )
+                        LOG.notice(f"Duplicate address: index={i} address={address}")
                         continue
                 else:
-                    LOG.warning(f"required error: index={i}")
+                    LOG.notice(f"Missing required field: index={i}")
                     continue
 
             await db_session.commit()
@@ -151,7 +147,7 @@ async def main():
         try:
             await processor.process()
         except ServiceUnavailable:
-            LOG.warning("An external service was unavailable")
+            LOG.notice("An external service was unavailable")
         except SQLAlchemyError as sa_err:
             LOG.error(f"A database error has occurred: code={sa_err.code}\n{sa_err}")
         except Exception:  # Unexpected errors

--- a/batch/indexer_Consume_Coupon.py
+++ b/batch/indexer_Consume_Coupon.py
@@ -234,7 +234,7 @@ async def main():
         try:
             await processor.sync_new_logs()
         except ServiceUnavailable:
-            LOG.warning("An external service was unavailable")
+            LOG.notice("An external service was unavailable")
         except SQLAlchemyError as sa_err:
             LOG.error(f"A database error has occurred: code={sa_err.code}\n{sa_err}")
         except Exception:

--- a/batch/indexer_DEX.py
+++ b/batch/indexer_DEX.py
@@ -522,7 +522,7 @@ async def main():
         try:
             await processor.sync_new_logs()
         except ServiceUnavailable:
-            LOG.warning("An external service was unavailable")
+            LOG.notice("An external service was unavailable")
         except SQLAlchemyError as sa_err:
             LOG.error(f"A database error has occurred: code={sa_err.code}\n{sa_err}")
         except Exception:

--- a/batch/indexer_Position_Bond.py
+++ b/batch/indexer_Position_Bond.py
@@ -1688,7 +1688,7 @@ async def main():
         try:
             await processor.sync_new_logs()
         except ServiceUnavailable:
-            LOG.warning("An external service was unavailable")
+            LOG.notice("An external service was unavailable")
         except SQLAlchemyError as sa_err:
             LOG.error(f"A database error has occurred: code={sa_err.code}\n{sa_err}")
         except Exception:

--- a/batch/indexer_Position_Coupon.py
+++ b/batch/indexer_Position_Coupon.py
@@ -1019,7 +1019,7 @@ async def main():
         try:
             await processor.sync_new_logs()
         except ServiceUnavailable:
-            LOG.warning("An external service was unavailable")
+            LOG.notice("An external service was unavailable")
         except SQLAlchemyError as sa_err:
             LOG.error(f"A database error has occurred: code={sa_err.code}\n{sa_err}")
         except Exception:

--- a/batch/indexer_Position_Membership.py
+++ b/batch/indexer_Position_Membership.py
@@ -983,7 +983,7 @@ async def main():
         try:
             await processor.sync_new_logs()
         except ServiceUnavailable:
-            LOG.warning("An external service was unavailable")
+            LOG.notice("An external service was unavailable")
         except SQLAlchemyError as sa_err:
             LOG.error(f"A database error has occurred: code={sa_err.code}\n{sa_err}")
         except Exception:

--- a/batch/indexer_Position_Share.py
+++ b/batch/indexer_Position_Share.py
@@ -1688,7 +1688,7 @@ async def main():
         try:
             await processor.sync_new_logs()
         except ServiceUnavailable:
-            LOG.warning("An external service was unavailable")
+            LOG.notice("An external service was unavailable")
         except SQLAlchemyError as sa_err:
             LOG.error(f"A database error has occurred: code={sa_err.code}\n{sa_err}")
         except Exception:

--- a/batch/indexer_Token_Detail.py
+++ b/batch/indexer_Token_Detail.py
@@ -131,8 +131,8 @@ class Processor:
                     elapsed_time = time.time() - start_time
                     await asyncio.sleep(max(self.SEC_PER_RECORD - elapsed_time, 0))
                 except (ObjectDeletedError, StaleDataError):
-                    LOG.warning(
-                        "The record may have been deleted in another session during the update"
+                    LOG.notice(
+                        "The record may have been deleted in a different session during the update"
                     )
 
 
@@ -145,7 +145,7 @@ async def main():
         try:
             await processor.process()
         except ServiceUnavailable:
-            LOG.warning("An external service was unavailable")
+            LOG.notice("An external service was unavailable")
         except SQLAlchemyError as sa_err:
             LOG.error(f"A database error has occurred: code={sa_err.code}\n{sa_err}")
         except Exception:  # Unexpected errors

--- a/batch/indexer_Token_Detail_ShortTerm.py
+++ b/batch/indexer_Token_Detail_ShortTerm.py
@@ -144,8 +144,8 @@ class Processor:
                     elapsed_time = time.time() - start_time
                     await asyncio.sleep(max(self.SEC_PER_RECORD - elapsed_time, 0))
                 except (ObjectDeletedError, StaleDataError):
-                    LOG.warning(
-                        "The record may have been deleted in another session during the update"
+                    LOG.notice(
+                        "The record may have been deleted in a different session during the update"
                     )
 
 
@@ -158,7 +158,7 @@ async def main():
         try:
             await processor.process()
         except ServiceUnavailable:
-            LOG.warning("An external service was unavailable")
+            LOG.notice("An external service was unavailable")
         except SQLAlchemyError as sa_err:
             LOG.error(f"A database error has occurred: code={sa_err.code}\n{sa_err}")
         except Exception:  # Unexpected errors

--- a/batch/indexer_Token_Holders.py
+++ b/batch/indexer_Token_Holders.py
@@ -556,7 +556,7 @@ async def main():
         try:
             await processor.collect()
         except ServiceUnavailable:
-            LOG.warning("An external service was unavailable")
+            LOG.notice("An external service was unavailable")
         except SQLAlchemyError as sa_err:
             LOG.error(f"A database error has occurred: code={sa_err.code}\n{sa_err}")
         except Exception:

--- a/batch/indexer_Token_List.py
+++ b/batch/indexer_Token_List.py
@@ -222,7 +222,7 @@ async def main():
             await processor.process()
             LOG.debug("Processed")
         except ServiceUnavailable:
-            LOG.warning("An external service was unavailable")
+            LOG.notice("An external service was unavailable")
         except SQLAlchemyError as sa_err:
             LOG.error(f"A database error has occurred: code={sa_err.code}\n{sa_err}")
         except Exception:

--- a/batch/indexer_Transfer.py
+++ b/batch/indexer_Transfer.py
@@ -476,7 +476,7 @@ async def main():
             await processor.sync_new_logs()
             LOG.debug("Processed")
         except ServiceUnavailable:
-            LOG.warning("An external service was unavailable")
+            LOG.notice("An external service was unavailable")
         except SQLAlchemyError as sa_err:
             LOG.error(f"A database error has occurred: code={sa_err.code}\n{sa_err}")
         except Exception:

--- a/batch/indexer_TransferApproval.py
+++ b/batch/indexer_TransferApproval.py
@@ -750,7 +750,7 @@ async def main():
         try:
             await processor.sync_new_logs()
         except ServiceUnavailable:
-            LOG.warning("An external service was unavailable")
+            LOG.notice("An external service was unavailable")
         except SQLAlchemyError as sa_err:
             LOG.error(f"A database error has occurred: code={sa_err.code}\n{sa_err}")
         except Exception:

--- a/batch/log.py
+++ b/batch/log.py
@@ -19,6 +19,7 @@ SPDX-License-Identifier: Apache-2.0
 
 import logging
 import sys
+from typing import cast
 
 from app import config
 from logger import SystemLogger
@@ -26,7 +27,7 @@ from logger import SystemLogger
 
 def get_logger(process_name: str = None):
     logging.setLoggerClass(SystemLogger)
-    LOG = logging.getLogger("ibet_wallet_batch")
+    LOG = cast(SystemLogger, logging.getLogger("ibet_wallet_batch"))
     LOG.propagate = False
     stream_handler = logging.StreamHandler(sys.stdout)
     formatter = logging.Formatter(

--- a/batch/processor_Block_Sync_Status.py
+++ b/batch/processor_Block_Sync_Status.py
@@ -198,7 +198,7 @@ class Processor:
         else:
             if not is_synced:
                 # If the same previous processing status, log output with WARING level.
-                LOG.warning(f"{endpoint_uri} Block synchronization is down: %s", errors)
+                LOG.notice(f"{endpoint_uri} Block synchronization is down: %s", errors)
 
     def __web3_errors(self, db_session: Session, endpoint_uri: str):
         try:

--- a/batch/processor_Notifications_Coupon_Exchange.py
+++ b/batch/processor_Notifications_Coupon_Exchange.py
@@ -147,7 +147,7 @@ class Watcher:
             await db_session.commit()
 
         except ServiceUnavailable:
-            LOG.warning("An external service was unavailable")
+            LOG.notice("An external service was unavailable")
         except SQLAlchemyError as sa_err:
             LOG.error(f"A database error has occurred: code={sa_err.code}\n{sa_err}")
         except Exception as err:  # Exceptionが発生した場合は処理を継続

--- a/batch/processor_Notifications_Membership_Exchange.py
+++ b/batch/processor_Notifications_Membership_Exchange.py
@@ -147,7 +147,7 @@ class Watcher:
             await db_session.commit()
 
         except ServiceUnavailable:
-            LOG.warning("An external service was unavailable")
+            LOG.notice("An external service was unavailable")
         except SQLAlchemyError as sa_err:
             LOG.error(f"A database error has occurred: code={sa_err.code}\n{sa_err}")
         except Exception as err:  # Exceptionが発生した場合は処理を継続

--- a/batch/processor_Notifications_Token.py
+++ b/batch/processor_Notifications_Token.py
@@ -198,7 +198,7 @@ class Watcher:
                 await db_session.commit()
 
         except ServiceUnavailable:
-            LOG.warning("An external service was unavailable")
+            LOG.notice("An external service was unavailable")
         except SQLAlchemyError as sa_err:
             LOG.error(f"A database error has occurred: code={sa_err.code}\n{sa_err}")
         finally:

--- a/batch/processor_Send_Mail.py
+++ b/batch/processor_Send_Mail.py
@@ -52,7 +52,7 @@ class Processor:
                             and mail.to_email.split("@")[1]
                             not in config.ALLOWED_EMAIL_DESTINATION_DOMAIN_LIST
                         ):
-                            LOG.warning(
+                            LOG.notice(
                                 f"Destination address is not allowed to send: id={mail.id}"
                             )
                             continue
@@ -68,7 +68,7 @@ class Processor:
                                 )
                             )
                         ):
-                            LOG.warning(
+                            LOG.notice(
                                 f"Destination address is not allowed to send: id={mail.id}"
                             )
                             continue
@@ -85,7 +85,7 @@ class Processor:
                         )
                         smtp_mail.send_mail()
                     except (SMTPException, SESException, IndexError):
-                        LOG.warning(f"Could not send email: id={mail.id}")
+                        LOG.notice(f"Could not send email: id={mail.id}")
                         continue
                     finally:
                         db_session.delete(mail)

--- a/batch/processor_Send_Mail.py
+++ b/batch/processor_Send_Mail.py
@@ -85,7 +85,7 @@ class Processor:
                         )
                         smtp_mail.send_mail()
                     except (SMTPException, SESException, IndexError):
-                        LOG.notice(f"Could not send email: id={mail.id}")
+                        LOG.warning(f"Could not send email: id={mail.id}")
                         continue
                     finally:
                         db_session.delete(mail)

--- a/docs/ibet_wallet_api.yaml
+++ b/docs/ibet_wallet_api.yaml
@@ -6117,6 +6117,27 @@ components:
         - earliest
         - pending
       title: BlockIdentifier
+    CompanyInfo:
+      properties:
+        address:
+          type: string
+          title: Address
+        corporate_name:
+          type: string
+          title: Corporate Name
+        rsa_publickey:
+          type: string
+          title: Rsa Publickey
+        homepage:
+          type: string
+          title: Homepage
+      type: object
+      required:
+        - address
+        - corporate_name
+        - rsa_publickey
+        - homepage
+      title: CompanyInfo
     CompleteAgreementSet_RetrieveCouponTokenResponse_:
       properties:
         token:
@@ -7791,7 +7812,7 @@ components:
       title: ListAllAdminTokensResponse
     ListAllCompanyInfoResponse:
       items:
-        $ref: '#/components/schemas/RetrieveCompanyInfoResponse'
+        $ref: '#/components/schemas/CompanyInfo'
       type: array
       title: ListAllCompanyInfoResponse
     ListAllCompanyTokensResponse:

--- a/logger.py
+++ b/logger.py
@@ -18,21 +18,14 @@ SPDX-License-Identifier: Apache-2.0
 """
 
 import logging
-import sys
 
-from app import config
-from logger import SystemLogger
+NOTICE = 25  # Set the log level to a number between info (20) and warning (30).
 
 
-def get_logger(process_name: str = None):
-    logging.setLoggerClass(SystemLogger)
-    LOG = logging.getLogger("ibet_wallet_batch")
-    LOG.propagate = False
-    stream_handler = logging.StreamHandler(sys.stdout)
-    formatter = logging.Formatter(
-        config.INFO_LOG_FORMAT.format(f"[{process_name}]"), config.LOG_TIMESTAMP_FORMAT
-    )
-    stream_handler.setFormatter(formatter)
-    LOG.addHandler(stream_handler)
+class SystemLogger(logging.Logger):
+    def __init__(self, name, level=logging.NOTSET):
+        super().__init__(name, level)
 
-    return LOG
+    def notice(self, msg, *args, **kwargs):
+        if self.isEnabledFor(NOTICE):
+            self._log(NOTICE, msg, args, **kwargs)

--- a/tests/app/eth_SendRawTransaction_test.py
+++ b/tests/app/eth_SendRawTransaction_test.py
@@ -429,7 +429,9 @@ class TestEthSendRawTransaction:
 
     # <Normal_4>
     # nonce too low
-    def test_normal_4(self, client: TestClient, session: Session):
+    def test_normal_4(
+        self, client: TestClient, session: Session, caplog: pytest.LogCaptureFixture
+    ):
         with mock.patch(
             "app.utils.web3_utils.AsyncFailOverHTTPProvider.fail_over_mode", True
         ):
@@ -522,9 +524,22 @@ class TestEthSendRawTransaction:
                 {"id": 1, "status": 3, "transaction_hash": ANY}
             ]
 
+            assert (
+                caplog.record_tuples.count(
+                    (
+                        log.LOG.name,
+                        logging.WARNING,
+                        "Sent transaction nonce is too low: {'code': -32000, 'message': 'nonce too low'}",
+                    )
+                )
+                == 1
+            )
+
     # <Normal_5>
     # already known
-    def test_normal_5(self, client: TestClient, session: Session):
+    def test_normal_5(
+        self, client: TestClient, session: Session, caplog: pytest.LogCaptureFixture
+    ):
         with mock.patch(
             "app.utils.web3_utils.AsyncFailOverHTTPProvider.fail_over_mode", True
         ):
@@ -616,6 +631,17 @@ class TestEthSendRawTransaction:
             assert resp.json()["data"] == [
                 {"id": 1, "status": 4, "transaction_hash": ANY}
             ]
+
+            assert (
+                caplog.record_tuples.count(
+                    (
+                        log.LOG.name,
+                        logging.WARNING,
+                        "Sent transaction has been already known: {'code': -32000, 'message': 'already known'}",
+                    )
+                )
+                == 1
+            )
 
     ###########################################################################
     # Error
@@ -1130,7 +1156,7 @@ class TestEthSendRawTransaction:
                 caplog.record_tuples.count(
                     (
                         log.LOG.name,
-                        logging.WARN,
+                        25,
                         "Contract revert detected: code: 0 message: Message sender balance is insufficient.",
                     )
                 )
@@ -1213,7 +1239,7 @@ class TestEthSendRawTransaction:
                 caplog.record_tuples.count(
                     (
                         log.LOG.name,
-                        logging.WARN,
+                        25,
                         "Contract revert detected: code: 0 message: execution reverted",
                     )
                 )

--- a/tests/batch/indexer_Consume_Coupon_test.py
+++ b/tests/batch/indexer_Consume_Coupon_test.py
@@ -527,6 +527,6 @@ class TestProcessor:
             asyncio.run(main_func())
 
         assert 1 == caplog.record_tuples.count(
-            (LOG.name, logging.WARNING, "An external service was unavailable")
+            (LOG.name, 25, "An external service was unavailable")
         )
         caplog.clear()

--- a/tests/batch/indexer_DEX_test.py
+++ b/tests/batch/indexer_DEX_test.py
@@ -1113,6 +1113,6 @@ class TestProcessor:
             asyncio.run(main_func())
 
         assert 1 == caplog.record_tuples.count(
-            (LOG.name, logging.WARNING, "An external service was unavailable")
+            (LOG.name, 25, "An external service was unavailable")
         )
         caplog.clear()

--- a/tests/batch/indexer_Position_Bond_test.py
+++ b/tests/batch/indexer_Position_Bond_test.py
@@ -2181,6 +2181,6 @@ class TestProcessor:
             asyncio.run(main_func())
 
         assert 1 == caplog.record_tuples.count(
-            (LOG.name, logging.WARNING, "An external service was unavailable")
+            (LOG.name, 25, "An external service was unavailable")
         )
         caplog.clear()

--- a/tests/batch/indexer_Position_Coupon_test.py
+++ b/tests/batch/indexer_Position_Coupon_test.py
@@ -1313,6 +1313,6 @@ class TestProcessor:
             asyncio.run(main_func())
 
         assert 1 == caplog.record_tuples.count(
-            (LOG.name, logging.WARNING, "An external service was unavailable")
+            (LOG.name, 25, "An external service was unavailable")
         )
         caplog.clear()

--- a/tests/batch/indexer_Position_Membership_test.py
+++ b/tests/batch/indexer_Position_Membership_test.py
@@ -1270,6 +1270,6 @@ class TestProcessor:
             asyncio.run(main_func())
 
         assert 1 == caplog.record_tuples.count(
-            (LOG.name, logging.WARNING, "An external service was unavailable")
+            (LOG.name, 25, "An external service was unavailable")
         )
         caplog.clear()

--- a/tests/batch/indexer_Position_Share_test.py
+++ b/tests/batch/indexer_Position_Share_test.py
@@ -2167,6 +2167,6 @@ class TestProcessor:
             asyncio.run(main_func())
 
         assert 1 == caplog.record_tuples.count(
-            (LOG.name, logging.WARNING, "An external service was unavailable")
+            (LOG.name, 25, "An external service was unavailable")
         )
         caplog.clear()

--- a/tests/batch/indexer_Token_Detail_ShortTerm_test.py
+++ b/tests/batch/indexer_Token_Detail_ShortTerm_test.py
@@ -928,6 +928,6 @@ class TestProcessor:
             (LOG.name, logging.INFO, "Service started successfully")
         )
         assert 1 == caplog.record_tuples.count(
-            (LOG.name, logging.WARNING, "An external service was unavailable")
+            (LOG.name, 25, "An external service was unavailable")
         )
         caplog.clear()

--- a/tests/batch/indexer_Token_Detail_test.py
+++ b/tests/batch/indexer_Token_Detail_test.py
@@ -532,6 +532,6 @@ class TestProcessor:
             (LOG.name, logging.INFO, "Service started successfully")
         )
         assert 1 == caplog.record_tuples.count(
-            (LOG.name, logging.WARNING, "An external service was unavailable")
+            (LOG.name, 25, "An external service was unavailable")
         )
         caplog.clear()

--- a/tests/batch/indexer_Token_List_test.py
+++ b/tests/batch/indexer_Token_List_test.py
@@ -877,6 +877,6 @@ class TestProcessor:
             (LOG.name, logging.INFO, "Service started successfully")
         )
         assert 1 == caplog.record_tuples.count(
-            (LOG.name, logging.WARNING, "An external service was unavailable")
+            (LOG.name, 25, "An external service was unavailable")
         )
         caplog.clear()

--- a/tests/batch/indexer_TransferApproval_test.py
+++ b/tests/batch/indexer_TransferApproval_test.py
@@ -1392,6 +1392,6 @@ class TestProcessor:
             asyncio.run(main_func())
 
         assert 1 == caplog.record_tuples.count(
-            (LOG.name, logging.WARNING, "An external service was unavailable")
+            (LOG.name, 25, "An external service was unavailable")
         )
         caplog.clear()

--- a/tests/batch/processor_Send_Mail_test.py
+++ b/tests/batch/processor_Send_Mail_test.py
@@ -193,7 +193,7 @@ class TestProcessorSendMail:
         assert len(session.scalars(select(Mail)).all()) == 0
 
         assert 1 == caplog.record_tuples.count(
-            (LOG.name, 25, "Could not send email: id=1")
+            (LOG.name, logging.WARNING, "Could not send email: id=1")
         )
 
         assert 1 == caplog.record_tuples.count((LOG.name, logging.INFO, "Process end"))

--- a/tests/batch/processor_Send_Mail_test.py
+++ b/tests/batch/processor_Send_Mail_test.py
@@ -125,7 +125,7 @@ class TestProcessorSendMail:
         assert 1 == caplog.record_tuples.count(
             (
                 LOG.name,
-                logging.WARNING,
+                25,
                 "Destination address is not allowed to send: id=1",
             )
         )
@@ -159,7 +159,7 @@ class TestProcessorSendMail:
         assert 1 == caplog.record_tuples.count(
             (
                 LOG.name,
-                logging.WARNING,
+                25,
                 "Destination address is not allowed to send: id=1",
             )
         )
@@ -193,7 +193,7 @@ class TestProcessorSendMail:
         assert len(session.scalars(select(Mail)).all()) == 0
 
         assert 1 == caplog.record_tuples.count(
-            (LOG.name, logging.WARNING, "Could not send email: id=1")
+            (LOG.name, 25, "Could not send email: id=1")
         )
 
         assert 1 == caplog.record_tuples.count((LOG.name, logging.INFO, "Process end"))


### PR DESCRIPTION
In Python's logging module, you can specify five levels of logging:

- `DEBUG`
- `INFO`
- `WARNING`
- `ERROR`
- `CRITICAL`

In the ibet-Wallet-API logs, we primarily use three of these levels: ERROR, WARNING, and INFO, with the following distinctions:

- `ERROR`: Information for detecting abnormal conditions. Indicates a failure state.
- `WARNING`: Information for detecting states that require attention. Indicates a state where an anomaly has occurred but is not a failure.
- `INFO`: Information necessary to confirm normal operation.

Regarding the WARNING level, in typical use of the ibet-Wallet-API, immediate detection is not currently in place. However, as service operators, there are situations where immediate detection and attention are desired. Therefore, we would like to restructure the log levels as follows:

- 🚨 `ERROR`: Information for detecting abnormal conditions. Indicates a failure state.
- 🚨 `WARNING`: Information for detecting exceptional events that are not failures.
- ⚠️ `NOTICE`: Information that is normal but represents an important event.
- `INFO`: Information necessary to confirm normal operation.

Based on this idea, I made a modification to add a new log level "NOTICE". Also, I reviewed the log levels of WARNING and NOTICE.