### PR TITLE
Release free memory back to the OS with malloc_trim

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -17,6 +17,9 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
+import ctypes
+from ctypes.util import find_library
+
 from fastapi import FastAPI, Request, status
 from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError
@@ -100,6 +103,8 @@ app = FastAPI(
 
 app.openapi = custom_openapi(app)  # type: ignore
 
+libc = ctypes.CDLL(find_library("c"))
+
 
 ###############################################################
 # ROUTER
@@ -108,6 +113,7 @@ app.openapi = custom_openapi(app)  # type: ignore
 
 @app.get("/", tags=["root"])
 def root():
+    libc.malloc_trim(0)
     return {"server": BRAND_NAME}
 
 

--- a/batch/__init__.py
+++ b/batch/__init__.py
@@ -16,3 +16,12 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 """
+
+import ctypes
+from ctypes.util import find_library
+
+libc = ctypes.CDLL(find_library("c"))
+
+
+def free_malloc():
+    libc.malloc_trim(0)

--- a/batch/indexer_Block_Tx_Data.py
+++ b/batch/indexer_Block_Tx_Data.py
@@ -32,7 +32,7 @@ from app.database import BatchAsyncSessionLocal
 from app.errors import ServiceUnavailable
 from app.model.db import IDXBlockData, IDXBlockDataBlockNumber, IDXTxData
 from app.utils.web3_utils import AsyncWeb3Wrapper
-from batch import log
+from batch import free_malloc, log
 
 process_name = "INDEXER-BLOCK_TX_DATA"
 LOG = log.get_logger(process_name=process_name)
@@ -161,6 +161,7 @@ async def main():
             LOG.exception("An exception occurred during event synchronization")
 
         await asyncio.sleep(5)
+        free_malloc()
 
 
 if __name__ == "__main__":

--- a/batch/indexer_CompanyList.py
+++ b/batch/indexer_CompanyList.py
@@ -33,7 +33,7 @@ from app.config import COMPANY_LIST_SLEEP_INTERVAL, COMPANY_LIST_URL, REQUEST_TI
 from app.database import BatchAsyncSessionLocal
 from app.errors import ServiceUnavailable
 from app.model.db import Company
-from batch import log
+from batch import free_malloc, log
 
 process_name = "INDEXER-COMPANY-LIST"
 LOG = log.get_logger(process_name=process_name)
@@ -155,6 +155,7 @@ async def main():
 
         elapsed_time = time.time() - start_time
         await asyncio.sleep(max(COMPANY_LIST_SLEEP_INTERVAL - elapsed_time, 0))
+        free_malloc()
 
 
 if __name__ == "__main__":

--- a/batch/indexer_Consume_Coupon.py
+++ b/batch/indexer_Consume_Coupon.py
@@ -36,7 +36,7 @@ from app.errors import ServiceUnavailable
 from app.model.db import IDXConsumeCoupon, Listing
 from app.model.schema.base import TokenType
 from app.utils.web3_utils import AsyncWeb3Wrapper
-from batch import log
+from batch import free_malloc, log
 
 local_tz = ZoneInfo(TZ)
 
@@ -241,6 +241,7 @@ async def main():
             LOG.exception("An exception occurred during event synchronization")
 
         await asyncio.sleep(10)
+        free_malloc()
 
 
 if __name__ == "__main__":

--- a/batch/indexer_DEX.py
+++ b/batch/indexer_DEX.py
@@ -42,7 +42,7 @@ from app.model.db import (
     Listing,
 )
 from app.utils.web3_utils import AsyncWeb3Wrapper
-from batch import log
+from batch import free_malloc, log
 
 local_tz = ZoneInfo(TZ)
 
@@ -529,6 +529,7 @@ async def main():
             LOG.exception("An exception occurred during event synchronization")
 
         await asyncio.sleep(1)
+        free_malloc()
 
 
 if __name__ == "__main__":

--- a/batch/indexer_Position_Bond.py
+++ b/batch/indexer_Position_Bond.py
@@ -47,7 +47,7 @@ from app.model.db import (
 from app.model.schema.base import TokenType
 from app.utils.asyncio_utils import SemaphoreTaskGroup
 from app.utils.web3_utils import AsyncWeb3Wrapper
-from batch import log
+from batch import free_malloc, log
 
 UTC = timezone(timedelta(hours=0), "UTC")
 
@@ -1725,6 +1725,7 @@ async def main():
             LOG.exception("An exception occurred during event synchronization")
 
         await asyncio.sleep(10)
+        free_malloc()
 
 
 if __name__ == "__main__":

--- a/batch/indexer_Position_Coupon.py
+++ b/batch/indexer_Position_Coupon.py
@@ -37,7 +37,7 @@ from app.model.db import IDXPosition, IDXPositionCouponBlockNumber, Listing
 from app.model.schema.base import TokenType
 from app.utils.asyncio_utils import SemaphoreTaskGroup
 from app.utils.web3_utils import AsyncWeb3Wrapper
-from batch import log
+from batch import free_malloc, log
 
 process_name = "INDEXER-POSITION-COUPON"
 LOG = log.get_logger(process_name=process_name)
@@ -1056,6 +1056,7 @@ async def main():
             LOG.exception("An exception occurred during event synchronization")
 
         await asyncio.sleep(10)
+        free_malloc()
 
 
 if __name__ == "__main__":

--- a/batch/indexer_Position_Membership.py
+++ b/batch/indexer_Position_Membership.py
@@ -37,7 +37,7 @@ from app.model.db import IDXPosition, IDXPositionMembershipBlockNumber, Listing
 from app.model.schema.base import TokenType
 from app.utils.asyncio_utils import SemaphoreTaskGroup
 from app.utils.web3_utils import AsyncWeb3Wrapper
-from batch import log
+from batch import free_malloc, log
 
 process_name = "INDEXER-POSITION-MEMBERSHIP"
 LOG = log.get_logger(process_name=process_name)
@@ -1020,6 +1020,7 @@ async def main():
             LOG.exception("An exception occurred during event synchronization")
 
         await asyncio.sleep(10)
+        free_malloc()
 
 
 if __name__ == "__main__":

--- a/batch/indexer_Position_Share.py
+++ b/batch/indexer_Position_Share.py
@@ -47,7 +47,7 @@ from app.model.db import (
 from app.model.schema.base import TokenType
 from app.utils.asyncio_utils import SemaphoreTaskGroup
 from app.utils.web3_utils import AsyncWeb3Wrapper
-from batch import log
+from batch import free_malloc, log
 
 UTC = timezone(timedelta(hours=0), "UTC")
 
@@ -1725,6 +1725,7 @@ async def main():
             LOG.exception("An exception occurred during event synchronization")
 
         await asyncio.sleep(10)
+        free_malloc()
 
 
 if __name__ == "__main__":

--- a/batch/indexer_Token_Detail.py
+++ b/batch/indexer_Token_Detail.py
@@ -37,7 +37,7 @@ from app.model.blockchain import BondToken, CouponToken, MembershipToken, ShareT
 from app.model.blockchain.token import TokenClassTypes
 from app.model.db import IDXTokenListItem, Listing
 from app.model.schema.base import TokenType
-from batch import log
+from batch import free_malloc, log
 
 process_name = "INDEXER-TOKEN-DETAIL"
 LOG = log.get_logger(process_name=process_name)
@@ -156,6 +156,7 @@ async def main():
         if time_to_sleep == 0:
             LOG.debug("Processing is delayed")
         await asyncio.sleep(time_to_sleep)
+        free_malloc()
 
 
 if __name__ == "__main__":

--- a/batch/indexer_Token_Detail_ShortTerm.py
+++ b/batch/indexer_Token_Detail_ShortTerm.py
@@ -47,7 +47,7 @@ from app.model.db import (
     Listing,
 )
 from app.model.schema.base import TokenType
-from batch import log
+from batch import free_malloc, log
 
 process_name = "INDEXER-TOKEN-DETAIL-SHORT-TERM"
 LOG = log.get_logger(process_name=process_name)
@@ -171,6 +171,7 @@ async def main():
         if time_to_sleep == 0:
             LOG.debug("Processing is delayed")
         await asyncio.sleep(time_to_sleep)
+        free_malloc()
 
 
 if __name__ == "__main__":

--- a/batch/indexer_Token_Holders.py
+++ b/batch/indexer_Token_Holders.py
@@ -34,7 +34,7 @@ from app.errors import ServiceUnavailable
 from app.model.db import TokenHolder, TokenHolderBatchStatus, TokenHoldersList
 from app.model.schema.base import TokenType
 from app.utils.web3_utils import AsyncWeb3Wrapper
-from batch import log
+from batch import free_malloc, log
 from batch.lib.token_list import TokenList
 
 process_name = "INDEXER-TOKEN_HOLDERS"
@@ -563,6 +563,7 @@ async def main():
             LOG.exception("An exception occurred during event synchronization")
 
         await asyncio.sleep(10)
+        free_malloc()
 
 
 if __name__ == "__main__":

--- a/batch/indexer_Token_List.py
+++ b/batch/indexer_Token_List.py
@@ -33,7 +33,7 @@ from app.errors import ServiceUnavailable
 from app.model.db import IDXTokenListBlockNumber, IDXTokenListItem
 from app.model.schema.base import TokenType
 from app.utils.web3_utils import AsyncWeb3Wrapper
-from batch import log
+from batch import free_malloc, log
 
 process_name = "INDEXER-TOKEN-LIST"
 LOG = log.get_logger(process_name=process_name)
@@ -229,6 +229,7 @@ async def main():
             LOG.exception("An exception occurred during event synchronization")
 
         await asyncio.sleep(5)
+        free_malloc()
 
 
 if __name__ == "__main__":

--- a/batch/indexer_Transfer.py
+++ b/batch/indexer_Transfer.py
@@ -44,7 +44,7 @@ from app.model.db import (
 )
 from app.model.schema.base import TokenType
 from app.utils.web3_utils import AsyncWeb3Wrapper
-from batch import log
+from batch import free_malloc, log
 
 UTC = timezone(timedelta(hours=0), "UTC")
 
@@ -495,6 +495,7 @@ async def main():
         except Exception:
             LOG.exception("An exception occurred during event synchronization")
         await asyncio.sleep(5)
+        free_malloc()
 
 
 if __name__ == "__main__":

--- a/batch/indexer_TransferApproval.py
+++ b/batch/indexer_TransferApproval.py
@@ -35,7 +35,7 @@ from app.errors import ServiceUnavailable
 from app.model.db import IDXTransferApproval, IDXTransferApprovalBlockNumber, Listing
 from app.model.schema.base import TokenType
 from app.utils.web3_utils import AsyncWeb3Wrapper
-from batch import log
+from batch import free_malloc, log
 
 process_name = "INDEXER-TRANSFER-APPROVAL"
 LOG = log.get_logger(process_name=process_name)
@@ -813,6 +813,7 @@ async def main():
             LOG.exception("An exception occurred during event synchronization")
 
         await asyncio.sleep(5)
+        free_malloc()
 
 
 if __name__ == "__main__":

--- a/batch/processor_Block_Sync_Status.py
+++ b/batch/processor_Block_Sync_Status.py
@@ -30,7 +30,7 @@ from web3.types import RPCEndpoint, RPCResponse
 from app import config
 from app.config import EXPECTED_BLOCKS_PER_SEC
 from app.model.db import Node
-from batch import log
+from batch import free_malloc, log
 
 LOG = log.get_logger(process_name="PROCESSOR-BLOCK_SYNC_STATUS")
 
@@ -253,6 +253,7 @@ def main():
 
         elapsed_time = time.time() - start_time
         time.sleep(max(config.BLOCK_SYNC_STATUS_SLEEP_INTERVAL - elapsed_time, 0))
+        free_malloc()
 
 
 if __name__ == "__main__":

--- a/batch/processor_Notifications_Coupon_Exchange.py
+++ b/batch/processor_Notifications_Coupon_Exchange.py
@@ -42,7 +42,7 @@ from app.model.schema.base import TokenType
 from app.utils.asyncio_utils import SemaphoreTaskGroup
 from app.utils.company_list import CompanyList
 from app.utils.web3_utils import AsyncWeb3Wrapper
-from batch import log
+from batch import free_malloc, log
 from batch.lib.token import TokenFactory
 from batch.lib.token_list import TokenList
 
@@ -605,6 +605,7 @@ async def main():
         LOG.info("<LOOP> finished in {} secs".format(elapsed_time))
 
         time.sleep(max(NOTIFICATION_PROCESS_INTERVAL - elapsed_time, 0))
+        free_malloc()
 
 
 if __name__ == "__main__":

--- a/batch/processor_Notifications_Membership_Exchange.py
+++ b/batch/processor_Notifications_Membership_Exchange.py
@@ -42,7 +42,7 @@ from app.model.schema.base import TokenType
 from app.utils.asyncio_utils import SemaphoreTaskGroup
 from app.utils.company_list import CompanyList
 from app.utils.web3_utils import AsyncWeb3Wrapper
-from batch import log
+from batch import free_malloc, log
 from batch.lib.token import TokenFactory
 from batch.lib.token_list import TokenList
 
@@ -614,6 +614,7 @@ async def main():
         LOG.info("<LOOP> finished in {} secs".format(elapsed_time))
 
         time.sleep(max(NOTIFICATION_PROCESS_INTERVAL - elapsed_time, 0))
+        free_malloc()
 
 
 if __name__ == "__main__":

--- a/batch/processor_Notifications_Token.py
+++ b/batch/processor_Notifications_Token.py
@@ -48,7 +48,7 @@ from app.model.db import (
 from app.utils.asyncio_utils import SemaphoreTaskGroup
 from app.utils.company_list import CompanyList
 from app.utils.web3_utils import AsyncWeb3Wrapper
-from batch import log
+from batch import free_malloc, log
 from batch.lib.token_list import TokenList
 
 LOG = log.get_logger(process_name="PROCESSOR-NOTIFICATIONS-TOKEN")
@@ -459,6 +459,7 @@ async def main():
         LOG.info("<LOOP> finished in {} secs".format(elapsed_time))
 
         await asyncio.sleep(max(NOTIFICATION_PROCESS_INTERVAL - elapsed_time, 0))
+        free_malloc()
 
 
 if __name__ == "__main__":

--- a/batch/processor_Send_Chat_Webhook.py
+++ b/batch/processor_Send_Chat_Webhook.py
@@ -29,7 +29,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from app.config import CHAT_WEBHOOK_URL
 from app.database import BatchAsyncSessionLocal
 from app.model.db import ChatWebhook
-from batch import log
+from batch import free_malloc, log
 
 LOG = log.get_logger(process_name="PROCESSOR-SEND-CHAT-WEBHOOK")
 
@@ -73,6 +73,7 @@ async def main():
 
         elapsed_time = time.time() - start_time
         await asyncio.sleep(max(30 - elapsed_time, 0))
+        free_malloc()
 
 
 if __name__ == "__main__":

--- a/batch/processor_Send_Mail.py
+++ b/batch/processor_Send_Mail.py
@@ -30,7 +30,7 @@ from sqlalchemy.orm import Session
 from app import config
 from app.model.db import Mail
 from app.model.mail import File, Mail as SMTPMail
-from batch import log
+from batch import free_malloc, log
 
 LOG = log.get_logger(process_name="PROCESSOR-SEND-MAIL")
 
@@ -109,6 +109,7 @@ def main():
 
         elapsed_time = time.time() - start_time
         time.sleep(max(30 - elapsed_time, 0))
+        free_malloc()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When a Python process runs for an extended period, unused memory may not be released and returned to the OS. 
To address this, I have implemented periodic execution of `malloc_trim(0)` to free up unused heap memory as much as possible.