### PR TITLE
(v25.6) Skip processing for unlisted tokens in token type cache

### DIFF
--- a/batch/indexer_Position_Bond.py
+++ b/batch/indexer_Position_Bond.py
@@ -246,6 +246,9 @@ class Processor:
                 )
                 self.token_type_cache[listed_token.token_address] = token_info[1]
             token_type = self.token_type_cache[listed_token.token_address]
+            if token_type is None or token_type == "":
+                # Skip if token is not listed in the TokenList contract
+                continue
 
             if token_type == TokenType.IbetStraightBond:
                 # Reuse token contract cache

--- a/batch/indexer_Position_Coupon.py
+++ b/batch/indexer_Position_Coupon.py
@@ -234,6 +234,9 @@ class Processor:
                 )
                 self.token_type_cache[listed_token.token_address] = token_info[1]
             token_type = self.token_type_cache[listed_token.token_address]
+            if token_type is None or token_type == "":
+                # Skip if token is not listed in the TokenList contract
+                continue
 
             if token_type == TokenType.IbetCoupon:
                 # Reuse token contract cache

--- a/batch/indexer_Position_Membership.py
+++ b/batch/indexer_Position_Membership.py
@@ -234,6 +234,9 @@ class Processor:
                 )
                 self.token_type_cache[listed_token.token_address] = token_info[1]
             token_type = self.token_type_cache[listed_token.token_address]
+            if token_type is None or token_type == "":
+                # Skip if token is not listed in the TokenList contract
+                continue
 
             if token_type == TokenType.IbetMembership:
                 # Reuse token contract cache

--- a/batch/indexer_Position_Share.py
+++ b/batch/indexer_Position_Share.py
@@ -246,6 +246,9 @@ class Processor:
                 )
                 self.token_type_cache[listed_token.token_address] = token_info[1]
             token_type = self.token_type_cache[listed_token.token_address]
+            if token_type is None or token_type == "":
+                # Skip if token is not listed in the TokenList contract
+                continue
 
             if token_type == TokenType.IbetShare:
                 # Reuse token contract cache

--- a/batch/indexer_Transfer.py
+++ b/batch/indexer_Transfer.py
@@ -288,6 +288,9 @@ class Processor:
                 )
                 self.token_type_cache[listed_token.token_address] = token_info[1]
             token_type = self.token_type_cache[listed_token.token_address]
+            if token_type is None or token_type == "":
+                # Skip if token is not listed in the TokenList contract
+                continue
 
             skip_timestamp, skip_block_number = await self.__get_latest_synchronized(
                 db_session, listed_token.token_address

--- a/batch/indexer_TransferApproval.py
+++ b/batch/indexer_TransferApproval.py
@@ -211,6 +211,9 @@ class Processor:
                 )
                 self.token_type_cache[listed_token.token_address] = token_info[1]
             token_type = self.token_type_cache[listed_token.token_address]
+            if token_type is None or token_type == "":
+                # Skip if token is not listed in the TokenList contract
+                continue
 
             if (
                 token_type == TokenType.IbetShare


### PR DESCRIPTION
## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->
This pull request introduces a validation step across multiple indexer files to skip processing tokens that are either unlisted or have an empty token type. This change ensures that only valid tokens are processed, improving the robustness of the indexing logic.

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
- Close #1640

## 🔄 Changes

<!-- List the major changes in this PR. -->

### Validation for token type:

* [`batch/indexer_Position_Bond.py`](diffhunk://#diff-e6aee665fd2105ec8714613c9b50a178d710490eb24c89975f79782d6c70d9a8R249-R251): Added a check to skip tokens with `None` or empty string as their type in the `__get_contract_list` method.
* [`batch/indexer_Position_Coupon.py`](diffhunk://#diff-3eb449147237d15155e609df5e7356d468f22207a8e0951f0b7936578ef90192R237-R239): Added the same validation logic in the `__get_contract_list` method for coupon tokens.
* [`batch/indexer_Position_Membership.py`](diffhunk://#diff-f8682018d50b35d8077484e85c45e3b2f9cf7b36481f1235087c1df0b99113aaR237-R239): Applied the token type validation in the `__get_contract_list` method for membership tokens.
* [`batch/indexer_Position_Share.py`](diffhunk://#diff-7c8731c28bc19df2012ab5b9793f86eada370544630547f35c1d6e28938c5b34R249-R251): Included the token type validation in the `__get_contract_list` method for share tokens.
* `batch/indexer_Transfer.py` and `batch/indexer_TransferApproval.py`: Extended the validation to the `__get_token_list` and `__get_contract_list` methods, respectively, to ensure unlisted or invalid tokens are skipped during transfer-related operations. [[1]](diffhunk://#diff-26279c42268d5591a5d3a60f9283de3fdf4776300a976ef0a89815f6872c6df2R291-R293) [[2]](diffhunk://#diff-9a4053b6a86b9174df8df54edeff1a2cc66c62e8378e4c90567cc4cfe0caa8b0R214-R216)


## 📌 Checklist

- [ ] I have added tests where necessary.
- [ ] I have updated the documentation where necessary.
