### PR TITLE
Refactor account_type to limit values to 1, 2, and 3

### DIFF
--- a/app/model/db/public_info.py
+++ b/app/model/db/public_info.py
@@ -76,9 +76,7 @@ class PublicAccountList(Base):
     # Key Manager Name
     key_manager_name: Mapped[str] = mapped_column(String(200), nullable=False)
     # Account Type
-    account_type: Mapped[Literal[1, 2, 3, 4, 5]] = mapped_column(
-        Integer, primary_key=True
-    )
+    account_type: Mapped[Literal[1, 2, 3]] = mapped_column(Integer, primary_key=True)
     # Account Address
     account_address: Mapped[str] = mapped_column(String(42), nullable=False)
 

--- a/app/model/schema/public_info.py
+++ b/app/model/schema/public_info.py
@@ -51,7 +51,7 @@ class IbetShareToken(TokenBase):
 class PublicAccount(BaseModel):
     key_manager: str
     key_manager_name: str
-    account_type: Literal[1, 2, 3, 4, 5]
+    account_type: Literal[1, 2, 3]
     account_address: EthereumAddress
     modified: str = Field(..., description="Updated Datetime (local timezone)")
 

--- a/docs/ibet_wallet_api.yaml
+++ b/docs/ibet_wallet_api.yaml
@@ -9628,8 +9628,6 @@ components:
             - 1
             - 2
             - 3
-            - 4
-            - 5
           title: Account Type
         account_address:
           type: string


### PR DESCRIPTION
## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->
This pull request reduces the valid values for the `account_type` field across several files, limiting it to `1`, `2`, and `3` and removing `4` and `5`. These changes ensure consistency between the database model, schema, and API documentation.

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
None

## 🔄 Changes

<!-- List the major changes in this PR. -->

### Changes to `account_type` field:

* **Database model update**: In `app/model/db/public_info.py`, the `account_type` field in the `PublicAccountList` class now only accepts `Literal[1, 2, 3]`, removing `4` and `5` as valid options.
* **Schema update**: In `app/model/schema/public_info.py`, the `account_type` field in the `PublicAccount` class has been updated to match the new restriction of `Literal[1, 2, 3]`.
* **API documentation update**: In `docs/ibet_wallet_api.yaml`, the `account_type` component has been updated to remove `4` and `5` from the list of valid values.

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
