### PR TITLE
Refactor processor_Block_Sync_Status to use AsyncHTTPProvider

### DIFF
--- a/app/contracts/__init__.py
+++ b/app/contracts/__init__.py
@@ -18,6 +18,6 @@ SPDX-License-Identifier: Apache-2.0
 """
 
 from .abi import create_abi_event_argument_models
-from .contract import AsyncContract, Contract
+from .contract import AsyncContract
 
 contract_version = "v25.6.0"

--- a/conf/local.ini
+++ b/conf/local.ini
@@ -7,7 +7,7 @@ allowed_methods=GET,PUT,POST,DELETE,OPTIONS
 level=INFO
 
 [database]
-echo=yes
+echo=no
 
 [web3]
 chainid=2017

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dev-dependencies = [
     "pytest-alembic<1.0.0,>=0.10.7",
     "pytest-freezer<1.0.0,>=0.4.8",
     "textual-dev<2.0.0,>=1.2.1",
-    "pytest-asyncio==0.25.0",
+    "pytest-asyncio==0.26.0",
     "pytest-aiohttp<2.0.0,>=1.0.5",
     "ruamel-yaml<1.0.0,>=0.18.6",
     "pytest-memray<2.0.0,>=1.6.0",

--- a/tests/app/admin_Tokens_POST_test.py
+++ b/tests/app/admin_Tokens_POST_test.py
@@ -27,10 +27,10 @@ from web3 import Web3
 from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
-from app.contracts import Contract
 from app.model.db import ExecutableContract, IDXBondToken, IDXPosition, Listing
 from tests.account_config import eth_account
 from tests.contract_modules import issue_bond_token, register_bond_list
+from tests.utils.contract import Contract
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
 web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)

--- a/tests/app/company_info_ListAllCompanies_test.py
+++ b/tests/app/company_info_ListAllCompanies_test.py
@@ -26,7 +26,6 @@ from web3 import Web3
 from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
-from app.contracts import Contract
 from app.model.db import (
     Company,
     IDXBondToken,
@@ -46,6 +45,7 @@ from tests.contract_modules import (
     register_bond_list,
     register_share_list,
 )
+from tests.utils.contract import Contract
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
 web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)

--- a/tests/app/e2e_message_EncryptionKey_test.py
+++ b/tests/app/e2e_message_EncryptionKey_test.py
@@ -23,8 +23,8 @@ from web3 import Web3
 from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
-from app.contracts import Contract
 from tests.account_config import eth_account
+from tests.utils.contract import Contract
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
 web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)

--- a/tests/app/eth_SendRawTransactionNowait_test.py
+++ b/tests/app/eth_SendRawTransactionNowait_test.py
@@ -31,10 +31,10 @@ from web3.exceptions import Web3RPCError
 from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config, log
-from app.contracts import Contract
 from app.model.db import ExecutableContract, Listing, Node
 from tests.account_config import eth_account
 from tests.contract_modules import coupon_register_list, issue_coupon_token
+from tests.utils.contract import Contract
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
 web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)

--- a/tests/app/eth_SendRawTransaction_test.py
+++ b/tests/app/eth_SendRawTransaction_test.py
@@ -32,10 +32,10 @@ from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config, log
 from app.api.routers import eth
-from app.contracts import Contract
 from app.model.db import ExecutableContract, Listing, Node
 from tests.account_config import eth_account
 from tests.contract_modules import coupon_register_list, issue_coupon_token
+from tests.utils.contract import Contract
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
 web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)

--- a/tests/app/eth_WaitForTransactionReceipt_test.py
+++ b/tests/app/eth_WaitForTransactionReceipt_test.py
@@ -26,7 +26,6 @@ from web3 import Web3
 from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
-from app.contracts import Contract
 from app.model.db import ExecutableContract, Listing
 from tests.account_config import eth_account
 from tests.contract_modules import (
@@ -34,6 +33,7 @@ from tests.contract_modules import (
     issue_coupon_token,
     transfer_coupon_token,
 )
+from tests.utils.contract import Contract
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
 web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)

--- a/tests/app/events_E2EMessagingEvents_test.py
+++ b/tests/app/events_E2EMessagingEvents_test.py
@@ -26,8 +26,8 @@ from web3 import Web3
 from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
-from app.contracts import Contract
 from tests.account_config import eth_account
+from tests.utils.contract import Contract
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
 web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)

--- a/tests/app/events_IbetSecurityTokenInterfaceEvents_test.py
+++ b/tests/app/events_IbetSecurityTokenInterfaceEvents_test.py
@@ -26,7 +26,6 @@ from web3 import Web3
 from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
-from app.contracts import Contract
 from app.model.db import Listing
 from tests.account_config import eth_account
 from tests.contract_modules import (
@@ -50,6 +49,7 @@ from tests.contract_modules import (
     register_share_list,
     transfer_token,
 )
+from tests.utils.contract import Contract
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
 web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)

--- a/tests/app/position_PositionCouponContractAddress_test.py
+++ b/tests/app/position_PositionCouponContractAddress_test.py
@@ -25,7 +25,6 @@ from web3 import Web3
 from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
-from app.contracts import Contract
 from app.model.db import IDXTransfer, IDXTransferSourceEventType, Listing
 from tests.account_config import eth_account
 from tests.contract_modules import (
@@ -35,6 +34,7 @@ from tests.contract_modules import (
     issue_coupon_token,
     transfer_coupon_token,
 )
+from tests.utils.contract import Contract
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
 web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)

--- a/tests/app/position_PositionCoupon_test.py
+++ b/tests/app/position_PositionCoupon_test.py
@@ -25,7 +25,6 @@ from web3 import Web3
 from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
-from app.contracts import Contract
 from app.model.db import (
     IDXConsumeCoupon,
     IDXCouponToken,
@@ -43,6 +42,7 @@ from tests.contract_modules import (
     issue_coupon_token,
     transfer_coupon_token,
 )
+from tests.utils.contract import Contract
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
 web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)

--- a/tests/app/position_PositionMembershipContractAddress_test.py
+++ b/tests/app/position_PositionMembershipContractAddress_test.py
@@ -25,7 +25,6 @@ from web3 import Web3
 from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
-from app.contracts import Contract
 from app.model.db import Listing
 from tests.account_config import eth_account
 from tests.contract_modules import (
@@ -33,6 +32,7 @@ from tests.contract_modules import (
     membership_register_list,
     membership_transfer_to_exchange,
 )
+from tests.utils.contract import Contract
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
 web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)

--- a/tests/app/position_PositionMembership_test.py
+++ b/tests/app/position_PositionMembership_test.py
@@ -25,7 +25,6 @@ from web3 import Web3
 from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
-from app.contracts import Contract
 from app.model.db import IDXMembershipToken, IDXPosition, IDXTokenListRegister, Listing
 from tests.account_config import eth_account
 from tests.contract_modules import (
@@ -33,6 +32,7 @@ from tests.contract_modules import (
     membership_register_list,
     membership_transfer_to_exchange,
 )
+from tests.utils.contract import Contract
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
 web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)

--- a/tests/app/position_PositionStraightBondContractAddress_test.py
+++ b/tests/app/position_PositionStraightBondContractAddress_test.py
@@ -25,7 +25,6 @@ from web3 import Web3
 from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
-from app.contracts import Contract
 from app.model.db import IDXBondToken, IDXLockedPosition, IDXPosition, Listing
 from tests.account_config import eth_account
 from tests.contract_modules import (
@@ -36,6 +35,7 @@ from tests.contract_modules import (
     transfer_bond_token,
 )
 from tests.utils import PersonalInfoUtils
+from tests.utils.contract import Contract
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
 web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)

--- a/tests/app/position_PositionStraightBond_test.py
+++ b/tests/app/position_PositionStraightBond_test.py
@@ -25,7 +25,6 @@ from web3 import Web3
 from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
-from app.contracts import Contract
 from app.model.db import (
     IDXBondToken,
     IDXLockedPosition,
@@ -42,6 +41,7 @@ from tests.contract_modules import (
     transfer_bond_token,
 )
 from tests.utils import PersonalInfoUtils
+from tests.utils.contract import Contract
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
 web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)

--- a/tests/app/token_TokenHoldersCollectionId_test.py
+++ b/tests/app/token_TokenHoldersCollectionId_test.py
@@ -28,9 +28,9 @@ from web3 import Web3
 from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
-from app.contracts import Contract
 from app.model.db import Listing, TokenHolderBatchStatus, TokenHoldersList
 from batch.indexer_Token_Holders import Processor
+from tests.utils.contract import Contract
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
 web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)

--- a/tests/app/token_TokenHoldersCollection_test.py
+++ b/tests/app/token_TokenHoldersCollection_test.py
@@ -27,9 +27,9 @@ from web3 import Web3
 from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
-from app.contracts import Contract
 from app.model.db import Listing, TokenHolderBatchStatus, TokenHoldersList
 from batch.indexer_Token_Holders import Processor
+from tests.utils.contract import Contract
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
 web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)

--- a/tests/app/token_TokenStatus_test.py
+++ b/tests/app/token_TokenStatus_test.py
@@ -27,7 +27,6 @@ from web3 import Web3
 from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
-from app.contracts import Contract
 from app.errors import ServiceUnavailable
 from app.model.db import Listing
 from tests.account_config import eth_account
@@ -49,6 +48,7 @@ from tests.contract_modules import (
     untransferable_coupon_token,
     untransferable_share_token,
 )
+from tests.utils.contract import Contract
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
 web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)

--- a/tests/app/token_bond_StraightBondTokenAddresses_test.py
+++ b/tests/app/token_bond_StraightBondTokenAddresses_test.py
@@ -27,12 +27,12 @@ from web3 import Web3
 from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
-from app.contracts import Contract
 from app.model.db import IDXTokenListRegister, Listing
 from batch import indexer_Token_Detail
 from batch.indexer_Token_Detail import Processor
 from tests.account_config import eth_account
 from tests.contract_modules import issue_bond_token, register_bond_list
+from tests.utils.contract import Contract
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
 web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)

--- a/tests/app/token_bond_StraightBondTokenDetails_test.py
+++ b/tests/app/token_bond_StraightBondTokenDetails_test.py
@@ -26,7 +26,6 @@ from web3 import Web3
 from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
-from app.contracts import Contract
 from app.model.db import Listing
 from tests.account_config import eth_account
 from tests.contract_modules import (
@@ -36,6 +35,7 @@ from tests.contract_modules import (
     register_bond_list,
     register_share_list,
 )
+from tests.utils.contract import Contract
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
 web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)

--- a/tests/app/token_bond_StraightBondTokens_test.py
+++ b/tests/app/token_bond_StraightBondTokens_test.py
@@ -27,12 +27,12 @@ from web3 import Web3
 from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
-from app.contracts import Contract
 from app.model.db import IDXTokenListRegister, Listing
 from batch import indexer_Token_Detail
 from batch.indexer_Token_Detail import Processor
 from tests.account_config import eth_account
 from tests.contract_modules import issue_bond_token, register_bond_list
+from tests.utils.contract import Contract
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
 web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)

--- a/tests/app/token_coupon_CouponTokenAddresses_test.py
+++ b/tests/app/token_coupon_CouponTokenAddresses_test.py
@@ -27,12 +27,12 @@ from web3 import Web3
 from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
-from app.contracts import Contract
 from app.model.db import IDXTokenListRegister, Listing
 from batch import indexer_Token_Detail
 from batch.indexer_Token_Detail import Processor
 from tests.account_config import eth_account
 from tests.contract_modules import coupon_register_list, issue_coupon_token
+from tests.utils.contract import Contract
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
 web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)

--- a/tests/app/token_coupon_CouponTokenDetails_test.py
+++ b/tests/app/token_coupon_CouponTokenDetails_test.py
@@ -26,7 +26,6 @@ from web3 import Web3
 from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
-from app.contracts import Contract
 from app.model.db import Listing
 from tests.account_config import eth_account
 from tests.contract_modules import (
@@ -36,6 +35,7 @@ from tests.contract_modules import (
     membership_issue,
     membership_register_list,
 )
+from tests.utils.contract import Contract
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
 web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)

--- a/tests/app/token_coupon_CouponTokens_test.py
+++ b/tests/app/token_coupon_CouponTokens_test.py
@@ -27,12 +27,12 @@ from web3 import Web3
 from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
-from app.contracts import Contract
 from app.model.db import IDXTokenListRegister, Listing
 from batch import indexer_Token_Detail
 from batch.indexer_Token_Detail import Processor
 from tests.account_config import eth_account
 from tests.contract_modules import coupon_register_list, issue_coupon_token
+from tests.utils.contract import Contract
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
 web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)

--- a/tests/app/token_membership_MembershipTokenAddresses_test.py
+++ b/tests/app/token_membership_MembershipTokenAddresses_test.py
@@ -27,12 +27,12 @@ from web3 import Web3
 from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
-from app.contracts import Contract
 from app.model.db import IDXTokenListRegister, Listing
 from batch import indexer_Token_Detail
 from batch.indexer_Token_Detail import Processor
 from tests.account_config import eth_account
 from tests.contract_modules import membership_issue, membership_register_list
+from tests.utils.contract import Contract
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
 web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)

--- a/tests/app/token_membership_MembershipTokenDetails_test.py
+++ b/tests/app/token_membership_MembershipTokenDetails_test.py
@@ -26,7 +26,6 @@ from web3 import Web3
 from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
-from app.contracts import Contract
 from app.model.db import Listing
 from tests.account_config import eth_account
 from tests.contract_modules import (
@@ -36,6 +35,7 @@ from tests.contract_modules import (
     membership_issue,
     membership_register_list,
 )
+from tests.utils.contract import Contract
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
 web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)

--- a/tests/app/token_membership_MembershipTokens_test.py
+++ b/tests/app/token_membership_MembershipTokens_test.py
@@ -27,12 +27,12 @@ from web3 import Web3
 from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
-from app.contracts import Contract
 from app.model.db import IDXTokenListRegister, Listing
 from batch import indexer_Token_Detail
 from batch.indexer_Token_Detail import Processor
 from tests.account_config import eth_account
 from tests.contract_modules import membership_issue, membership_register_list
+from tests.utils.contract import Contract
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
 web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)

--- a/tests/app/token_share_ShareTokenAddresses_test.py
+++ b/tests/app/token_share_ShareTokenAddresses_test.py
@@ -27,12 +27,12 @@ from web3 import Web3
 from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
-from app.contracts import Contract
 from app.model.db import IDXTokenListRegister, Listing
 from batch import indexer_Token_Detail
 from batch.indexer_Token_Detail import Processor
 from tests.account_config import eth_account
 from tests.contract_modules import issue_share_token, register_share_list
+from tests.utils.contract import Contract
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
 web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)

--- a/tests/app/token_share_ShareTokenDetails_test.py
+++ b/tests/app/token_share_ShareTokenDetails_test.py
@@ -26,7 +26,6 @@ from web3 import Web3
 from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
-from app.contracts import Contract
 from app.model.db import Listing
 from tests.account_config import eth_account
 from tests.contract_modules import (
@@ -36,6 +35,7 @@ from tests.contract_modules import (
     register_bond_list,
     register_share_list,
 )
+from tests.utils.contract import Contract
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
 web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)

--- a/tests/app/token_share_ShareTokens_test.py
+++ b/tests/app/token_share_ShareTokens_test.py
@@ -27,12 +27,12 @@ from web3 import Web3
 from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
-from app.contracts import Contract
 from app.model.db import IDXTokenListRegister, Listing
 from batch import indexer_Token_Detail
 from batch.indexer_Token_Detail import Processor
 from tests.account_config import eth_account
 from tests.contract_modules import issue_share_token, register_share_list
+from tests.utils.contract import Contract
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
 web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)

--- a/tests/batch/indexer_Company_List_test.py
+++ b/tests/batch/indexer_Company_List_test.py
@@ -17,7 +17,6 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
-import asyncio
 import json
 import logging
 from typing import Sequence
@@ -63,6 +62,7 @@ class MockResponse:
         return self.data
 
 
+@pytest.mark.asyncio
 class TestProcessor:
     ###########################################################################
     # Normal Case
@@ -71,7 +71,7 @@ class TestProcessor:
     # <Normal_1>
     # 0 record
     @mock.patch("aiohttp.client.ClientSession.get")
-    def test_normal_1(self, mock_get, processor, session):
+    async def test_normal_1(self, mock_get, processor, session):
         # Prepare data
         _company = Company()
         _company.address = "0x01"
@@ -97,7 +97,7 @@ class TestProcessor:
         mock_get.side_effect = [MockResponse([])]
 
         # Run target process
-        asyncio.run(processor.process())
+        await processor.process()
 
         # Assertion
         session.rollback()
@@ -109,7 +109,7 @@ class TestProcessor:
     # <Normal_2>
     # 1 record
     @mock.patch("aiohttp.client.ClientSession.get")
-    def test_normal_2(self, mock_get, processor, session):
+    async def test_normal_2(self, mock_get, processor, session):
         # Prepare data
         _company = Company()
         _company.address = "0x01"
@@ -146,7 +146,7 @@ class TestProcessor:
         ]
 
         # Run target process
-        asyncio.run(processor.process())
+        await processor.process()
 
         # Assertion
         _company_list: Sequence[Company] = session.scalars(
@@ -164,7 +164,7 @@ class TestProcessor:
     # <Normal_3>
     # 2 record
     @mock.patch("aiohttp.client.ClientSession.get")
-    def test_normal_3(self, mock_get, processor, session):
+    async def test_normal_3(self, mock_get, processor, session):
         # Prepare data
         _company = Company()
         _company.address = "0x01"
@@ -206,7 +206,7 @@ class TestProcessor:
         ]
 
         # Run target process
-        asyncio.run(processor.process())
+        await processor.process()
 
         # Assertion
         _company_list: Sequence[Company] = session.scalars(
@@ -233,7 +233,7 @@ class TestProcessor:
     # type error
     # address
     @mock.patch("aiohttp.client.ClientSession.get")
-    def test_normal_4_1_1(self, mock_get, processor, session):
+    async def test_normal_4_1_1(self, mock_get, processor, session):
         # Prepare data
         _company = Company()
         _company.address = "0x01"
@@ -276,7 +276,7 @@ class TestProcessor:
         ]
 
         # Run target process
-        asyncio.run(processor.process())
+        await processor.process()
 
         # Assertion
         _company_list: Sequence[Company] = session.scalars(
@@ -296,7 +296,7 @@ class TestProcessor:
     # type error
     # corporate_name
     @mock.patch("aiohttp.client.ClientSession.get")
-    def test_normal_4_1_2(self, mock_get, processor, session):
+    async def test_normal_4_1_2(self, mock_get, processor, session):
         # Prepare data
         _company = Company()
         _company.address = "0x01"
@@ -339,7 +339,7 @@ class TestProcessor:
         ]
 
         # Run target process
-        asyncio.run(processor.process())
+        await processor.process()
 
         # Assertion
         _company_list: Sequence[Company] = session.scalars(
@@ -359,7 +359,7 @@ class TestProcessor:
     # type error
     # rsa_publickey
     @mock.patch("aiohttp.client.ClientSession.get")
-    def test_normal_4_1_3(self, mock_get, processor, session):
+    async def test_normal_4_1_3(self, mock_get, processor, session):
         # Prepare data
         _company = Company()
         _company.address = "0x01"
@@ -402,7 +402,7 @@ class TestProcessor:
         ]
 
         # Run target process
-        asyncio.run(processor.process())
+        await processor.process()
 
         # Assertion
         _company_list: Sequence[Company] = session.scalars(
@@ -422,7 +422,7 @@ class TestProcessor:
     # type error
     # homepage
     @mock.patch("aiohttp.client.ClientSession.get")
-    def test_normal_4_1_4(self, mock_get, processor, session):
+    async def test_normal_4_1_4(self, mock_get, processor, session):
         # Prepare data
         _company = Company()
         _company.address = "0x01"
@@ -465,7 +465,7 @@ class TestProcessor:
         ]
 
         # Run target process
-        asyncio.run(processor.process())
+        await processor.process()
 
         # Assertion
         _company_list: Sequence[Company] = session.scalars(
@@ -485,7 +485,7 @@ class TestProcessor:
     # required error
     # address
     @mock.patch("aiohttp.client.ClientSession.get")
-    def test_normal_4_2_1(self, mock_get, processor, session):
+    async def test_normal_4_2_1(self, mock_get, processor, session):
         # Prepare data
         _company = Company()
         _company.address = "0x01"
@@ -527,7 +527,7 @@ class TestProcessor:
         ]
 
         # Run target process
-        asyncio.run(processor.process())
+        await processor.process()
 
         # Assertion
         _company_list: Sequence[Company] = session.scalars(
@@ -547,7 +547,7 @@ class TestProcessor:
     # required error
     # corporate_name
     @mock.patch("aiohttp.client.ClientSession.get")
-    def test_normal_4_2_2(self, mock_get, processor, session):
+    async def test_normal_4_2_2(self, mock_get, processor, session):
         # Prepare data
         _company = Company()
         _company.address = "0x01"
@@ -589,7 +589,7 @@ class TestProcessor:
         ]
 
         # Run target process
-        asyncio.run(processor.process())
+        await processor.process()
 
         # Assertion
         _company_list: Sequence[Company] = session.scalars(
@@ -609,7 +609,7 @@ class TestProcessor:
     # required error
     # address
     @mock.patch("aiohttp.client.ClientSession.get")
-    def test_normal_4_2_3(self, mock_get, processor, session):
+    async def test_normal_4_2_3(self, mock_get, processor, session):
         # Prepare data
         _company = Company()
         _company.address = "0x01"
@@ -651,7 +651,7 @@ class TestProcessor:
         ]
 
         # Run target process
-        asyncio.run(processor.process())
+        await processor.process()
 
         # Assertion
         _company_list: Sequence[Company] = session.scalars(
@@ -670,7 +670,7 @@ class TestProcessor:
     # Insert SKIP
     # invalid address error
     @mock.patch("aiohttp.client.ClientSession.get")
-    def test_normal_4_3(self, mock_get, processor, session):
+    async def test_normal_4_3(self, mock_get, processor, session):
         # Prepare data
         _company = Company()
         _company.address = "0x01"
@@ -713,7 +713,7 @@ class TestProcessor:
         ]
 
         # Run target process
-        asyncio.run(processor.process())
+        await processor.process()
 
         # Assertion
         _company_list: Sequence[Company] = session.scalars(
@@ -732,7 +732,7 @@ class TestProcessor:
     # There are no differences from last time
     # -> Skip this cycle
     @mock.patch("aiohttp.client.ClientSession.get")
-    def test_normal_5_1(self, mock_get, processor, session, caplog):
+    async def test_normal_5_1(self, mock_get, processor, session, caplog):
         # Run target process: 1st time
         mock_get.side_effect = [
             MockResponse(
@@ -752,7 +752,7 @@ class TestProcessor:
                 ]
             )
         ]
-        asyncio.run(processor.process())
+        await processor.process()
 
         # Run target process: 2nd time
         mock_get.side_effect = [
@@ -773,7 +773,7 @@ class TestProcessor:
                 ]
             )
         ]
-        asyncio.run(processor.process())
+        await processor.process()
 
         # Assertion
         _company_list: Sequence[Company] = session.scalars(
@@ -808,7 +808,7 @@ class TestProcessor:
     # <Normal_5_2>
     # There are differences from the previous cycle
     @mock.patch("aiohttp.client.ClientSession.get")
-    def test_normal_5_2(self, mock_get, processor, session, caplog):
+    async def test_normal_5_2(self, mock_get, processor, session, caplog):
         # Run target process: 1st time
         mock_get.side_effect = [
             MockResponse(
@@ -828,7 +828,7 @@ class TestProcessor:
                 ]
             )
         ]
-        asyncio.run(processor.process())
+        await processor.process()
 
         # Run target process: 2nd time
         mock_get.side_effect = [
@@ -843,7 +843,7 @@ class TestProcessor:
                 ]
             )
         ]
-        asyncio.run(processor.process())
+        await processor.process()
 
         # Assertion
         _company_list: Sequence[Company] = session.scalars(
@@ -878,7 +878,7 @@ class TestProcessor:
         "aiohttp.client.ClientSession.get",
         MagicMock(side_effect=requests.exceptions.ConnectionError),
     )
-    def test_error_1_1(self, processor, session):
+    async def test_error_1_1(self, processor, session):
         # Prepare data
         _company = Company()
         _company.address = "0x01"
@@ -901,7 +901,7 @@ class TestProcessor:
         session.commit()
 
         # Run target process
-        asyncio.run(processor.process())
+        await processor.process()
 
         # Assertion
         _company_list: Sequence[Company] = session.scalars(
@@ -913,7 +913,7 @@ class TestProcessor:
     # API error
     # not succeed api
     @mock.patch("aiohttp.client.ClientSession.get")
-    def test_error_1_2(self, mock_get, processor, session):
+    async def test_error_1_2(self, mock_get, processor, session):
         # Prepare data
         _company = Company()
         _company.address = "0x01"
@@ -939,7 +939,7 @@ class TestProcessor:
         mock_get.side_effect = [MockResponse([], 400)]
 
         # Run target process
-        asyncio.run(processor.process())
+        await processor.process()
 
         # Assertion
         _company_list: Sequence[Company] = session.scalars(
@@ -953,7 +953,7 @@ class TestProcessor:
         "aiohttp.client.ClientSession.get",
         MagicMock(side_effect=json.decoder.JSONDecodeError),
     )
-    def test_error_2(self, processor, session):
+    async def test_error_2(self, processor, session):
         # Prepare data
         _company = Company()
         _company.address = "0x01"
@@ -976,7 +976,7 @@ class TestProcessor:
         session.commit()
 
         # Run target process
-        asyncio.run(processor.process())
+        await processor.process()
 
         # Assertion
         _company_list: Sequence[Company] = session.scalars(
@@ -987,7 +987,7 @@ class TestProcessor:
     # <Error_3>
     # other error
     @mock.patch("aiohttp.client.ClientSession.get")
-    def test_error_3(self, mock_get, processor, session):
+    async def test_error_3(self, mock_get, processor, session):
         # Prepare data
         _company = Company()
         _company.address = "0x01"
@@ -1026,7 +1026,7 @@ class TestProcessor:
 
         # Run target process
         with pytest.raises(Exception):
-            asyncio.run(processor.process())
+            await processor.process()
 
         # Assertion
         _company_list: Sequence[Company] = session.scalars(

--- a/tests/batch/indexer_Position_Share_test.py
+++ b/tests/batch/indexer_Position_Share_test.py
@@ -24,6 +24,7 @@ from unittest import mock
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+import pytest_asyncio
 from eth_utils import to_checksum_address
 from sqlalchemy import and_, select
 from sqlalchemy.exc import SQLAlchemyError
@@ -33,7 +34,6 @@ from web3.exceptions import ABIEventNotFound
 from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
-from app.contracts import Contract
 from app.errors import ServiceUnavailable
 from app.model.db import (
     IDXLock,
@@ -68,6 +68,7 @@ from tests.contract_modules import (
     take_sell,
 )
 from tests.utils import PersonalInfoUtils
+from tests.utils.contract import Contract
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
 web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
@@ -92,13 +93,14 @@ def main_func(test_module):
     LOG.setLevel(default_log_level)
 
 
-@pytest.fixture(scope="function")
-def processor(test_module, session):
+@pytest_asyncio.fixture(scope="function")
+async def processor(test_module, session):
     processor = test_module.Processor()
-    asyncio.run(processor.initial_sync())
+    await processor.initial_sync()
     return processor
 
 
+@pytest.mark.asyncio
 class TestProcessor:
     issuer = eth_account["issuer"]
     trader = eth_account["trader"]
@@ -150,7 +152,7 @@ class TestProcessor:
     # Single Token
     # Single event logs
     # - Transfer
-    def test_normal_1(self, processor, shared_contract, session):
+    async def test_normal_1(self, processor, shared_contract, session):
         # Issue Token
         token_list_contract = shared_contract["TokenList"]
         personal_info_contract = shared_contract["PersonalInfo"]
@@ -175,7 +177,7 @@ class TestProcessor:
 
         # Run target process
         block_number = web3.eth.block_number
-        asyncio.run(processor.sync_new_logs())
+        await processor.sync_new_logs()
 
         # Assertion
         _position_list: Sequence[IDXPosition] = session.scalars(
@@ -228,7 +230,7 @@ class TestProcessor:
     # Single Token
     # Multi event logs
     # - Transfer
-    def test_normal_2(self, processor, shared_contract, session):
+    async def test_normal_2(self, processor, shared_contract, session):
         # Issue Token
         token_list_contract = shared_contract["TokenList"]
         personal_info_contract = shared_contract["PersonalInfo"]
@@ -257,7 +259,7 @@ class TestProcessor:
 
         # Run target process
         block_number = web3.eth.block_number
-        asyncio.run(processor.sync_new_logs())
+        await processor.sync_new_logs()
 
         # Assertion
         _position_list: Sequence[IDXPosition] = session.scalars(
@@ -310,7 +312,7 @@ class TestProcessor:
     # Multi Token
     # Multi event logs
     # - Transfer
-    def test_normal_3(self, processor, shared_contract, session):
+    async def test_normal_3(self, processor, shared_contract, session):
         # Issue Token
         token_list_contract = shared_contract["TokenList"]
         personal_info_contract = shared_contract["PersonalInfo"]
@@ -357,7 +359,7 @@ class TestProcessor:
 
         # Run target process
         block_number = web3.eth.block_number
-        asyncio.run(processor.sync_new_logs())
+        await processor.sync_new_logs()
 
         # Assertion
         _position_list: Sequence[IDXPosition] = session.scalars(
@@ -479,7 +481,7 @@ class TestProcessor:
     # Single Token
     # Single event logs
     # - Lock
-    def test_normal_4_1(self, processor, shared_contract, session):
+    async def test_normal_4_1(self, processor, shared_contract, session):
         # Issue Token
         token_list_contract = shared_contract["TokenList"]
         personal_info_contract = shared_contract["PersonalInfo"]
@@ -503,7 +505,7 @@ class TestProcessor:
 
         # Run target process
         block_number = web3.eth.block_number
-        asyncio.run(processor.sync_new_logs())
+        await processor.sync_new_logs()
 
         # Assertion
         _position_list: Sequence[IDXPosition] = session.scalars(
@@ -561,7 +563,7 @@ class TestProcessor:
     # Single Token
     # Single event logs
     # - ForceLock
-    def test_normal_4_2(self, processor, shared_contract, session):
+    async def test_normal_4_2(self, processor, shared_contract, session):
         # Issue Token
         token_list_contract = shared_contract["TokenList"]
         personal_info_contract = shared_contract["PersonalInfo"]
@@ -600,7 +602,7 @@ class TestProcessor:
 
         # Run target process
         block_number = web3.eth.block_number
-        asyncio.run(processor.sync_new_logs())
+        await processor.sync_new_logs()
 
         # Assertion
         _position_list: Sequence[IDXPosition] = session.scalars(
@@ -660,7 +662,7 @@ class TestProcessor:
     # Single Token
     # Single event logs
     # - Unlock
-    def test_normal_5_1(self, processor, shared_contract, session):
+    async def test_normal_5_1(self, processor, shared_contract, session):
         # Issue Token
         token_list_contract = shared_contract["TokenList"]
         personal_info_contract = shared_contract["PersonalInfo"]
@@ -689,7 +691,7 @@ class TestProcessor:
 
         # Run target process
         block_number = web3.eth.block_number
-        asyncio.run(processor.sync_new_logs())
+        await processor.sync_new_logs()
 
         # Assertion
         _position_list: Sequence[IDXPosition] = session.scalars(
@@ -776,7 +778,7 @@ class TestProcessor:
     # Single Token
     # Single event logs
     # - ForceUnlock
-    def test_normal_5_2(self, processor, shared_contract, session):
+    async def test_normal_5_2(self, processor, shared_contract, session):
         # Issue Token
         token_list_contract = shared_contract["TokenList"]
         personal_info_contract = shared_contract["PersonalInfo"]
@@ -806,7 +808,7 @@ class TestProcessor:
 
         # Run target process
         block_number = web3.eth.block_number
-        asyncio.run(processor.sync_new_logs())
+        await processor.sync_new_logs()
 
         # Assertion
         _position_list: Sequence[IDXPosition] = session.scalars(
@@ -893,7 +895,7 @@ class TestProcessor:
     # Single Token
     # Single event logs
     # - Issue(add balance)
-    def test_normal_6(self, processor, shared_contract, session):
+    async def test_normal_6(self, processor, shared_contract, session):
         # Issue Token
         token_list_contract = shared_contract["TokenList"]
         personal_info_contract = shared_contract["PersonalInfo"]
@@ -913,7 +915,7 @@ class TestProcessor:
 
         # Run target process
         block_number = web3.eth.block_number
-        asyncio.run(processor.sync_new_logs())
+        await processor.sync_new_logs()
 
         # Assertion
         _position_list: Sequence[IDXPosition] = session.scalars(
@@ -940,7 +942,7 @@ class TestProcessor:
     # Single Token
     # Single event logs
     # - Redeem
-    def test_normal_7(self, processor, shared_contract, session):
+    async def test_normal_7(self, processor, shared_contract, session):
         # Issue Token
         token_list_contract = shared_contract["TokenList"]
         personal_info_contract = shared_contract["PersonalInfo"]
@@ -960,7 +962,7 @@ class TestProcessor:
 
         # Run target process
         block_number = web3.eth.block_number
-        asyncio.run(processor.sync_new_logs())
+        await processor.sync_new_logs()
 
         # Assertion
         _position_list: Sequence[IDXPosition] = session.scalars(
@@ -988,7 +990,7 @@ class TestProcessor:
     # Single event logs
     # - Transfer
     # - Apply For Transfer
-    def test_normal_8(self, processor, shared_contract, session):
+    async def test_normal_8(self, processor, shared_contract, session):
         # Issue Token
         token_list_contract = shared_contract["TokenList"]
         personal_info_contract = shared_contract["PersonalInfo"]
@@ -1028,7 +1030,7 @@ class TestProcessor:
 
         # Run target process
         block_number = web3.eth.block_number
-        asyncio.run(processor.sync_new_logs())
+        await processor.sync_new_logs()
 
         # Assertion
         _position_list: Sequence[IDXPosition] = session.scalars(
@@ -1084,7 +1086,7 @@ class TestProcessor:
     # - Transfer
     # - Apply For Transfer
     # - Approve
-    def test_normal_9(self, processor, shared_contract, session):
+    async def test_normal_9(self, processor, shared_contract, session):
         # Issue Token
         token_list_contract = shared_contract["TokenList"]
         personal_info_contract = shared_contract["PersonalInfo"]
@@ -1129,7 +1131,7 @@ class TestProcessor:
 
         # Run target process
         block_number = web3.eth.block_number
-        asyncio.run(processor.sync_new_logs())
+        await processor.sync_new_logs()
 
         # Assertion
         _position_list: Sequence[IDXPosition] = session.scalars(
@@ -1201,7 +1203,7 @@ class TestProcessor:
     # - Transfer
     # - Apply For Transfer
     # - Cancel
-    def test_normal_10(self, processor, shared_contract, session):
+    async def test_normal_10(self, processor, shared_contract, session):
         # Issue Token
         token_list_contract = shared_contract["TokenList"]
         personal_info_contract = shared_contract["PersonalInfo"]
@@ -1246,7 +1248,7 @@ class TestProcessor:
 
         # Run target process
         block_number = web3.eth.block_number
-        asyncio.run(processor.sync_new_logs())
+        await processor.sync_new_logs()
 
         # Assertion
         _position_list: Sequence[IDXPosition] = session.scalars(
@@ -1301,7 +1303,7 @@ class TestProcessor:
     # - CreateEscrow
     # - EscrowFinished
     # - CreateEscrow
-    def test_normal_11(self, processor, shared_contract, session):
+    async def test_normal_11(self, processor, shared_contract, session):
         # Issue Token
         token_list_contract = shared_contract["TokenList"]
         escrow_contract = shared_contract["IbetSecurityTokenEscrow"]
@@ -1348,7 +1350,7 @@ class TestProcessor:
 
         # Run target process
         block_number = web3.eth.block_number
-        asyncio.run(processor.sync_new_logs())
+        await processor.sync_new_logs()
 
         # Assertion
         _position_list: Sequence[IDXPosition] = session.scalars(
@@ -1406,7 +1408,7 @@ class TestProcessor:
     # - MakeOrder
     # - ForceCancelOrder
     # - MakeOrder
-    def test_normal_12(self, processor, shared_contract, session):
+    async def test_normal_12(self, processor, shared_contract, session):
         # Issue Token
         token_list_contract = shared_contract["TokenList"]
         exchange_contract = shared_contract["IbetShareExchange"]
@@ -1433,7 +1435,7 @@ class TestProcessor:
 
         # Run target process
         block_number = web3.eth.block_number
-        asyncio.run(processor.sync_new_logs())
+        await processor.sync_new_logs()
 
         # Assertion
         _position_list: Sequence[IDXPosition] = session.scalars(
@@ -1465,7 +1467,7 @@ class TestProcessor:
     # - CancelAgreement
     # - MakeOrder
     # - TakeOrder
-    def test_normal_13(self, processor, shared_contract, session):
+    async def test_normal_13(self, processor, shared_contract, session):
         # Issue Token
         token_list_contract = shared_contract["TokenList"]
         exchange_contract = shared_contract["IbetShareExchange"]
@@ -1505,7 +1507,7 @@ class TestProcessor:
 
         # Run target process
         block_number = web3.eth.block_number
-        asyncio.run(processor.sync_new_logs())
+        await processor.sync_new_logs()
 
         # Assertion
         _position_list: Sequence[IDXPosition] = session.scalars(
@@ -1535,7 +1537,7 @@ class TestProcessor:
     # - DeliveryCanceled
     # - DeliveryFinished
     # - DeliveryAborted
-    def test_normal_14(self, processor, shared_contract, session):
+    async def test_normal_14(self, processor, shared_contract, session):
         # Issue Token
         token_list_contract = shared_contract["TokenList"]
         dvp_contract = shared_contract["IbetSecurityTokenDVP"]
@@ -1597,7 +1599,7 @@ class TestProcessor:
 
         # Run target process
         block_number = web3.eth.block_number
-        asyncio.run(processor.sync_new_logs())
+        await processor.sync_new_logs()
 
         # Assertion
         _position_list: Sequence[IDXPosition] = session.scalars(
@@ -1648,7 +1650,7 @@ class TestProcessor:
 
     # <Normal_15>
     # No event logs
-    def test_normal_15(self, processor, shared_contract, session):
+    async def test_normal_15(self, processor, shared_contract, session):
         # Issue Token
         token_list_contract = shared_contract["TokenList"]
         personal_info_contract = shared_contract["PersonalInfo"]
@@ -1663,7 +1665,7 @@ class TestProcessor:
         # Not Event
         # Run target process
         block_number = web3.eth.block_number
-        asyncio.run(processor.sync_new_logs())
+        await processor.sync_new_logs()
 
         # Assertion
         _position_list: Sequence[IDXPosition] = session.scalars(
@@ -1681,7 +1683,7 @@ class TestProcessor:
     # <Normal_16>
     # Not listing Token is NOT indexed,
     # and indexed properly after listing
-    def test_normal_16(self, processor, shared_contract, session):
+    async def test_normal_16(self, processor, shared_contract, session):
         # Issue Token
         token_list_contract = shared_contract["TokenList"]
         personal_info_contract = shared_contract["PersonalInfo"]
@@ -1704,7 +1706,7 @@ class TestProcessor:
         )
 
         # Run target process
-        asyncio.run(processor.sync_new_logs())
+        await processor.sync_new_logs()
 
         # Assertion
         _position_list: Sequence[IDXPosition] = session.scalars(
@@ -1725,7 +1727,7 @@ class TestProcessor:
         self.listing_token(token["address"], session)
 
         block_number = web3.eth.block_number
-        asyncio.run(processor.sync_new_logs())
+        await processor.sync_new_logs()
 
         # Assertion
         session.rollback()
@@ -1746,7 +1748,7 @@ class TestProcessor:
     # Multi event logs
     # - Transfer
     # Duplicate events to be removed
-    def test_normal_17(self, processor, shared_contract, session):
+    async def test_normal_17(self, processor, shared_contract, session):
         # Issue Token
         token_list_contract = shared_contract["TokenList"]
         personal_info_contract = shared_contract["PersonalInfo"]
@@ -1785,7 +1787,7 @@ class TestProcessor:
     # <Normal_18>
     # When stored index is 9,999,999 and current block number is 19,999,999,
     # then processor must process "__sync_all" method 10 times.
-    def test_normal_18(self, processor, shared_contract, session):
+    async def test_normal_18(self, processor, shared_contract, session):
         token_list_contract = shared_contract["TokenList"]
         escrow_contract = shared_contract["IbetSecurityTokenEscrow"]
         personal_info_contract = shared_contract["PersonalInfo"]
@@ -1825,7 +1827,7 @@ class TestProcessor:
                 session.merge(idx_position_share_block_number)
                 session.commit()
                 __sync_all_mock.return_value = None
-                asyncio.run(processor.initial_sync())
+                await processor.initial_sync()
                 # Then processor call "__sync_all" method 10 times.
                 assert __sync_all_mock.call_count == 10
 
@@ -1837,7 +1839,7 @@ class TestProcessor:
             ) as __sync_all_mock:
                 # Stored index is 19,999,999
                 __sync_all_mock.return_value = None
-                asyncio.run(processor.sync_new_logs())
+                await processor.sync_new_logs()
                 # Then processor call "__sync_all" method once.
                 assert __sync_all_mock.call_count == 1
 
@@ -1857,7 +1859,7 @@ class TestProcessor:
             ) as __sync_all_mock:
                 # Stored index is 19,999,999
                 __sync_all_mock.return_value = None
-                asyncio.run(processor.sync_new_logs())
+                await processor.sync_new_logs()
                 # Then processor call "__sync_all" method 20 times.
                 assert __sync_all_mock.call_count == 20
 
@@ -1866,7 +1868,7 @@ class TestProcessor:
     # Multi event logs
     # - Transfer/Exchange/Lock
     # Skip exchange events which has already been synced
-    def test_normal_19(self, processor, shared_contract, session):
+    async def test_normal_19(self, processor, shared_contract, session):
         token_list_contract = shared_contract["TokenList"]
         exchange_contract = shared_contract["IbetStraightBondExchange"]
         agent = eth_account["agent"]
@@ -1941,7 +1943,7 @@ class TestProcessor:
 
         # Run target process
         block_number1 = web3.eth.block_number
-        asyncio.run(processor.sync_new_logs())
+        await processor.sync_new_logs()
 
         # Assertion
         _position_list: Sequence[IDXPosition] = session.scalars(
@@ -1969,7 +1971,7 @@ class TestProcessor:
 
         # Run target process
         block_number2 = web3.eth.block_number
-        asyncio.run(processor.sync_new_logs())
+        await processor.sync_new_logs()
 
         session.rollback()
         _position_list: Sequence[IDXPosition] = session.scalars(
@@ -2033,7 +2035,7 @@ class TestProcessor:
     # Single Token
     # Multi event logs (Over 1000)
     # - Transfer
-    def test_normal_20(self, processor, shared_contract, session):
+    async def test_normal_20(self, processor, shared_contract, session):
         # Issue Token
         token_list_contract = shared_contract["TokenList"]
         escrow_contract = shared_contract["IbetSecurityTokenEscrow"]
@@ -2061,7 +2063,7 @@ class TestProcessor:
 
         # Run target process
         block_number = web3.eth.block_number
-        asyncio.run(processor.sync_new_logs())
+        await processor.sync_new_logs()
 
         # Assertion
         _position_list: Sequence[IDXPosition] = session.scalars(
@@ -2116,7 +2118,7 @@ class TestProcessor:
         "web3.eth.async_eth.AsyncEth.get_logs",
         MagicMock(side_effect=ABIEventNotFound()),
     )
-    def test_error_1(self, processor, shared_contract, session):
+    async def test_error_1(self, processor, shared_contract, session):
         # Issue Token
         token_list_contract = shared_contract["TokenList"]
         personal_info_contract = shared_contract["PersonalInfo"]
@@ -2140,7 +2142,7 @@ class TestProcessor:
 
         block_number_current = web3.eth.block_number
         # Run initial sync
-        asyncio.run(processor.initial_sync())
+        await processor.initial_sync()
 
         # Assertion
         _position_list: Sequence[IDXPosition] = session.scalars(
@@ -2165,10 +2167,10 @@ class TestProcessor:
 
         block_number_current = web3.eth.block_number
         # Run target process
-        asyncio.run(processor.sync_new_logs())
+        await processor.sync_new_logs()
 
         # Run target process
-        asyncio.run(processor.sync_new_logs())
+        await processor.sync_new_logs()
 
         # Clear cache in DB session.
         session.rollback()
@@ -2190,7 +2192,7 @@ class TestProcessor:
         )
 
     # <Error_2_1>: ServiceUnavailable occurs in "initial_sync" / "sync_new_logs".
-    def test_error_2_1(self, processor, shared_contract, session, caplog):
+    async def test_error_2_1(self, processor, shared_contract, session, caplog):
         # Issue Token
         token_list_contract = shared_contract["TokenList"]
         personal_info_contract = shared_contract["PersonalInfo"]
@@ -2221,7 +2223,7 @@ class TestProcessor:
             ),
             pytest.raises(ServiceUnavailable),
         ):
-            asyncio.run(processor.initial_sync())
+            await processor.initial_sync()
 
         # Clear cache in DB session.
         session.rollback()
@@ -2254,7 +2256,7 @@ class TestProcessor:
             ),
             pytest.raises(ServiceUnavailable),
         ):
-            asyncio.run(processor.sync_new_logs())
+            await processor.sync_new_logs()
 
         # Clear cache in DB session.
         session.rollback()
@@ -2280,7 +2282,7 @@ class TestProcessor:
         )
 
     # <Error_2_2>: SQLAlchemyError occurs in "initial_sync" / "sync_new_logs".
-    def test_error_2_2(self, processor, shared_contract, session, caplog):
+    async def test_error_2_2(self, processor, shared_contract, session, caplog):
         # Issue Token
         token_list_contract = shared_contract["TokenList"]
         personal_info_contract = shared_contract["PersonalInfo"]
@@ -2308,7 +2310,7 @@ class TestProcessor:
             mock.patch.object(Session, "commit", side_effect=SQLAlchemyError()),
             pytest.raises(SQLAlchemyError),
         ):
-            asyncio.run(processor.initial_sync())
+            await processor.initial_sync()
 
         # Clear cache in DB session.
         session.rollback()
@@ -2338,7 +2340,7 @@ class TestProcessor:
             mock.patch.object(Session, "commit", side_effect=SQLAlchemyError()),
             pytest.raises(SQLAlchemyError),
         ):
-            asyncio.run(processor.sync_new_logs())
+            await processor.sync_new_logs()
 
         # Clear cache in DB session.
         session.rollback()
@@ -2364,7 +2366,7 @@ class TestProcessor:
         )
 
     # <Error_3>: ServiceUnavailable occurs and is handled in mainloop.
-    def test_error_3(self, main_func, shared_contract, session, caplog):
+    async def test_error_3(self, main_func, shared_contract, session, caplog):
         # Mocking time.sleep to break mainloop
         asyncio_mock = AsyncMock(wraps=asyncio)
         asyncio_mock.sleep.side_effect = [True, TypeError()]
@@ -2382,7 +2384,7 @@ class TestProcessor:
             pytest.raises(TypeError),
         ):
             # Expect that sync_new_logs() raises ServiceUnavailable and handled in mainloop.
-            asyncio.run(main_func())
+            await main_func()
 
         assert 1 == caplog.record_tuples.count(
             (LOG.name, 25, "An external service was unavailable")

--- a/tests/batch/indexer_Token_Detail_ShortTerm_test.py
+++ b/tests/batch/indexer_Token_Detail_ShortTerm_test.py
@@ -32,7 +32,6 @@ from web3 import Web3
 from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
-from app.contracts import Contract
 from app.errors import ServiceUnavailable
 from app.model.blockchain import BondToken, CouponToken, MembershipToken, ShareToken
 from app.model.db import (
@@ -56,6 +55,7 @@ from tests.contract_modules import (
     register_bond_list,
     register_share_list,
 )
+from tests.utils.contract import Contract
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
 web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)

--- a/tests/batch/indexer_Token_Holders_test.py
+++ b/tests/batch/indexer_Token_Holders_test.py
@@ -31,7 +31,6 @@ from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
 from app.config import ZERO_ADDRESS
-from app.contracts import Contract
 from app.errors import ServiceUnavailable
 from app.model.db import Listing, TokenHolder, TokenHolderBatchStatus, TokenHoldersList
 from batch.indexer_Token_Holders import LOG, Processor
@@ -90,6 +89,7 @@ from tests.contract_modules import (
     take_sell,
     transfer_token,
 )
+from tests.utils.contract import Contract
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
 web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)

--- a/tests/batch/indexer_Token_List_Event_test.py
+++ b/tests/batch/indexer_Token_List_Event_test.py
@@ -32,7 +32,6 @@ from web3.exceptions import ABIEventNotFound
 from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
-from app.contracts import Contract
 from app.errors import ServiceUnavailable
 from app.model.db import IDXTokenListBlockNumber, IDXTokenListRegister, Listing
 from batch import indexer_Token_List_Event
@@ -48,6 +47,7 @@ from tests.contract_modules import (
     register_bond_list,
     register_share_list,
 )
+from tests.utils.contract import Contract
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
 web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)

--- a/tests/batch/indexer_TransferApproval_test.py
+++ b/tests/batch/indexer_TransferApproval_test.py
@@ -33,7 +33,6 @@ from web3.exceptions import ABIEventNotFound
 from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
-from app.contracts import Contract
 from app.errors import ServiceUnavailable
 from app.model.db import IDXTransferApproval, IDXTransferApprovalBlockNumber, Listing
 from batch import indexer_TransferApproval
@@ -45,6 +44,7 @@ from tests.contract_modules import (
     transfer_token,
 )
 from tests.utils import PersonalInfoUtils
+from tests.utils.contract import Contract
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
 web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,12 +27,11 @@ from pytest_asyncio import is_async_test
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 from web3 import Web3
-from web3.eth import Contract as Web3Contract
+from web3.contract import Contract as Web3Contract
 from web3.middleware import ExtraDataToPOAMiddleware
 from web3.types import ChecksumAddress, RPCEndpoint
 
 from app import config
-from app.contracts import Contract
 from app.database import (
     AsyncSessionLocal,
     SessionLocal,
@@ -46,6 +45,7 @@ from app.model.db import Notification
 from app.model.db.base import Base
 from app.utils.web3_utils import AsyncFailOverHTTPProvider
 from tests.account_config import eth_account
+from tests.utils.contract import Contract
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
 web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)

--- a/tests/contract_modules.py
+++ b/tests/contract_modules.py
@@ -24,9 +24,9 @@ from web3 import Web3
 from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
-from app.contracts import Contract
 from tests.account_config import eth_account
 from tests.conftest import DeployedContract, UnitTestAccount
+from tests.utils.contract import Contract
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
 web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)

--- a/tests/utils/personal_info.py
+++ b/tests/utils/personal_info.py
@@ -21,7 +21,7 @@ from web3 import Web3
 from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
-from app.contracts import Contract
+from tests.utils.contract import Contract
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
 web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)

--- a/tests/utils/share_token.py
+++ b/tests/utils/share_token.py
@@ -23,8 +23,8 @@ from web3 import Web3
 from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
-from app.contracts import Contract
 from tests.account_config import eth_account
+from tests.utils.contract import Contract
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
 web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)

--- a/tests/utils/standard_token.py
+++ b/tests/utils/standard_token.py
@@ -23,7 +23,7 @@ from web3 import Web3
 from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
-from app.contracts import Contract
+from tests.utils.contract import Contract
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
 web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)

--- a/uv.lock
+++ b/uv.lock
@@ -827,7 +827,7 @@ dev = [
     { name = "pytest", specifier = ">=8.3.2,<9.0.0" },
     { name = "pytest-aiohttp", specifier = ">=1.0.5,<2.0.0" },
     { name = "pytest-alembic", specifier = ">=0.10.7,<1.0.0" },
-    { name = "pytest-asyncio", specifier = "==0.25.0" },
+    { name = "pytest-asyncio", specifier = "==0.26.0" },
     { name = "pytest-cov", specifier = ">=5.0.0,<6.0.0" },
     { name = "pytest-freezer", specifier = ">=0.4.8,<1.0.0" },
     { name = "pytest-memray", specifier = ">=1.6.0,<2.0.0" },
@@ -1376,14 +1376,14 @@ wheels = [
 
 [[package]]
 name = "pytest-asyncio"
-version = "0.25.0"
+version = "0.26.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/94/18/82fcb4ee47d66d99f6cd1efc0b11b2a25029f303c599a5afda7c1bca4254/pytest_asyncio-0.25.0.tar.gz", hash = "sha256:8c0610303c9e0442a5db8604505fc0f545456ba1528824842b37b4a626cbf609", size = 53298 }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/c4/453c52c659521066969523e87d85d54139bbd17b78f09532fb8eb8cdb58e/pytest_asyncio-0.26.0.tar.gz", hash = "sha256:c4df2a697648241ff39e7f0e4a73050b03f123f760673956cf0d72a4990e312f", size = 54156 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/56/2ee0cab25c11d4e38738a2a98c645a8f002e2ecf7b5ed774c70d53b92bb1/pytest_asyncio-0.25.0-py3-none-any.whl", hash = "sha256:db5432d18eac6b7e28b46dcd9b69921b55c3b1086e85febfe04e70b18d9e81b3", size = 19245 },
+    { url = "https://files.pythonhosted.org/packages/20/7f/338843f449ace853647ace35870874f69a764d251872ed1b4de9f234822c/pytest_asyncio-0.26.0-py3-none-any.whl", hash = "sha256:7b51ed894f4fbea1340262bdae5135797ebbe21d8638978e35d31c6d19f72fb0", size = 19694 },
 ]
 
 [[package]]


### PR DESCRIPTION
## 📌 Description

- Refactored `processor_Block_Sync_Status` to use `AsyncHTTPProvider`.

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
- Close #1622 

## 🔄 Changes

<!-- List the major changes in this PR. -->

- Refactored `batch/processor_Block_Sync_Status.py` to use asynchronous Web3 operations (`AsyncWeb3`) and database sessions (`AsyncSession`) .
- Removed `Contract` class used in sync logic from `app/contracts/contract.py` module.

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
