### PR TITLE
Improve security for 3rd-party GH Actions

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -7,7 +7,6 @@ addReviewers: true
 # A list of reviewers to be added to pull requests (GitHub user name)
 reviewers:
   - YoshihitoAso
-  - kyken
   - purplesmoke05
 
 # A number of reviewers added to the pull request

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -10,4 +10,4 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: kentaro-m/auto-assign-action@v2.0.0
+      - uses: kentaro-m/auto-assign-action@f4648c0a9fdb753479e9e75fc251f507ce17bb7e  # v2.0.0

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: chartboost/ruff-action@v1
+      - uses: astral-sh/ruff-action@v3
   unit-test:
     name: 'Unit tests'
     runs-on: ubuntu-latest
@@ -90,7 +90,7 @@ jobs:
         run: jrm cov/pytest.xml "cov/pytest-*.xml"
       - name: Pytest coverage comment
         id: coverageComment
-        uses: MishaKav/pytest-coverage-comment@main
+        uses: MishaKav/pytest-coverage-comment@13d3c18e21895566c746187c9ea74736372e5e91  # v1.1.54
         with:
           report-only-changed-files: true
           pytest-xml-coverage-path: cov/coverage.xml


### PR DESCRIPTION
## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->

This pull request updates several GitHub Actions workflows to use more specific references for actions, ensuring better stability and traceability. The changes include pinning action versions to specific commit SHAs and updating to newer, more appropriate actions.

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
None

## 🔄 Changes

<!-- List the major changes in this PR. -->

### Workflow updates for stability and traceability:

* [`.github/workflows/auto-assign.yml`](diffhunk://#diff-3df58dd42b351a284a19d2c3d3fe8c50db1cc811bb690ebbf402d1282bce9757L13-R13): Updated the `kentaro-m/auto-assign-action` to use a specific commit SHA (`f4648c0a9fdb753479e9e75fc251f507ce17bb7e`) instead of a version tag (`v2.0.0`).

* `.github/workflows/pr.yml`:
  - Replaced `chartboost/ruff-action@v1` with `astral-sh/ruff-action@v3` to use the officially maintained action.
  - Updated the `MishaKav/pytest-coverage-comment` action to pin it to a specific commit SHA (`13d3c18e21895566c746187c9ea74736372e5e91`) for version `v1.1.54`.

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
