### PR TITLE
Update account_type to include value 4 in PublicAccount model and API schema

### DIFF
--- a/app/model/db/public_info.py
+++ b/app/model/db/public_info.py
@@ -76,7 +76,7 @@ class PublicAccountList(Base):
     # Key Manager Name
     key_manager_name: Mapped[str] = mapped_column(String(200), nullable=False)
     # Account Type
-    account_type: Mapped[Literal[1, 2, 3]] = mapped_column(Integer, primary_key=True)
+    account_type: Mapped[Literal[1, 2, 3, 4]] = mapped_column(Integer, primary_key=True)
     # Account Address
     account_address: Mapped[str] = mapped_column(String(42), nullable=False)
 

--- a/app/model/schema/public_info.py
+++ b/app/model/schema/public_info.py
@@ -51,7 +51,7 @@ class IbetShareToken(TokenBase):
 class PublicAccount(BaseModel):
     key_manager: str
     key_manager_name: str
-    account_type: Literal[1, 2, 3]
+    account_type: Literal[1, 2, 3, 4]
     account_address: EthereumAddress
     modified: str = Field(..., description="Updated Datetime (local timezone)")
 

--- a/docs/ibet_wallet_api.yaml
+++ b/docs/ibet_wallet_api.yaml
@@ -9628,6 +9628,7 @@ components:
             - 1
             - 2
             - 3
+            - 4
           title: Account Type
         account_address:
           type: string


### PR DESCRIPTION
## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->

This pull request introduces a new account type (`4`) to the system, updating the relevant database model, schema, and API documentation to ensure consistency across the application.

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
- Related to #1636 

## 🔄 Changes

### Updates to support the new account type:

* **Database model update:**
  - Expanded the `account_type` field in `class PublicAccountList` to include `Literal[1, 2, 3, 4]`. (`app/model/db/public_info.py`, [app/model/db/public_info.pyL79-R79](diffhunk://#diff-32a542de7df291104133e7a8e214d1dc33bc5486d602f26e462055fcbea1797cL79-R79))

* **Schema update:**
  - Updated the `account_type` field in `class PublicAccount` to include `Literal[1, 2, 3, 4]`. (`app/model/schema/public_info.py`, [app/model/schema/public_info.pyL54-R54](diffhunk://#diff-b8e5bdbf84c6017b002df4f3b0e606f540eef057d16bb331f9ce578aa8c01e41L54-R54))

* **API documentation update:**
  - Added `4` as a valid account type in the `components` section of `ibet_wallet_api.yaml`. (`docs/ibet_wallet_api.yaml`, [docs/ibet_wallet_api.yamlR9631](diffhunk://#diff-0d3dd149478fabbb3f19d0a1bcd53189156e1c767a9ba57e8e2c6a2d72eaa1c1R9631))

## 📌 Checklist

- [ ] I have added tests where necessary.
- [ ] I have updated the documentation where necessary.
