### PR TITLE
Update data schema of lock/unlock event

### DIFF
--- a/app/model/db/__init__.py
+++ b/app/model/db/__init__.py
@@ -42,6 +42,7 @@ from .idx_token import (
 )
 from .idx_token_list import IDXTokenListBlockNumber, IDXTokenListItem
 from .idx_transfer import (
+    DataMessage,
     IDXTransfer,
     IDXTransferBlockNumber,
     IDXTransferSourceEventType,

--- a/batch/indexer_Transfer.py
+++ b/batch/indexer_Transfer.py
@@ -24,6 +24,7 @@ from datetime import datetime, timedelta, timezone
 from typing import List, Optional, Sequence
 
 from eth_utils import to_checksum_address
+from pydantic import ValidationError
 from sqlalchemy import desc, select
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -34,6 +35,7 @@ from app.contracts import AsyncContract
 from app.database import BatchAsyncSessionLocal
 from app.errors import ServiceUnavailable
 from app.model.db import (
+    DataMessage,
     IDXTransfer,
     IDXTransferBlockNumber,
     IDXTransferSourceEventType,
@@ -174,10 +176,20 @@ class Processor:
         if data_str is not None:
             try:
                 data = json.loads(data_str)
+                validated_data = DataMessage(**data)
+                message = validated_data.message
+            except ValidationError:
+                data = {}
+                message = None
+            except json.JSONDecodeError:
+                data = {}
+                message = None
             except:
                 data = {}
+                message = None
         else:
             data = None
+            message = None
         transfer = IDXTransfer()
         transfer.transaction_hash = transaction_hash
         transfer.token_address = token_address
@@ -188,6 +200,7 @@ class Processor:
         transfer.modified = event_created
         transfer.source_event = source_event.value
         transfer.data = data
+        transfer.message = message
         db_session.add(transfer)
 
     @staticmethod

--- a/migrations/versions/603fd86dc179_v24_12_0_feature_1574.py
+++ b/migrations/versions/603fd86dc179_v24_12_0_feature_1574.py
@@ -1,0 +1,45 @@
+"""v24_12_0_feature_1574
+
+Revision ID: 603fd86dc179
+Revises: 418af51b07b5
+Create Date: 2024-11-01 11:01:24.485369
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+from app.database import get_db_schema
+
+# revision identifiers, used by Alembic.
+revision = "603fd86dc179"
+down_revision = "418af51b07b5"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    connection = op.get_bind()
+
+    op.add_column(
+        "transfer",
+        sa.Column("message", sa.String(length=50), nullable=True),
+        schema=get_db_schema(),
+    )
+    op.create_index(
+        op.f("ix_transfer_message"),
+        "transfer",
+        ["message"],
+        unique=False,
+        schema=get_db_schema(),
+    )
+
+
+def downgrade():
+    connection = op.get_bind()
+
+    op.drop_index(
+        op.f("ix_transfer_message"), table_name="transfer", schema=get_db_schema()
+    )
+    op.drop_column("transfer", "message", schema=get_db_schema())

--- a/tests/app/token_TransferHistory_Search_test.py
+++ b/tests/app/token_TransferHistory_Search_test.py
@@ -64,6 +64,11 @@ class TestTokenTransferHistorySearch:
         _transfer.value = transfer_event["value"]
         _transfer.source_event = transfer_source_event.value
         _transfer.data = transfer_event_data
+        _transfer.message = (
+            transfer_event_data.get("message")
+            if transfer_event_data is not None
+            else None
+        )
         if created is not None:
             _transfer.created = created
         session.add(_transfer)
@@ -174,7 +179,7 @@ class TestTokenTransferHistorySearch:
             session=session,
             transfer_event=transfer_event_2,
             transfer_source_event=IDXTransferSourceEventType.UNLOCK,
-            transfer_event_data={"message": "unlock"},
+            transfer_event_data={"message": "force_unlock"},
         )
 
         session.commit()
@@ -199,6 +204,7 @@ class TestTokenTransferHistorySearch:
         assert data[0]["value"] == transfer_event_1["value"]
         assert data[0]["source_event"] == IDXTransferSourceEventType.TRANSFER.value
         assert data[0]["data"] is None
+        assert data[0]["message"] is None
 
         assert data[1]["transaction_hash"] == transfer_event_2["transaction_hash"]
         assert data[1]["token_address"] == transfer_event_2["token_address"]
@@ -206,7 +212,8 @@ class TestTokenTransferHistorySearch:
         assert data[1]["to_address"] == transfer_event_2["to_address"]
         assert data[1]["value"] == transfer_event_2["value"]
         assert data[1]["source_event"] == IDXTransferSourceEventType.UNLOCK.value
-        assert data[1]["data"] == {"message": "unlock"}
+        assert data[1]["data"] == {"message": "force_unlock"}
+        assert data[1]["message"] == "force_unlock"
 
     # Normal_3_2
     # Transferイベントあり：2件
@@ -245,7 +252,7 @@ class TestTokenTransferHistorySearch:
             session=session,
             transfer_event=transfer_event_2,
             transfer_source_event=IDXTransferSourceEventType.UNLOCK,
-            transfer_event_data={"message": "unlock"},
+            transfer_event_data={"message": "force_unlock"},
         )
 
         session.commit()
@@ -272,7 +279,8 @@ class TestTokenTransferHistorySearch:
         assert data[0]["to_address"] == transfer_event_2["to_address"]
         assert data[0]["value"] == transfer_event_2["value"]
         assert data[0]["source_event"] == IDXTransferSourceEventType.UNLOCK.value
-        assert data[0]["data"] == {"message": "unlock"}
+        assert data[0]["data"] == {"message": "force_unlock"}
+        assert data[0]["message"] == "force_unlock"
 
     # Normal_3_3
     # Transferイベントあり：2件
@@ -311,13 +319,13 @@ class TestTokenTransferHistorySearch:
             session=session,
             transfer_event=transfer_event_2,
             transfer_source_event=IDXTransferSourceEventType.UNLOCK,
-            transfer_event_data={"message": "unlock"},
+            transfer_event_data={"message": "force_unlock"},
         )
 
         session.commit()
 
         apiurl = self.apiurl_base.format(contract_address=self.token_address)
-        resp = client.post(apiurl, json={"data": "unlock"})
+        resp = client.post(apiurl, json={"data": "force_unlock"})
 
         assert resp.status_code == 200
         assert resp.json()["meta"] == {"code": 200, "message": "OK"}
@@ -336,7 +344,8 @@ class TestTokenTransferHistorySearch:
         assert data[0]["to_address"] == transfer_event_2["to_address"]
         assert data[0]["value"] == transfer_event_2["value"]
         assert data[0]["source_event"] == IDXTransferSourceEventType.UNLOCK.value
-        assert data[0]["data"] == {"message": "unlock"}
+        assert data[0]["data"] == {"message": "force_unlock"}
+        assert data[0]["message"] == "force_unlock"
 
     # Normal_3_4
     # Transferイベントあり：2件
@@ -375,7 +384,7 @@ class TestTokenTransferHistorySearch:
             session=session,
             transfer_event=transfer_event_2,
             transfer_source_event=IDXTransferSourceEventType.UNLOCK,
-            transfer_event_data={"message": "unlock"},
+            transfer_event_data={"message": "force_unlock"},
         )
 
         session.commit()
@@ -401,6 +410,7 @@ class TestTokenTransferHistorySearch:
         assert data[0]["value"] == transfer_event_1["value"]
         assert data[0]["source_event"] == IDXTransferSourceEventType.TRANSFER.value
         assert data[0]["data"] is None
+        assert data[0]["message"] is None
 
     # Normal_3_5_1
     # Transferイベントあり：2件
@@ -446,7 +456,7 @@ class TestTokenTransferHistorySearch:
             session=session,
             transfer_event=transfer_event_2,
             transfer_source_event=IDXTransferSourceEventType.UNLOCK,
-            transfer_event_data={"message": "unlock"},
+            transfer_event_data={"message": "force_unlock"},
             created=datetime.now(UTC).replace(tzinfo=None) - timedelta(seconds=1),
         )
         session.commit()
@@ -472,6 +482,7 @@ class TestTokenTransferHistorySearch:
         assert data[0]["value"] == transfer_event_1["value"]
         assert data[0]["source_event"] == IDXTransferSourceEventType.TRANSFER.value
         assert data[0]["data"] is None
+        assert data[0]["message"] is None
 
     # Normal_3_5_2
     # Transferイベントあり：2件
@@ -515,7 +526,7 @@ class TestTokenTransferHistorySearch:
             session=session,
             transfer_event=transfer_event_2,
             transfer_source_event=IDXTransferSourceEventType.UNLOCK,
-            transfer_event_data={"message": "unlock"},
+            transfer_event_data={"message": "force_unlock"},
             created=datetime.now(UTC).replace(tzinfo=None) + timedelta(seconds=1),
         )
         session.commit()
@@ -541,6 +552,7 @@ class TestTokenTransferHistorySearch:
         assert data[0]["value"] == transfer_event_1["value"]
         assert data[0]["source_event"] == IDXTransferSourceEventType.TRANSFER.value
         assert data[0]["data"] is None
+        assert data[0]["message"] is None
 
     # Normal_3_6_1
     # Transferイベントあり：2件
@@ -580,7 +592,7 @@ class TestTokenTransferHistorySearch:
             session=session,
             transfer_event=transfer_event_2,
             transfer_source_event=IDXTransferSourceEventType.UNLOCK,
-            transfer_event_data={"message": "unlock"},
+            transfer_event_data={"message": "force_unlock"},
             created=datetime.now(UTC).replace(tzinfo=None) + timedelta(seconds=1),
         )
         session.commit()
@@ -606,6 +618,7 @@ class TestTokenTransferHistorySearch:
         assert data[0]["value"] == transfer_event_1["value"]
         assert data[0]["source_event"] == IDXTransferSourceEventType.TRANSFER.value
         assert data[0]["data"] is None
+        assert data[0]["message"] is None
 
     # Normal_3_6_2
     # Transferイベントあり：2件
@@ -645,7 +658,7 @@ class TestTokenTransferHistorySearch:
             session=session,
             transfer_event=transfer_event_2,
             transfer_source_event=IDXTransferSourceEventType.UNLOCK,
-            transfer_event_data={"message": "unlock"},
+            transfer_event_data={"message": "force_unlock"},
             created=datetime.now(UTC).replace(tzinfo=None) + timedelta(seconds=1),
         )
         session.commit()
@@ -670,7 +683,8 @@ class TestTokenTransferHistorySearch:
         assert data[0]["to_address"] == transfer_event_2["to_address"]
         assert data[0]["value"] == transfer_event_2["value"]
         assert data[0]["source_event"] == IDXTransferSourceEventType.UNLOCK.value
-        assert data[0]["data"] == {"message": "unlock"}
+        assert data[0]["data"] == {"message": "force_unlock"}
+        assert data[0]["message"] == "force_unlock"
 
     # Normal_3_6_3
     # Transferイベントあり：2件
@@ -710,7 +724,7 @@ class TestTokenTransferHistorySearch:
             session=session,
             transfer_event=transfer_event_2,
             transfer_source_event=IDXTransferSourceEventType.UNLOCK,
-            transfer_event_data={"message": "unlock"},
+            transfer_event_data={"message": "force_unlock"},
             created=datetime.now(UTC).replace(tzinfo=None) + timedelta(seconds=1),
         )
         session.commit()
@@ -736,6 +750,7 @@ class TestTokenTransferHistorySearch:
         assert data[0]["value"] == transfer_event_1["value"]
         assert data[0]["source_event"] == IDXTransferSourceEventType.TRANSFER.value
         assert data[0]["data"] is None
+        assert data[0]["message"] is None
 
     # Normal_3_7
     # Transferイベントあり：2件
@@ -774,7 +789,7 @@ class TestTokenTransferHistorySearch:
             session=session,
             transfer_event=transfer_event_2,
             transfer_source_event=IDXTransferSourceEventType.UNLOCK,
-            transfer_event_data={"message": "unlock"},
+            transfer_event_data={"message": "force_unlock"},
         )
 
         session.commit()
@@ -802,6 +817,7 @@ class TestTokenTransferHistorySearch:
         assert data[0]["value"] == transfer_event_1["value"]
         assert data[0]["source_event"] == IDXTransferSourceEventType.TRANSFER.value
         assert data[0]["data"] is None
+        assert data[0]["message"] is None
 
     # Normal_3_8
     # Transferイベントあり：2件
@@ -840,7 +856,7 @@ class TestTokenTransferHistorySearch:
             session=session,
             transfer_event=transfer_event_2,
             transfer_source_event=IDXTransferSourceEventType.UNLOCK,
-            transfer_event_data={"message": "unlock"},
+            transfer_event_data={"message": "force_unlock"},
         )
 
         session.commit()
@@ -866,6 +882,7 @@ class TestTokenTransferHistorySearch:
         assert data[0]["value"] == transfer_event_1["value"]
         assert data[0]["source_event"] == IDXTransferSourceEventType.TRANSFER.value
         assert data[0]["data"] is None
+        assert data[0]["message"] is None
 
     # Normal_3_9
     # Transferイベントあり：2件
@@ -904,7 +921,7 @@ class TestTokenTransferHistorySearch:
             session=session,
             transfer_event=transfer_event_2,
             transfer_source_event=IDXTransferSourceEventType.UNLOCK,
-            transfer_event_data={"message": "unlock"},
+            transfer_event_data={"message": "force_unlock"},
         )
 
         session.commit()
@@ -930,6 +947,7 @@ class TestTokenTransferHistorySearch:
         assert data[0]["value"] == transfer_event_1["value"]
         assert data[0]["source_event"] == IDXTransferSourceEventType.TRANSFER.value
         assert data[0]["data"] is None
+        assert data[0]["message"] is None
 
     # Normal_4_1_1
     # Transferイベントあり：2件
@@ -968,7 +986,7 @@ class TestTokenTransferHistorySearch:
             session=session,
             transfer_event=transfer_event_2,
             transfer_source_event=IDXTransferSourceEventType.UNLOCK,
-            transfer_event_data={"message": "unlock"},
+            transfer_event_data={"message": "force_unlock"},
         )
 
         # ３件目
@@ -1019,7 +1037,8 @@ class TestTokenTransferHistorySearch:
         assert data[0]["to_address"] == transfer_event_2["to_address"]
         assert data[0]["value"] == transfer_event_2["value"]
         assert data[0]["source_event"] == IDXTransferSourceEventType.UNLOCK.value
-        assert data[0]["data"] == {"message": "unlock"}
+        assert data[0]["data"] == {"message": "force_unlock"}
+        assert data[0]["message"] == "force_unlock"
 
         assert data[1]["transaction_hash"] == transfer_event_1["transaction_hash"]
         assert data[1]["token_address"] == transfer_event_1["token_address"]
@@ -1028,6 +1047,7 @@ class TestTokenTransferHistorySearch:
         assert data[1]["value"] == transfer_event_1["value"]
         assert data[1]["source_event"] == IDXTransferSourceEventType.TRANSFER.value
         assert data[1]["data"] is None
+        assert data[1]["message"] is None
 
         assert data[2]["transaction_hash"] == transfer_event_3["transaction_hash"]
         assert data[2]["token_address"] == transfer_event_3["token_address"]
@@ -1036,6 +1056,7 @@ class TestTokenTransferHistorySearch:
         assert data[2]["value"] == transfer_event_3["value"]
         assert data[2]["source_event"] == IDXTransferSourceEventType.TRANSFER.value
         assert data[2]["data"] is None
+        assert data[2]["message"] is None
 
     # Normal_4_1_2
     # Transferイベントあり：2件
@@ -1074,7 +1095,7 @@ class TestTokenTransferHistorySearch:
             session=session,
             transfer_event=transfer_event_2,
             transfer_source_event=IDXTransferSourceEventType.UNLOCK,
-            transfer_event_data={"message": "unlock"},
+            transfer_event_data={"message": "force_unlock"},
         )
 
         # ３件目
@@ -1142,7 +1163,7 @@ class TestTokenTransferHistorySearch:
         assert data[2]["to_address"] == transfer_event_2["to_address"]
         assert data[2]["value"] == transfer_event_2["value"]
         assert data[2]["source_event"] == IDXTransferSourceEventType.UNLOCK.value
-        assert data[2]["data"] == {"message": "unlock"}
+        assert data[2]["data"] == {"message": "force_unlock"}
 
     # Normal_4_2_1
     # Transferイベントあり：2件
@@ -1181,7 +1202,7 @@ class TestTokenTransferHistorySearch:
             session=session,
             transfer_event=transfer_event_2,
             transfer_source_event=IDXTransferSourceEventType.UNLOCK,
-            transfer_event_data={"message": "unlock"},
+            transfer_event_data={"message": "force_unlock"},
         )
 
         # ３件目
@@ -1232,7 +1253,7 @@ class TestTokenTransferHistorySearch:
         assert data[0]["to_address"] == transfer_event_2["to_address"]
         assert data[0]["value"] == transfer_event_2["value"]
         assert data[0]["source_event"] == IDXTransferSourceEventType.UNLOCK.value
-        assert data[0]["data"] == {"message": "unlock"}
+        assert data[0]["data"] == {"message": "force_unlock"}
 
         assert data[1]["transaction_hash"] == transfer_event_1["transaction_hash"]
         assert data[1]["token_address"] == transfer_event_1["token_address"]
@@ -1287,7 +1308,7 @@ class TestTokenTransferHistorySearch:
             session=session,
             transfer_event=transfer_event_2,
             transfer_source_event=IDXTransferSourceEventType.UNLOCK,
-            transfer_event_data={"message": "unlock"},
+            transfer_event_data={"message": "force_unlock"},
         )
 
         # ３件目
@@ -1340,6 +1361,7 @@ class TestTokenTransferHistorySearch:
         assert data[0]["value"] == transfer_event_3["value"]
         assert data[0]["source_event"] == IDXTransferSourceEventType.TRANSFER.value
         assert data[0]["data"] is None
+        assert data[0]["message"] is None
 
         assert data[1]["transaction_hash"] == transfer_event_1["transaction_hash"]
         assert data[1]["token_address"] == transfer_event_1["token_address"]
@@ -1348,6 +1370,7 @@ class TestTokenTransferHistorySearch:
         assert data[1]["value"] == transfer_event_1["value"]
         assert data[1]["source_event"] == IDXTransferSourceEventType.TRANSFER.value
         assert data[1]["data"] is None
+        assert data[1]["message"] is None
 
         assert data[2]["transaction_hash"] == transfer_event_2["transaction_hash"]
         assert data[2]["token_address"] == transfer_event_2["token_address"]
@@ -1355,7 +1378,8 @@ class TestTokenTransferHistorySearch:
         assert data[2]["to_address"] == transfer_event_2["to_address"]
         assert data[2]["value"] == transfer_event_2["value"]
         assert data[2]["source_event"] == IDXTransferSourceEventType.UNLOCK.value
-        assert data[2]["data"] == {"message": "unlock"}
+        assert data[2]["data"] == {"message": "force_unlock"}
+        assert data[2]["message"] == "force_unlock"
 
     # Normal_4_3
     # Transferイベントあり：2件
@@ -1394,7 +1418,7 @@ class TestTokenTransferHistorySearch:
             session=session,
             transfer_event=transfer_event_2,
             transfer_source_event=IDXTransferSourceEventType.UNLOCK,
-            transfer_event_data={"message": "unlock"},
+            transfer_event_data={"message": "force_unlock"},
         )
 
         # ３件目
@@ -1450,7 +1474,7 @@ class TestTokenTransferHistorySearch:
         assert data[2]["to_address"] == transfer_event_2["to_address"]
         assert data[2]["value"] == transfer_event_2["value"]
         assert data[2]["source_event"] == IDXTransferSourceEventType.UNLOCK.value
-        assert data[2]["data"] == {"message": "unlock"}
+        assert data[2]["data"] == {"message": "force_unlock"}
 
     # Normal_4_4
     # Transferイベントあり：2件
@@ -1489,7 +1513,7 @@ class TestTokenTransferHistorySearch:
             session=session,
             transfer_event=transfer_event_2,
             transfer_source_event=IDXTransferSourceEventType.UNLOCK,
-            transfer_event_data={"message": "unlock"},
+            transfer_event_data={"message": "force_unlock"},
         )
 
         # ３件目
@@ -1545,7 +1569,7 @@ class TestTokenTransferHistorySearch:
         assert data[2]["to_address"] == transfer_event_2["to_address"]
         assert data[2]["value"] == transfer_event_2["value"]
         assert data[2]["source_event"] == IDXTransferSourceEventType.UNLOCK.value
-        assert data[2]["data"] == {"message": "unlock"}
+        assert data[2]["data"] == {"message": "force_unlock"}
 
     # Normal_4_5
     # Transferイベントあり：2件
@@ -1585,7 +1609,7 @@ class TestTokenTransferHistorySearch:
             session=session,
             transfer_event=transfer_event_2,
             transfer_source_event=IDXTransferSourceEventType.UNLOCK,
-            transfer_event_data={"message": "unlock"},
+            transfer_event_data={"message": "force_unlock"},
             created=datetime(2023, 11, 6, 20, 0, 1),
         )
 
@@ -1628,6 +1652,7 @@ class TestTokenTransferHistorySearch:
         assert data[0]["value"] == transfer_event_3["value"]
         assert data[0]["source_event"] == IDXTransferSourceEventType.TRANSFER.value
         assert data[0]["data"] is None
+        assert data[0]["message"] is None
 
         assert data[1]["transaction_hash"] == transfer_event_2["transaction_hash"]
         assert data[1]["token_address"] == transfer_event_2["token_address"]
@@ -1635,7 +1660,8 @@ class TestTokenTransferHistorySearch:
         assert data[1]["to_address"] == transfer_event_2["to_address"]
         assert data[1]["value"] == transfer_event_2["value"]
         assert data[1]["source_event"] == IDXTransferSourceEventType.UNLOCK.value
-        assert data[1]["data"] == {"message": "unlock"}
+        assert data[1]["data"] == {"message": "force_unlock"}
+        assert data[1]["message"] == "force_unlock"
 
         assert data[2]["transaction_hash"] == transfer_event_1["transaction_hash"]
         assert data[2]["token_address"] == transfer_event_1["token_address"]
@@ -1644,6 +1670,7 @@ class TestTokenTransferHistorySearch:
         assert data[2]["value"] == transfer_event_1["value"]
         assert data[2]["source_event"] == IDXTransferSourceEventType.TRANSFER.value
         assert data[2]["data"] is None
+        assert data[2]["message"] is None
 
     # Normal_5_1
     # offset=1, limit=設定なし
@@ -1682,7 +1709,7 @@ class TestTokenTransferHistorySearch:
             session=session,
             transfer_event=transfer_event_2,
             transfer_source_event=IDXTransferSourceEventType.UNLOCK,
-            transfer_event_data={"message": "unlock"},
+            transfer_event_data={"message": "force_unlock"},
         )
 
         session.commit()
@@ -1707,7 +1734,8 @@ class TestTokenTransferHistorySearch:
         assert data[0]["to_address"] == transfer_event_2["to_address"]
         assert data[0]["value"] == transfer_event_2["value"]
         assert data[0]["source_event"] == IDXTransferSourceEventType.UNLOCK.value
-        assert data[0]["data"] == {"message": "unlock"}
+        assert data[0]["data"] == {"message": "force_unlock"}
+        assert data[0]["message"] == "force_unlock"
 
     # Normal_5_2
     # offset=0, limit=設定なし
@@ -1746,7 +1774,7 @@ class TestTokenTransferHistorySearch:
             session=session,
             transfer_event=transfer_event_2,
             transfer_source_event=IDXTransferSourceEventType.UNLOCK,
-            transfer_event_data={"message": "unlock"},
+            transfer_event_data={"message": "force_unlock"},
         )
 
         session.commit()
@@ -1772,6 +1800,7 @@ class TestTokenTransferHistorySearch:
         assert data[0]["value"] == transfer_event_1["value"]
         assert data[0]["source_event"] == IDXTransferSourceEventType.TRANSFER.value
         assert data[0]["data"] is None
+        assert data[0]["message"] is None
 
         assert data[1]["transaction_hash"] == transfer_event_2["transaction_hash"]
         assert data[1]["token_address"] == transfer_event_2["token_address"]
@@ -1779,7 +1808,8 @@ class TestTokenTransferHistorySearch:
         assert data[1]["to_address"] == transfer_event_2["to_address"]
         assert data[1]["value"] == transfer_event_2["value"]
         assert data[1]["source_event"] == IDXTransferSourceEventType.UNLOCK.value
-        assert data[1]["data"] == {"message": "unlock"}
+        assert data[1]["data"] == {"message": "force_unlock"}
+        assert data[1]["message"] == "force_unlock"
 
     # Normal_5_3
     # offset =設定なし, limit=1
@@ -1818,7 +1848,7 @@ class TestTokenTransferHistorySearch:
             session=session,
             transfer_event=transfer_event_2,
             transfer_source_event=IDXTransferSourceEventType.UNLOCK,
-            transfer_event_data={"message": "unlock"},
+            transfer_event_data={"message": "force_unlock"},
         )
 
         session.commit()
@@ -1844,6 +1874,7 @@ class TestTokenTransferHistorySearch:
         assert data[0]["value"] == transfer_event_1["value"]
         assert data[0]["source_event"] == IDXTransferSourceEventType.TRANSFER.value
         assert data[0]["data"] is None
+        assert data[0]["message"] is None
 
     ####################################################################
     # Error

--- a/tests/app/token_TransferHistory_test.py
+++ b/tests/app/token_TransferHistory_test.py
@@ -64,6 +64,11 @@ class TestTokenTransferHistory:
         _transfer.value = transfer_event["value"]
         _transfer.source_event = transfer_source_event.value
         _transfer.data = transfer_event_data
+        _transfer.message = (
+            transfer_event_data.get("message")
+            if transfer_event_data is not None
+            else None
+        )
         if created is not None:
             _transfer.created = created
         session.add(_transfer)
@@ -176,7 +181,7 @@ class TestTokenTransferHistory:
             session=session,
             transfer_event=transfer_event_2,
             transfer_source_event=IDXTransferSourceEventType.UNLOCK,
-            transfer_event_data={"message": "unlock"},
+            transfer_event_data={"message": "force_unlock"},
         )
 
         session.commit()
@@ -202,6 +207,7 @@ class TestTokenTransferHistory:
         assert data[0]["value"] == transfer_event_1["value"]
         assert data[0]["source_event"] == IDXTransferSourceEventType.TRANSFER.value
         assert data[0]["data"] is None
+        assert data[0]["message"] is None
 
         assert data[1]["transaction_hash"] == transfer_event_2["transaction_hash"]
         assert data[1]["token_address"] == transfer_event_2["token_address"]
@@ -209,7 +215,8 @@ class TestTokenTransferHistory:
         assert data[1]["to_address"] == transfer_event_2["to_address"]
         assert data[1]["value"] == transfer_event_2["value"]
         assert data[1]["source_event"] == IDXTransferSourceEventType.UNLOCK.value
-        assert data[1]["data"] == {"message": "unlock"}
+        assert data[1]["data"] == {"message": "force_unlock"}
+        assert data[1]["message"] == "force_unlock"
 
     # Normal_3_2_1
     # Transferイベントあり：2件
@@ -255,7 +262,7 @@ class TestTokenTransferHistory:
             session=session,
             transfer_event=transfer_event_2,
             transfer_source_event=IDXTransferSourceEventType.UNLOCK,
-            transfer_event_data={"message": "unlock"},
+            transfer_event_data={"message": "force_unlock"},
         )
 
         session.commit()
@@ -283,6 +290,7 @@ class TestTokenTransferHistory:
         assert data[0]["value"] == transfer_event_1["value"]
         assert data[0]["source_event"] == IDXTransferSourceEventType.TRANSFER.value
         assert data[0]["data"] is None
+        assert data[0]["message"] is None
 
         assert data[1]["transaction_hash"] == transfer_event_2["transaction_hash"]
         assert data[1]["token_address"] == transfer_event_2["token_address"]
@@ -290,7 +298,8 @@ class TestTokenTransferHistory:
         assert data[1]["to_address"] == transfer_event_2["to_address"]
         assert data[1]["value"] == transfer_event_2["value"]
         assert data[1]["source_event"] == IDXTransferSourceEventType.UNLOCK.value
-        assert data[1]["data"] == {"message": "unlock"}
+        assert data[1]["data"] == {"message": "force_unlock"}
+        assert data[1]["message"] == "force_unlock"
 
     # Normal_3_2_2
     # Transferイベントあり：2件
@@ -336,7 +345,7 @@ class TestTokenTransferHistory:
             session=session,
             transfer_event=transfer_event_2,
             transfer_source_event=IDXTransferSourceEventType.UNLOCK,
-            transfer_event_data={"message": "unlock"},
+            transfer_event_data={"message": "force_unlock"},
         )
 
         session.commit()
@@ -364,6 +373,7 @@ class TestTokenTransferHistory:
         assert data[0]["value"] == transfer_event_1["value"]
         assert data[0]["source_event"] == IDXTransferSourceEventType.TRANSFER.value
         assert data[0]["data"] is None
+        assert data[0]["message"] is None
 
         assert data[1]["transaction_hash"] == transfer_event_2["transaction_hash"]
         assert data[1]["token_address"] == transfer_event_2["token_address"]
@@ -371,7 +381,8 @@ class TestTokenTransferHistory:
         assert data[1]["to_address"] == transfer_event_2["to_address"]
         assert data[1]["value"] == transfer_event_2["value"]
         assert data[1]["source_event"] == IDXTransferSourceEventType.UNLOCK.value
-        assert data[1]["data"] == {"message": "unlock"}
+        assert data[1]["data"] == {"message": "force_unlock"}
+        assert data[1]["message"] == "force_unlock"
 
     # Normal_3_2_3
     # Transferイベントあり：2件
@@ -410,7 +421,7 @@ class TestTokenTransferHistory:
             session=session,
             transfer_event=transfer_event_2,
             transfer_source_event=IDXTransferSourceEventType.UNLOCK,
-            transfer_event_data={"message": "unlock"},
+            transfer_event_data={"message": "force_unlock"},
         )
 
         session.commit()
@@ -468,7 +479,7 @@ class TestTokenTransferHistory:
             session=session,
             transfer_event=transfer_event_2,
             transfer_source_event=IDXTransferSourceEventType.UNLOCK,
-            transfer_event_data={"message": "unlock"},
+            transfer_event_data={"message": "force_unlock"},
         )
 
         session.commit()
@@ -495,7 +506,8 @@ class TestTokenTransferHistory:
         assert data[0]["to_address"] == transfer_event_2["to_address"]
         assert data[0]["value"] == transfer_event_2["value"]
         assert data[0]["source_event"] == IDXTransferSourceEventType.UNLOCK.value
-        assert data[0]["data"] == {"message": "unlock"}
+        assert data[0]["data"] == {"message": "force_unlock"}
+        assert data[0]["message"] == "force_unlock"
 
     # Normal_4_2
     # Transferイベントあり：2件
@@ -534,13 +546,13 @@ class TestTokenTransferHistory:
             session=session,
             transfer_event=transfer_event_2,
             transfer_source_event=IDXTransferSourceEventType.UNLOCK,
-            transfer_event_data={"message": "unlock"},
+            transfer_event_data={"message": "force_unlock"},
         )
 
         session.commit()
 
         apiurl = self.apiurl_base.format(contract_address=self.token_address)
-        resp = client.get(apiurl, params={"data": "unlock"})
+        resp = client.get(apiurl, params={"data": "force_unlock"})
 
         assert resp.status_code == 200
         assert resp.json()["meta"] == {"code": 200, "message": "OK"}
@@ -559,7 +571,8 @@ class TestTokenTransferHistory:
         assert data[0]["to_address"] == transfer_event_2["to_address"]
         assert data[0]["value"] == transfer_event_2["value"]
         assert data[0]["source_event"] == IDXTransferSourceEventType.UNLOCK.value
-        assert data[0]["data"] == {"message": "unlock"}
+        assert data[0]["data"] == {"message": "force_unlock"}
+        assert data[0]["message"] == "force_unlock"
 
     # Normal_4_3_1
     # Transferイベントあり：2件
@@ -598,7 +611,7 @@ class TestTokenTransferHistory:
             session=session,
             transfer_event=transfer_event_2,
             transfer_source_event=IDXTransferSourceEventType.UNLOCK,
-            transfer_event_data={"message": "unlock"},
+            transfer_event_data={"message": "force_unlock"},
         )
         session.commit()
 
@@ -623,6 +636,7 @@ class TestTokenTransferHistory:
         assert data[0]["value"] == transfer_event_1["value"]
         assert data[0]["source_event"] == IDXTransferSourceEventType.TRANSFER.value
         assert data[0]["data"] is None
+        assert data[0]["message"] is None
 
     # Normal_4_3_2
     # Transferイベントあり：2件
@@ -661,7 +675,7 @@ class TestTokenTransferHistory:
             session=session,
             transfer_event=transfer_event_2,
             transfer_source_event=IDXTransferSourceEventType.UNLOCK,
-            transfer_event_data={"message": "unlock"},
+            transfer_event_data={"message": "force_unlock"},
         )
         session.commit()
 
@@ -685,7 +699,8 @@ class TestTokenTransferHistory:
         assert data[0]["to_address"] == transfer_event_2["to_address"]
         assert data[0]["value"] == transfer_event_2["value"]
         assert data[0]["source_event"] == IDXTransferSourceEventType.UNLOCK.value
-        assert data[0]["data"] == {"message": "unlock"}
+        assert data[0]["data"] == {"message": "force_unlock"}
+        assert data[0]["message"] == "force_unlock"
 
     # Normal_4_3_3
     # Transferイベントあり：2件
@@ -724,7 +739,7 @@ class TestTokenTransferHistory:
             session=session,
             transfer_event=transfer_event_2,
             transfer_source_event=IDXTransferSourceEventType.UNLOCK,
-            transfer_event_data={"message": "unlock"},
+            transfer_event_data={"message": "force_unlock"},
         )
         session.commit()
 
@@ -749,6 +764,7 @@ class TestTokenTransferHistory:
         assert data[0]["value"] == transfer_event_1["value"]
         assert data[0]["source_event"] == IDXTransferSourceEventType.TRANSFER.value
         assert data[0]["data"] is None
+        assert data[0]["message"] is None
 
     # Normal_4_4
     # Transferイベントあり：2件
@@ -787,7 +803,7 @@ class TestTokenTransferHistory:
             session=session,
             transfer_event=transfer_event_2,
             transfer_source_event=IDXTransferSourceEventType.UNLOCK,
-            transfer_event_data={"message": "unlock"},
+            transfer_event_data={"message": "force_unlock"},
         )
 
         session.commit()
@@ -815,6 +831,7 @@ class TestTokenTransferHistory:
         assert data[0]["value"] == transfer_event_1["value"]
         assert data[0]["source_event"] == IDXTransferSourceEventType.TRANSFER.value
         assert data[0]["data"] is None
+        assert data[0]["message"] is None
 
     # Normal_4_5
     # Transferイベントあり：2件
@@ -853,7 +870,7 @@ class TestTokenTransferHistory:
             session=session,
             transfer_event=transfer_event_2,
             transfer_source_event=IDXTransferSourceEventType.UNLOCK,
-            transfer_event_data={"message": "unlock"},
+            transfer_event_data={"message": "force_unlock"},
         )
 
         session.commit()
@@ -879,6 +896,7 @@ class TestTokenTransferHistory:
         assert data[0]["value"] == transfer_event_1["value"]
         assert data[0]["source_event"] == IDXTransferSourceEventType.TRANSFER.value
         assert data[0]["data"] is None
+        assert data[0]["message"] is None
 
     # Normal_4_6
     # Transferイベントあり：2件
@@ -917,7 +935,7 @@ class TestTokenTransferHistory:
             session=session,
             transfer_event=transfer_event_2,
             transfer_source_event=IDXTransferSourceEventType.UNLOCK,
-            transfer_event_data={"message": "unlock"},
+            transfer_event_data={"message": "force_unlock"},
         )
 
         session.commit()
@@ -943,6 +961,7 @@ class TestTokenTransferHistory:
         assert data[0]["value"] == transfer_event_1["value"]
         assert data[0]["source_event"] == IDXTransferSourceEventType.TRANSFER.value
         assert data[0]["data"] is None
+        assert data[0]["message"] is None
 
     # Normal_4_7
     # Transferイベントあり : 2件
@@ -985,7 +1004,7 @@ class TestTokenTransferHistory:
             session=session,
             transfer_event=transfer_event_2,
             transfer_source_event=IDXTransferSourceEventType.UNLOCK,
-            transfer_event_data={"message": "unlock"},
+            transfer_event_data={"message": "force_unlock"},
             created=base_time - timedelta(seconds=1),
         )
 
@@ -1011,6 +1030,7 @@ class TestTokenTransferHistory:
         assert data[0]["value"] == transfer_event_1["value"]
         assert data[0]["source_event"] == IDXTransferSourceEventType.TRANSFER.value
         assert data[0]["data"] is None
+        assert data[0]["message"] is None
 
     # Normal_4_8
     # Transferイベントあり : 2件
@@ -1053,7 +1073,7 @@ class TestTokenTransferHistory:
             session=session,
             transfer_event=transfer_event_2,
             transfer_source_event=IDXTransferSourceEventType.UNLOCK,
-            transfer_event_data={"message": "unlock"},
+            transfer_event_data={"message": "force_unlock"},
             created=base_time + timedelta(seconds=1),
         )
 
@@ -1079,6 +1099,7 @@ class TestTokenTransferHistory:
         assert data[0]["value"] == transfer_event_1["value"]
         assert data[0]["source_event"] == IDXTransferSourceEventType.TRANSFER.value
         assert data[0]["data"] is None
+        assert data[0]["message"] is None
 
     # Normal_5_1
     # offset=1, limit=設定なし
@@ -1117,7 +1138,7 @@ class TestTokenTransferHistory:
             session=session,
             transfer_event=transfer_event_2,
             transfer_source_event=IDXTransferSourceEventType.UNLOCK,
-            transfer_event_data={"message": "unlock"},
+            transfer_event_data={"message": "force_unlock"},
         )
 
         session.commit()
@@ -1143,7 +1164,8 @@ class TestTokenTransferHistory:
         assert data[0]["to_address"] == transfer_event_2["to_address"]
         assert data[0]["value"] == transfer_event_2["value"]
         assert data[0]["source_event"] == IDXTransferSourceEventType.UNLOCK.value
-        assert data[0]["data"] == {"message": "unlock"}
+        assert data[0]["data"] == {"message": "force_unlock"}
+        assert data[0]["message"] == "force_unlock"
 
     # Normal_5_2
     # offset=0, limit=設定なし
@@ -1182,7 +1204,7 @@ class TestTokenTransferHistory:
             session=session,
             transfer_event=transfer_event_2,
             transfer_source_event=IDXTransferSourceEventType.UNLOCK,
-            transfer_event_data={"message": "unlock"},
+            transfer_event_data={"message": "force_unlock"},
         )
 
         session.commit()
@@ -1209,6 +1231,7 @@ class TestTokenTransferHistory:
         assert data[0]["value"] == transfer_event_1["value"]
         assert data[0]["source_event"] == IDXTransferSourceEventType.TRANSFER.value
         assert data[0]["data"] is None
+        assert data[0]["message"] is None
 
         assert data[1]["transaction_hash"] == transfer_event_2["transaction_hash"]
         assert data[1]["token_address"] == transfer_event_2["token_address"]
@@ -1216,7 +1239,8 @@ class TestTokenTransferHistory:
         assert data[1]["to_address"] == transfer_event_2["to_address"]
         assert data[1]["value"] == transfer_event_2["value"]
         assert data[1]["source_event"] == IDXTransferSourceEventType.UNLOCK.value
-        assert data[1]["data"] == {"message": "unlock"}
+        assert data[1]["data"] == {"message": "force_unlock"}
+        assert data[1]["message"] == "force_unlock"
 
     # Normal_5_3
     # offset =設定なし, limit=1
@@ -1255,7 +1279,7 @@ class TestTokenTransferHistory:
             session=session,
             transfer_event=transfer_event_2,
             transfer_source_event=IDXTransferSourceEventType.UNLOCK,
-            transfer_event_data={"message": "unlock"},
+            transfer_event_data={"message": "force_unlock"},
         )
 
         session.commit()
@@ -1282,6 +1306,7 @@ class TestTokenTransferHistory:
         assert data[0]["value"] == transfer_event_1["value"]
         assert data[0]["source_event"] == IDXTransferSourceEventType.TRANSFER.value
         assert data[0]["data"] is None
+        assert data[0]["message"] is None
 
     ####################################################################
     # Error

--- a/tests/batch/indexer_Transfer_test.py
+++ b/tests/batch/indexer_Transfer_test.py
@@ -264,6 +264,7 @@ class TestProcessor:
             token=share_token,
             lock_address=self.trader2["account_address"],
             amount=50000,
+            data_str=json.dumps({"message": "garnishment"}),
         )
         share_unlock(
             invoker=self.trader2,
@@ -271,7 +272,7 @@ class TestProcessor:
             target=self.trader["account_address"],
             recipient=self.trader2["account_address"],
             amount=50000,
-            data_str=json.dumps({"message": "unlock"}),
+            data_str=json.dumps({"invalid_message": "invalid_value"}),
         )
         block_number_2 = web3.eth.block_number
 
@@ -306,7 +307,8 @@ class TestProcessor:
         assert idx_transfer.to_address == self.trader2["account_address"]
         assert idx_transfer.value == 50000
         assert idx_transfer.source_event == IDXTransferSourceEventType.UNLOCK.value
-        assert idx_transfer.data == {"message": "unlock"}
+        assert idx_transfer.data == {}
+        assert idx_transfer.message is None
         assert idx_transfer.created is not None
         assert idx_transfer.modified is not None
 
@@ -355,6 +357,7 @@ class TestProcessor:
             token=share_token,
             lock_address=self.trader2["account_address"],
             amount=50000,
+            data_str=json.dumps({"message": "garnishment"}),
         )
         share_unlock(
             invoker=self.trader2,
@@ -362,6 +365,7 @@ class TestProcessor:
             target=self.trader["account_address"],
             recipient=self.trader["account_address"],
             amount=50000,
+            data_str=json.dumps({"message": "force_unlock"}),
         )
         block_number = web3.eth.block_number
 
@@ -434,6 +438,7 @@ class TestProcessor:
             token=share_token,
             lock_address=self.trader2["account_address"],
             amount=100000,
+            data_str=json.dumps({"message": "garnishment"}),
         )
         share_unlock(
             invoker=self.trader2,
@@ -441,7 +446,7 @@ class TestProcessor:
             target=self.trader["account_address"],
             recipient=self.trader2["account_address"],
             amount=50000,
-            data_str=json.dumps({"message": "unlock"}),
+            data_str=json.dumps({"message": "force_unlock"}),
         )
         block_number_3 = web3.eth.block_number
 
@@ -451,7 +456,7 @@ class TestProcessor:
             target=self.trader["account_address"],
             recipient=self.trader2["account_address"],
             amount=50000,
-            data_str=json.dumps({"message": "unlock"}),
+            data_str=json.dumps({"message": "force_unlock"}),
         )
         block_number_4 = web3.eth.block_number
 
@@ -499,7 +504,8 @@ class TestProcessor:
         assert idx_transfer.to_address == self.trader2["account_address"]
         assert idx_transfer.value == 50000
         assert idx_transfer.source_event == IDXTransferSourceEventType.UNLOCK.value
-        assert idx_transfer.data == {"message": "unlock"}
+        assert idx_transfer.data == {"message": "force_unlock"}
+        assert idx_transfer.message == "force_unlock"
         assert idx_transfer.created is not None
         assert idx_transfer.modified is not None
 
@@ -512,7 +518,8 @@ class TestProcessor:
         assert idx_transfer.to_address == self.trader2["account_address"]
         assert idx_transfer.value == 50000
         assert idx_transfer.source_event == IDXTransferSourceEventType.UNLOCK.value
-        assert idx_transfer.data == {"message": "unlock"}
+        assert idx_transfer.data == {"message": "force_unlock"}
+        assert idx_transfer.message == "force_unlock"
         assert idx_transfer.created is not None
         assert idx_transfer.modified is not None
 

--- a/tests/contract_modules.py
+++ b/tests/contract_modules.py
@@ -482,11 +482,11 @@ def share_approve_transfer(invoker, token, application_id, application_data):
 
 
 # SHAREトークン：資産ロック
-def share_lock(invoker, token, lock_address: str, amount: int):
+def share_lock(invoker, token, lock_address: str, amount: int, data_str: str = ""):
     web3.eth.default_account = invoker["account_address"]
 
     TokenContract = Contract.get_contract("IbetShare", token["address"])
-    TokenContract.functions.lock(lock_address, amount, "").transact(
+    TokenContract.functions.lock(lock_address, amount, data_str).transact(
         {"from": invoker["account_address"]}
     )
 

--- a/tests/contract_modules.py
+++ b/tests/contract_modules.py
@@ -277,10 +277,10 @@ def bond_approve_transfer(invoker, token, application_id, application_data):
 
 
 # BONDトークン：資産ロック
-def bond_lock(invoker, token, lock_address: str, amount: int):
+def bond_lock(invoker, token, lock_address: str, amount: int, data_str: str = ""):
     web3.eth.default_account = invoker["account_address"]
     TokenContract = Contract.get_contract("IbetStraightBond", token["address"])
-    TokenContract.functions.lock(lock_address, amount, "").transact(
+    TokenContract.functions.lock(lock_address, amount, data_str).transact(
         {"from": invoker["account_address"]}
     )
 


### PR DESCRIPTION
- Updated the data schema of lock/unlock contract event to classify transfer data derived from Unlock events
- Ref: https://github.com/BoostryJP/ibet-Prime/pull/713 