### PR TITLE
Replace aiohttp with requests in batch processing modules

### DIFF
--- a/batch/indexer_Company_List.py
+++ b/batch/indexer_Company_List.py
@@ -17,27 +17,32 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
-import asyncio
 import hashlib
 import json
 import sys
 import time
 
-import aiohttp
-from aiohttp import ClientTimeout
+import requests
 from eth_utils import to_checksum_address
 from sqlalchemy import delete
+from sqlalchemy.engine.create import create_engine
 from sqlalchemy.exc import SQLAlchemyError
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm.session import Session
 
-from app.config import COMPANY_LIST_SLEEP_INTERVAL, COMPANY_LIST_URL, REQUEST_TIMEOUT
-from app.database import BatchAsyncSessionLocal
+from app.config import (
+    COMPANY_LIST_SLEEP_INTERVAL,
+    COMPANY_LIST_URL,
+    DATABASE_URL,
+    REQUEST_TIMEOUT,
+)
 from app.errors import ServiceUnavailable
 from app.model.db import Company
 from batch import free_malloc, log
 
 process_name = "INDEXER-COMPANY-LIST"
 LOG = log.get_logger(process_name=process_name)
+
+db_engine = create_engine(DATABASE_URL, echo=False, pool_pre_ping=True)
 
 
 class Processor:
@@ -46,21 +51,15 @@ class Processor:
     def __init__(self):
         self.company_list_digest = None
 
-    async def process(self):
+    def process(self):
         LOG.info("Syncing company list")
 
         # Get from COMPANY_LIST_URL
         try:
-            async with aiohttp.ClientSession(trust_env=True) as session:
-                async with session.get(
-                    COMPANY_LIST_URL,
-                    timeout=ClientTimeout(
-                        connect=REQUEST_TIMEOUT[0], total=REQUEST_TIMEOUT[1]
-                    ),
-                ) as response:
-                    if response.status != 200:
-                        raise Exception(f"status code={response.status}")
-                    company_list_json = await response.json()
+            _resp = requests.get(COMPANY_LIST_URL, timeout=REQUEST_TIMEOUT)
+            if _resp.status_code != 200:
+                raise Exception(f"status code={_resp.status_code}")
+            company_list_json = _resp.json()
         except Exception:
             LOG.exception("Failed to get company list")
             return
@@ -76,10 +75,10 @@ class Processor:
             self.company_list_digest = _resp_digest
 
         # Update DB data
-        db_session = BatchAsyncSessionLocal()
+        db_session = Session(autocommit=False, autoflush=True, bind=db_engine)
         try:
             # Delete all company list from DB
-            await db_session.execute(delete(Company))
+            db_session.execute(delete(Company))
 
             # Insert company list
             for i, company in enumerate(company_list_json):
@@ -105,7 +104,7 @@ class Processor:
                     except ValueError:
                         LOG.notice(f"Invalid address: index={i} address={address}")
                         continue
-                    await self.__sink_on_company(
+                    self.__sink_on_company(
                         db_session=db_session,
                         address=to_checksum_address(address),
                         corporate_name=corporate_name,
@@ -116,17 +115,17 @@ class Processor:
                     LOG.notice(f"Missing required field: index={i}")
                     continue
 
-            await db_session.commit()
-        except Exception as e:
-            await db_session.rollback()
-            raise e
+            db_session.commit()
+        except Exception:
+            db_session.rollback()
+            raise
         finally:
-            await db_session.close()
+            db_session.close()
         LOG.info("Sync job has been completed")
 
     @staticmethod
-    async def __sink_on_company(
-        db_session: AsyncSession,
+    def __sink_on_company(
+        db_session: Session,
         address: str,
         corporate_name: str,
         rsa_publickey: str,
@@ -137,17 +136,17 @@ class Processor:
         _company.corporate_name = corporate_name
         _company.rsa_publickey = rsa_publickey
         _company.homepage = homepage
-        await db_session.merge(_company)
+        db_session.merge(_company)
 
 
-async def main():
+def main():
     LOG.info("Service started successfully")
     processor = Processor()
     while True:
         start_time = time.time()
 
         try:
-            await processor.process()
+            processor.process()
         except ServiceUnavailable:
             LOG.notice("An external service was unavailable")
         except SQLAlchemyError as sa_err:
@@ -156,12 +155,12 @@ async def main():
             LOG.exception("An exception occurred during processing")
 
         elapsed_time = time.time() - start_time
-        await asyncio.sleep(max(COMPANY_LIST_SLEEP_INTERVAL - elapsed_time, 0))
+        time.sleep(max(COMPANY_LIST_SLEEP_INTERVAL - elapsed_time, 0))
         free_malloc()
 
 
 if __name__ == "__main__":
     try:
-        asyncio.run(main())
+        main()
     except KeyboardInterrupt:
         sys.exit(1)

--- a/batch/indexer_PublicInfo_PublicAccountList.py
+++ b/batch/indexer_PublicInfo_PublicAccountList.py
@@ -17,31 +17,32 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
-import asyncio
 import hashlib
 import json
 import sys
 import time
 
-import aiohttp
-from aiohttp import ClientTimeout
+import requests
 from eth_utils import to_checksum_address
 from sqlalchemy import delete
+from sqlalchemy.engine.create import create_engine
 from sqlalchemy.exc import SQLAlchemyError
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm.session import Session
 
 from app.config import (
+    DATABASE_URL,
     PUBLIC_ACCOUNT_LIST_SLEEP_INTERVAL,
     PUBLIC_ACCOUNT_LIST_URL,
     REQUEST_TIMEOUT,
 )
-from app.database import BatchAsyncSessionLocal
 from app.errors import ServiceUnavailable
 from app.model.db import PublicAccountList
 from batch import free_malloc, log
 
 process_name = "INDEXER-PUBLIC-INFO-PUBLIC-ACCOUNT"
 LOG = log.get_logger(process_name=process_name)
+
+db_engine = create_engine(DATABASE_URL, echo=False, pool_pre_ping=True)
 
 
 class Processor:
@@ -50,21 +51,15 @@ class Processor:
     def __init__(self):
         self.account_list_digest = None
 
-    async def process(self):
+    def process(self):
         LOG.info("Syncing public account list")
 
         # Get data from PUBLIC_ACCOUNT_LIST_URL
         try:
-            async with aiohttp.ClientSession(trust_env=True) as session:
-                async with session.get(
-                    PUBLIC_ACCOUNT_LIST_URL,
-                    timeout=ClientTimeout(
-                        connect=REQUEST_TIMEOUT[0], total=REQUEST_TIMEOUT[1]
-                    ),
-                ) as response:
-                    if response.status != 200:
-                        raise Exception(f"status code={response.status}")
-                    account_list_json = await response.json()
+            _resp = requests.get(PUBLIC_ACCOUNT_LIST_URL, timeout=REQUEST_TIMEOUT)
+            if _resp.status_code != 200:
+                raise Exception(f"status code={_resp.status_code}")
+            account_list_json = _resp.json()
         except Exception:
             LOG.exception("Failed to get public account list")
             return
@@ -80,10 +75,10 @@ class Processor:
             self.account_list_digest = _resp_digest
 
         # Update DB data
-        db_session = BatchAsyncSessionLocal()
+        db_session = Session(autocommit=False, autoflush=True, bind=db_engine)
         try:
             # Delete all account list from DB
-            await db_session.execute(delete(PublicAccountList))
+            db_session.execute(delete(PublicAccountList))
 
             # Insert account list
             for i, _account in enumerate(account_list_json):
@@ -109,7 +104,7 @@ class Processor:
                         f"Invalid address: index={i} account_address={account_address}"
                     )
                     continue
-                await self.__sink_on_account_list(
+                self.__sink_on_account_list(
                     db_session=db_session,
                     key_manager=key_manager,
                     key_manager_name=key_manager_name,
@@ -117,18 +112,18 @@ class Processor:
                     account_address=account_address,
                 )
 
-            await db_session.commit()
+            db_session.commit()
         except Exception as e:
-            await db_session.rollback()
+            db_session.rollback()
             raise e
         finally:
-            await db_session.close()
+            db_session.close()
 
         LOG.info("Sync job has been completed")
 
     @staticmethod
-    async def __sink_on_account_list(
-        db_session: AsyncSession,
+    def __sink_on_account_list(
+        db_session: Session,
         key_manager: str,
         key_manager_name: str,
         account_type: int,
@@ -139,17 +134,17 @@ class Processor:
         _account_list.key_manager_name = key_manager_name
         _account_list.account_type = account_type
         _account_list.account_address = account_address
-        await db_session.merge(_account_list)
+        db_session.merge(_account_list)
 
 
-async def main():
+def main():
     LOG.info("Service started successfully")
     processor = Processor()
     while True:
         start_time = time.time()
 
         try:
-            await processor.process()
+            processor.process()
         except ServiceUnavailable:
             LOG.notice("An external service was unavailable")
         except SQLAlchemyError as sa_err:
@@ -158,12 +153,12 @@ async def main():
             LOG.exception("An exception occurred during processing")
 
         elapsed_time = time.time() - start_time
-        await asyncio.sleep(max(PUBLIC_ACCOUNT_LIST_SLEEP_INTERVAL - elapsed_time, 0))
+        time.sleep(max(PUBLIC_ACCOUNT_LIST_SLEEP_INTERVAL - elapsed_time, 0))
         free_malloc()
 
 
 if __name__ == "__main__":
     try:
-        asyncio.run(main())
+        main()
     except KeyboardInterrupt:
         sys.exit(1)

--- a/batch/indexer_PublicInfo_TokenList.py
+++ b/batch/indexer_PublicInfo_TokenList.py
@@ -17,27 +17,32 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
-import asyncio
 import hashlib
 import json
 import sys
 import time
 
-import aiohttp
-from aiohttp import ClientTimeout
+import requests
 from eth_utils import to_checksum_address
 from sqlalchemy import delete
+from sqlalchemy.engine.create import create_engine
 from sqlalchemy.exc import SQLAlchemyError
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm.session import Session
 
-from app.config import REQUEST_TIMEOUT, TOKEN_LIST_SLEEP_INTERVAL, TOKEN_LIST_URL
-from app.database import BatchAsyncSessionLocal
+from app.config import (
+    DATABASE_URL,
+    REQUEST_TIMEOUT,
+    TOKEN_LIST_SLEEP_INTERVAL,
+    TOKEN_LIST_URL,
+)
 from app.errors import ServiceUnavailable
 from app.model.db import TokenList
 from batch import free_malloc, log
 
 process_name = "INDEXER-PUBLIC-INFO-TOKEN-LIST"
 LOG = log.get_logger(process_name=process_name)
+
+db_engine = create_engine(DATABASE_URL, echo=False, pool_pre_ping=True)
 
 
 class Processor:
@@ -46,21 +51,15 @@ class Processor:
     def __init__(self):
         self.token_list_digest = None
 
-    async def process(self):
+    def process(self):
         LOG.info("Syncing token list")
 
         # Get from TOKEN_LIST_URL
         try:
-            async with aiohttp.ClientSession(trust_env=True) as session:
-                async with session.get(
-                    TOKEN_LIST_URL,
-                    timeout=ClientTimeout(
-                        connect=REQUEST_TIMEOUT[0], total=REQUEST_TIMEOUT[1]
-                    ),
-                ) as response:
-                    if response.status != 200:
-                        raise Exception(f"status code={response.status}")
-                    token_list_json = await response.json()
+            _resp = requests.get(TOKEN_LIST_URL, timeout=REQUEST_TIMEOUT)
+            if _resp.status_code != 200:
+                raise Exception(f"status code={_resp.status_code}")
+            token_list_json = _resp.json()
         except Exception:
             LOG.exception("Failed to get token list")
             return
@@ -74,10 +73,10 @@ class Processor:
             self.token_list_digest = _resp_digest
 
         # Update DB data
-        db_session = BatchAsyncSessionLocal()
+        db_session = Session(autocommit=False, autoflush=True, bind=db_engine)
         try:
             # Delete all token list from DB
-            await db_session.execute(delete(TokenList))
+            db_session.execute(delete(TokenList))
 
             # Insert token list
             for i, token in enumerate(token_list_json):
@@ -104,7 +103,7 @@ class Processor:
                     )
                     continue
 
-                await self.__sink_on_token_list(
+                self.__sink_on_token_list(
                     db_session=db_session,
                     token_address=token_address,
                     token_template=token_template,
@@ -112,18 +111,18 @@ class Processor:
                     product_type=product_type,
                 )
 
-            await db_session.commit()
+            db_session.commit()
         except Exception as e:
-            await db_session.rollback()
+            db_session.rollback()
             raise e
         finally:
-            await db_session.close()
+            db_session.close()
 
         LOG.info("Sync job has been completed")
 
     @staticmethod
-    async def __sink_on_token_list(
-        db_session: AsyncSession,
+    def __sink_on_token_list(
+        db_session: Session,
         token_address: str,
         token_template: str,
         key_manager: list[str],
@@ -134,17 +133,17 @@ class Processor:
         _token_list.token_template = token_template
         _token_list.key_manager = key_manager
         _token_list.product_type = product_type
-        await db_session.merge(_token_list)
+        db_session.merge(_token_list)
 
 
-async def main():
+def main():
     LOG.info("Service started successfully")
     processor = Processor()
     while True:
         start_time = time.time()
 
         try:
-            await processor.process()
+            processor.process()
         except ServiceUnavailable:
             LOG.notice("An external service was unavailable")
         except SQLAlchemyError as sa_err:
@@ -153,12 +152,12 @@ async def main():
             LOG.exception("An exception occurred during processing")
 
         elapsed_time = time.time() - start_time
-        await asyncio.sleep(max(TOKEN_LIST_SLEEP_INTERVAL - elapsed_time, 0))
+        time.sleep(max(TOKEN_LIST_SLEEP_INTERVAL - elapsed_time, 0))
         free_malloc()
 
 
 if __name__ == "__main__":
     try:
-        asyncio.run(main())
+        main()
     except KeyboardInterrupt:
         sys.exit(1)

--- a/batch/processor_Send_Chat_Webhook.py
+++ b/batch/processor_Send_Chat_Webhook.py
@@ -17,67 +17,68 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
-import asyncio
 import sys
 import time
 from typing import Sequence
 
-import aiohttp
+import requests
 from sqlalchemy import select
+from sqlalchemy.engine.create import create_engine
 from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm.session import Session
 
-from app.config import CHAT_WEBHOOK_URL
-from app.database import BatchAsyncSessionLocal
+from app.config import CHAT_WEBHOOK_URL, DATABASE_URL
 from app.model.db import ChatWebhook
 from batch import free_malloc, log
 
 LOG = log.get_logger(process_name="PROCESSOR-SEND-CHAT-WEBHOOK")
 
+db_engine = create_engine(DATABASE_URL, echo=False, pool_pre_ping=True)
+
 
 class Processor:
-    async def process(self):
-        db_session = BatchAsyncSessionLocal()
+    def process(self):
+        db_session = Session(autocommit=False, autoflush=True, bind=db_engine)
         try:
             hook_list: Sequence[ChatWebhook] = (
-                await db_session.scalars(select(ChatWebhook))
+                db_session.scalars(select(ChatWebhook))
             ).all()
             if len(hook_list) > 0:
                 LOG.info("Process start")
 
                 for hook in hook_list:
                     try:
-                        async with aiohttp.ClientSession(trust_env=True) as session:
-                            await session.post(CHAT_WEBHOOK_URL, json=hook.message)
+                        requests.post(CHAT_WEBHOOK_URL, json=hook.message)
                     except Exception:
                         LOG.exception("Failed to send chat webhook")
                     finally:
                         # Delete the message regardless of the status code of the response.
-                        await db_session.delete(hook)
-                        await db_session.commit()
+                        db_session.delete(hook)
+                        db_session.commit()
                 LOG.info("Process end")
         finally:
-            await db_session.close()
+            db_session.close()
 
 
-async def main():
+def main():
     LOG.info("Service started successfully")
     processor = Processor()
     while True:
         start_time = time.time()
         try:
-            await processor.process()
+            processor.process()
         except SQLAlchemyError as sa_err:
             LOG.error(f"A database error has occurred: code={sa_err.code}\n{sa_err}")
         except Exception as ex:
             LOG.exception(ex)
 
         elapsed_time = time.time() - start_time
-        await asyncio.sleep(max(30 - elapsed_time, 0))
+        time.sleep(max(30 - elapsed_time, 0))
         free_malloc()
 
 
 if __name__ == "__main__":
     try:
-        asyncio.run(main())
+        main()
     except KeyboardInterrupt:
         sys.exit(1)

--- a/cmd/explorer/pyproject.toml
+++ b/cmd/explorer/pyproject.toml
@@ -6,8 +6,11 @@ authors = [
     {name = "BOOSTRY Co., Ltd.", email = "dev@boostry.co.jp"},
 ]
 readme = "README.md"
-requires-python = "==3.12.2"
-dependencies = []
+requires-python = "==3.12.9"
+dependencies = [
+    "aiohttp>=3.12.13",
+    "async-cache>=1.1.1",
+]
 
 [project.scripts]
 ibet-explorer = "main:app"

--- a/cmd/explorer/uv.lock
+++ b/cmd/explorer/uv.lock
@@ -1,7 +1,204 @@
 version = 1
-requires-python = "==3.12.2"
+revision = 2
+requires-python = "==3.12.9"
+
+[[package]]
+name = "aiohappyeyeballs"
+version = "2.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/30/f84a107a9c4331c14b2b586036f40965c128aa4fee4dda5d3d51cb14ad54/aiohappyeyeballs-2.6.1.tar.gz", hash = "sha256:c3f9d0113123803ccadfdf3f0faa505bc78e6a72d1cc4806cbd719826e943558", size = 22760, upload-time = "2025-03-12T01:42:48.764Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/15/5bf3b99495fb160b63f95972b81750f18f7f4e02ad051373b669d17d44f2/aiohappyeyeballs-2.6.1-py3-none-any.whl", hash = "sha256:f349ba8f4b75cb25c99c5c2d84e997e485204d2902a9597802b0371f09331fb8", size = 15265, upload-time = "2025-03-12T01:42:47.083Z" },
+]
+
+[[package]]
+name = "aiohttp"
+version = "3.12.13"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohappyeyeballs" },
+    { name = "aiosignal" },
+    { name = "attrs" },
+    { name = "frozenlist" },
+    { name = "multidict" },
+    { name = "propcache" },
+    { name = "yarl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/6e/ab88e7cb2a4058bed2f7870276454f85a7c56cd6da79349eb314fc7bbcaa/aiohttp-3.12.13.tar.gz", hash = "sha256:47e2da578528264a12e4e3dd8dd72a7289e5f812758fe086473fab037a10fcce", size = 7819160, upload-time = "2025-06-14T15:15:41.354Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/6a/ce40e329788013cd190b1d62bbabb2b6a9673ecb6d836298635b939562ef/aiohttp-3.12.13-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0aa580cf80558557285b49452151b9c69f2fa3ad94c5c9e76e684719a8791b73", size = 700491, upload-time = "2025-06-14T15:14:00.048Z" },
+    { url = "https://files.pythonhosted.org/packages/28/d9/7150d5cf9163e05081f1c5c64a0cdf3c32d2f56e2ac95db2a28fe90eca69/aiohttp-3.12.13-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b103a7e414b57e6939cc4dece8e282cfb22043efd0c7298044f6594cf83ab347", size = 475104, upload-time = "2025-06-14T15:14:01.691Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/91/d42ba4aed039ce6e449b3e2db694328756c152a79804e64e3da5bc19dffc/aiohttp-3.12.13-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:78f64e748e9e741d2eccff9597d09fb3cd962210e5b5716047cbb646dc8fe06f", size = 467948, upload-time = "2025-06-14T15:14:03.561Z" },
+    { url = "https://files.pythonhosted.org/packages/99/3b/06f0a632775946981d7c4e5a865cddb6e8dfdbaed2f56f9ade7bb4a1039b/aiohttp-3.12.13-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c955989bf4c696d2ededc6b0ccb85a73623ae6e112439398935362bacfaaf6", size = 1714742, upload-time = "2025-06-14T15:14:05.558Z" },
+    { url = "https://files.pythonhosted.org/packages/92/a6/2552eebad9ec5e3581a89256276009e6a974dc0793632796af144df8b740/aiohttp-3.12.13-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:d640191016763fab76072c87d8854a19e8e65d7a6fcfcbf017926bdbbb30a7e5", size = 1697393, upload-time = "2025-06-14T15:14:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/9f/bd08fdde114b3fec7a021381b537b21920cdd2aa29ad48c5dffd8ee314f1/aiohttp-3.12.13-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4dc507481266b410dede95dd9f26c8d6f5a14315372cc48a6e43eac652237d9b", size = 1752486, upload-time = "2025-06-14T15:14:08.808Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/e1/affdea8723aec5bd0959171b5490dccd9a91fcc505c8c26c9f1dca73474d/aiohttp-3.12.13-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8a94daa873465d518db073bd95d75f14302e0208a08e8c942b2f3f1c07288a75", size = 1798643, upload-time = "2025-06-14T15:14:10.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/9d/666d856cc3af3a62ae86393baa3074cc1d591a47d89dc3bf16f6eb2c8d32/aiohttp-3.12.13-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:177f52420cde4ce0bb9425a375d95577fe082cb5721ecb61da3049b55189e4e6", size = 1718082, upload-time = "2025-06-14T15:14:12.38Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/ce/3c185293843d17be063dada45efd2712bb6bf6370b37104b4eda908ffdbd/aiohttp-3.12.13-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0f7df1f620ec40f1a7fbcb99ea17d7326ea6996715e78f71a1c9a021e31b96b8", size = 1633884, upload-time = "2025-06-14T15:14:14.415Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/5b/f3413f4b238113be35dfd6794e65029250d4b93caa0974ca572217745bdb/aiohttp-3.12.13-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3062d4ad53b36e17796dce1c0d6da0ad27a015c321e663657ba1cc7659cfc710", size = 1694943, upload-time = "2025-06-14T15:14:16.48Z" },
+    { url = "https://files.pythonhosted.org/packages/82/c8/0e56e8bf12081faca85d14a6929ad5c1263c146149cd66caa7bc12255b6d/aiohttp-3.12.13-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:8605e22d2a86b8e51ffb5253d9045ea73683d92d47c0b1438e11a359bdb94462", size = 1716398, upload-time = "2025-06-14T15:14:18.589Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f3/33192b4761f7f9b2f7f4281365d925d663629cfaea093a64b658b94fc8e1/aiohttp-3.12.13-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:54fbbe6beafc2820de71ece2198458a711e224e116efefa01b7969f3e2b3ddae", size = 1657051, upload-time = "2025-06-14T15:14:20.223Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/0b/26ddd91ca8f84c48452431cb4c5dd9523b13bc0c9766bda468e072ac9e29/aiohttp-3.12.13-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:050bd277dfc3768b606fd4eae79dd58ceda67d8b0b3c565656a89ae34525d15e", size = 1736611, upload-time = "2025-06-14T15:14:21.988Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/8d/e04569aae853302648e2c138a680a6a2f02e374c5b6711732b29f1e129cc/aiohttp-3.12.13-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:2637a60910b58f50f22379b6797466c3aa6ae28a6ab6404e09175ce4955b4e6a", size = 1764586, upload-time = "2025-06-14T15:14:23.979Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/98/c193c1d1198571d988454e4ed75adc21c55af247a9fda08236602921c8c8/aiohttp-3.12.13-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e986067357550d1aaa21cfe9897fa19e680110551518a5a7cf44e6c5638cb8b5", size = 1724197, upload-time = "2025-06-14T15:14:25.692Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/9e/07bb8aa11eec762c6b1ff61575eeeb2657df11ab3d3abfa528d95f3e9337/aiohttp-3.12.13-cp312-cp312-win32.whl", hash = "sha256:ac941a80aeea2aaae2875c9500861a3ba356f9ff17b9cb2dbfb5cbf91baaf5bf", size = 421771, upload-time = "2025-06-14T15:14:27.364Z" },
+    { url = "https://files.pythonhosted.org/packages/52/66/3ce877e56ec0813069cdc9607cd979575859c597b6fb9b4182c6d5f31886/aiohttp-3.12.13-cp312-cp312-win_amd64.whl", hash = "sha256:671f41e6146a749b6c81cb7fd07f5a8356d46febdaaaf07b0e774ff04830461e", size = 447869, upload-time = "2025-06-14T15:14:29.05Z" },
+]
+
+[[package]]
+name = "aiosignal"
+version = "1.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "frozenlist" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ba/b5/6d55e80f6d8a08ce22b982eafa278d823b541c925f11ee774b0b9c43473d/aiosignal-1.3.2.tar.gz", hash = "sha256:a8c255c66fafb1e499c9351d0bf32ff2d8a0321595ebac3b93713656d2436f54", size = 19424, upload-time = "2024-12-13T17:10:40.86Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/6a/bc7e17a3e87a2985d3e8f4da4cd0f481060eb78fb08596c42be62c90a4d9/aiosignal-1.3.2-py2.py3-none-any.whl", hash = "sha256:45cde58e409a301715980c2b01d0c28bdde3770d8290b5eb2173759d9acb31a5", size = 7597, upload-time = "2024-12-13T17:10:38.469Z" },
+]
+
+[[package]]
+name = "async-cache"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/6e/908402652bf7d8ab02fa204399d9517d247fb3a0926045a8c8a28708cd40/async-cache-1.1.1.tar.gz", hash = "sha256:81aa9ccd19fb06784aaf30bd5f2043dc0a23fc3e998b93d0c2c17d1af9803393", size = 3848, upload-time = "2021-07-03T18:24:36.769Z" }
+
+[[package]]
+name = "attrs"
+version = "25.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/b0/1367933a8532ee6ff8d63537de4f1177af4bff9f3e829baf7331f595bb24/attrs-25.3.0.tar.gz", hash = "sha256:75d7cefc7fb576747b2c81b4442d4d4a1ce0900973527c011d1030fd3bf4af1b", size = 812032, upload-time = "2025-03-13T11:10:22.779Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/06/bb80f5f86020c4551da315d78b3ab75e8228f89f0162f2c3a819e407941a/attrs-25.3.0-py3-none-any.whl", hash = "sha256:427318ce031701fea540783410126f03899a97ffc6f61596ad581ac2e40e3bc3", size = 63815, upload-time = "2025-03-13T11:10:21.14Z" },
+]
+
+[[package]]
+name = "frozenlist"
+version = "1.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/b1/b64018016eeb087db503b038296fd782586432b9c077fc5c7839e9cb6ef6/frozenlist-1.7.0.tar.gz", hash = "sha256:2e310d81923c2437ea8670467121cc3e9b0f76d3043cc1d2331d56c7fb7a3a8f", size = 45078, upload-time = "2025-06-09T23:02:35.538Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/a2/c8131383f1e66adad5f6ecfcce383d584ca94055a34d683bbb24ac5f2f1c/frozenlist-1.7.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3dbf9952c4bb0e90e98aec1bd992b3318685005702656bc6f67c1a32b76787f2", size = 81424, upload-time = "2025-06-09T23:00:42.24Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/9d/02754159955088cb52567337d1113f945b9e444c4960771ea90eb73de8db/frozenlist-1.7.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:1f5906d3359300b8a9bb194239491122e6cf1444c2efb88865426f170c262cdb", size = 47952, upload-time = "2025-06-09T23:00:43.481Z" },
+    { url = "https://files.pythonhosted.org/packages/01/7a/0046ef1bd6699b40acd2067ed6d6670b4db2f425c56980fa21c982c2a9db/frozenlist-1.7.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3dabd5a8f84573c8d10d8859a50ea2dec01eea372031929871368c09fa103478", size = 46688, upload-time = "2025-06-09T23:00:44.793Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/a2/a910bafe29c86997363fb4c02069df4ff0b5bc39d33c5198b4e9dd42d8f8/frozenlist-1.7.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aa57daa5917f1738064f302bf2626281a1cb01920c32f711fbc7bc36111058a8", size = 243084, upload-time = "2025-06-09T23:00:46.125Z" },
+    { url = "https://files.pythonhosted.org/packages/64/3e/5036af9d5031374c64c387469bfcc3af537fc0f5b1187d83a1cf6fab1639/frozenlist-1.7.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:c193dda2b6d49f4c4398962810fa7d7c78f032bf45572b3e04dd5249dff27e08", size = 233524, upload-time = "2025-06-09T23:00:47.73Z" },
+    { url = "https://files.pythonhosted.org/packages/06/39/6a17b7c107a2887e781a48ecf20ad20f1c39d94b2a548c83615b5b879f28/frozenlist-1.7.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bfe2b675cf0aaa6d61bf8fbffd3c274b3c9b7b1623beb3809df8a81399a4a9c4", size = 248493, upload-time = "2025-06-09T23:00:49.742Z" },
+    { url = "https://files.pythonhosted.org/packages/be/00/711d1337c7327d88c44d91dd0f556a1c47fb99afc060ae0ef66b4d24793d/frozenlist-1.7.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8fc5d5cda37f62b262405cf9652cf0856839c4be8ee41be0afe8858f17f4c94b", size = 244116, upload-time = "2025-06-09T23:00:51.352Z" },
+    { url = "https://files.pythonhosted.org/packages/24/fe/74e6ec0639c115df13d5850e75722750adabdc7de24e37e05a40527ca539/frozenlist-1.7.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b0d5ce521d1dd7d620198829b87ea002956e4319002ef0bc8d3e6d045cb4646e", size = 224557, upload-time = "2025-06-09T23:00:52.855Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/db/48421f62a6f77c553575201e89048e97198046b793f4a089c79a6e3268bd/frozenlist-1.7.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:488d0a7d6a0008ca0db273c542098a0fa9e7dfaa7e57f70acef43f32b3f69dca", size = 241820, upload-time = "2025-06-09T23:00:54.43Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/fa/cb4a76bea23047c8462976ea7b7a2bf53997a0ca171302deae9d6dd12096/frozenlist-1.7.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:15a7eaba63983d22c54d255b854e8108e7e5f3e89f647fc854bd77a237e767df", size = 236542, upload-time = "2025-06-09T23:00:56.409Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/32/476a4b5cfaa0ec94d3f808f193301debff2ea42288a099afe60757ef6282/frozenlist-1.7.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:1eaa7e9c6d15df825bf255649e05bd8a74b04a4d2baa1ae46d9c2d00b2ca2cb5", size = 249350, upload-time = "2025-06-09T23:00:58.468Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/ba/9a28042f84a6bf8ea5dbc81cfff8eaef18d78b2a1ad9d51c7bc5b029ad16/frozenlist-1.7.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:e4389e06714cfa9d47ab87f784a7c5be91d3934cd6e9a7b85beef808297cc025", size = 225093, upload-time = "2025-06-09T23:01:00.015Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/29/3a32959e68f9cf000b04e79ba574527c17e8842e38c91d68214a37455786/frozenlist-1.7.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:73bd45e1488c40b63fe5a7df892baf9e2a4d4bb6409a2b3b78ac1c6236178e01", size = 245482, upload-time = "2025-06-09T23:01:01.474Z" },
+    { url = "https://files.pythonhosted.org/packages/80/e8/edf2f9e00da553f07f5fa165325cfc302dead715cab6ac8336a5f3d0adc2/frozenlist-1.7.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:99886d98e1643269760e5fe0df31e5ae7050788dd288947f7f007209b8c33f08", size = 249590, upload-time = "2025-06-09T23:01:02.961Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/80/9a0eb48b944050f94cc51ee1c413eb14a39543cc4f760ed12657a5a3c45a/frozenlist-1.7.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:290a172aae5a4c278c6da8a96222e6337744cd9c77313efe33d5670b9f65fc43", size = 237785, upload-time = "2025-06-09T23:01:05.095Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/74/87601e0fb0369b7a2baf404ea921769c53b7ae00dee7dcfe5162c8c6dbf0/frozenlist-1.7.0-cp312-cp312-win32.whl", hash = "sha256:426c7bc70e07cfebc178bc4c2bf2d861d720c4fff172181eeb4a4c41d4ca2ad3", size = 39487, upload-time = "2025-06-09T23:01:06.54Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/15/c026e9a9fc17585a9d461f65d8593d281fedf55fbf7eb53f16c6df2392f9/frozenlist-1.7.0-cp312-cp312-win_amd64.whl", hash = "sha256:563b72efe5da92e02eb68c59cb37205457c977aa7a449ed1b37e6939e5c47c6a", size = 43874, upload-time = "2025-06-09T23:01:07.752Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/45/b82e3c16be2182bff01179db177fe144d58b5dc787a7d4492c6ed8b9317f/frozenlist-1.7.0-py3-none-any.whl", hash = "sha256:9a5af342e34f7e97caf8c995864c7a396418ae2859cc6fdf1b1073020d516a7e", size = 13106, upload-time = "2025-06-09T23:02:34.204Z" },
+]
 
 [[package]]
 name = "ibet-wallet-api-explorer"
 version = "0.1.0"
 source = { virtual = "." }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "async-cache" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "aiohttp", specifier = ">=3.12.13" },
+    { name = "async-cache", specifier = ">=1.1.1" },
+]
+
+[[package]]
+name = "idna"
+version = "3.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload-time = "2024-09-15T18:07:39.745Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload-time = "2024-09-15T18:07:37.964Z" },
+]
+
+[[package]]
+name = "multidict"
+version = "6.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/43/2d90c414d9efc4587d6e7cebae9f2c2d8001bcb4f89ed514ae837e9dcbe6/multidict-6.5.1.tar.gz", hash = "sha256:a835ea8103f4723915d7d621529c80ef48db48ae0c818afcabe0f95aa1febc3a", size = 98690, upload-time = "2025-06-24T22:16:05.117Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/36/225fb9b890607d740f61957febf622f5c9cd9e641a93502c7877934d57ef/multidict-6.5.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:48f95fe064f63d9601ef7a3dce2fc2a437d5fcc11bca960bc8be720330b13b6a", size = 74287, upload-time = "2025-06-24T22:14:29.456Z" },
+    { url = "https://files.pythonhosted.org/packages/70/e5/c9eabb16ecf77275664413263527ab169e08371dfa6b168025d8f67261fd/multidict-6.5.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7b7b6e1ce9b61f721417c68eeeb37599b769f3b631e6b25c21f50f8f619420b9", size = 44092, upload-time = "2025-06-24T22:14:30.686Z" },
+    { url = "https://files.pythonhosted.org/packages/df/0b/dd9322a432c477a2e6d089bbb53acb68ed25515b8292dbc60f27e7e45d70/multidict-6.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8b83b055889bda09fc866c0a652cdb6c36eeeafc2858259c9a7171fe82df5773", size = 42565, upload-time = "2025-06-24T22:14:31.8Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/ac/22f5b4e55a4bc99f9622de280f7da366c1d7f29ec4eec9d339cb2ba62019/multidict-6.5.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b7bd4d655dc460c7aebb73b58ed1c074e85f7286105b012556cf0f25c6d1dba3", size = 254896, upload-time = "2025-06-24T22:14:32.865Z" },
+    { url = "https://files.pythonhosted.org/packages/09/dc/2f6d96d4a80ec731579cb69532fac33cbbda2a838079ae0c47c6e8f5545b/multidict-6.5.1-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:aa6dcf25ced31cdce10f004506dbc26129f28a911b32ed10e54453a0842a6173", size = 236854, upload-time = "2025-06-24T22:14:34.185Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/cb/ef38a69ee75e8b72e5cff9ed4cff92379eadd057a99eaf4893494bf6ab64/multidict-6.5.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:059fb556c3e6ce1a168496f92ef139ad839a47f898eaa512b1d43e5e05d78c6b", size = 265131, upload-time = "2025-06-24T22:14:35.534Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/9e/85d9fe9e658e0edf566c02181248fa2aaf5e53134df0c80f7231ce5fc689/multidict-6.5.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f97680c839dd9fa208e9584b1c2a5f1224bd01d31961f7f7d94984408c4a6b9e", size = 262187, upload-time = "2025-06-24T22:14:36.891Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/1c/b46ec1dd78c3faa55bffb354410c48fadd81029a144cd056828c82ca15b4/multidict-6.5.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7710c716243525cc05cd038c6e09f1807ee0fef2510a6e484450712c389c8d7f", size = 251220, upload-time = "2025-06-24T22:14:38.584Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/6b/481ec5179ddc7da8b05077ebae2dd51da3df3ae3e5842020fbfa939167c1/multidict-6.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:83eb172b4856ffff2814bdcf9c7792c0439302faab1b31376817b067b26cd8f5", size = 249949, upload-time = "2025-06-24T22:14:40.033Z" },
+    { url = "https://files.pythonhosted.org/packages/00/e3/642f63e12c1b8e6662c23626a98e9d764fe5a63c3a6cb59002f6fdcb920f/multidict-6.5.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:562d4714fa43f6ebc043a657535e4575e7d6141a818c9b3055f0868d29a1a41b", size = 244438, upload-time = "2025-06-24T22:14:41.464Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/cf/797397f6d38b011912504aef213a4be43ef4ec134859caa47f94d810bad8/multidict-6.5.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:2d7def2fc47695c46a427b8f298fb5ace03d635c1fb17f30d6192c9a8fb69e70", size = 259921, upload-time = "2025-06-24T22:14:43.248Z" },
+    { url = "https://files.pythonhosted.org/packages/82/b2/ae914a2d84eba21e956fa3727060248ca23ed4a5bf1beb057df0d10f9de3/multidict-6.5.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:77bc8ab5c6bfe696eff564824e73a451fdeca22f3b960261750836cee02bcbfa", size = 252691, upload-time = "2025-06-24T22:14:45.57Z" },
+    { url = "https://files.pythonhosted.org/packages/01/fa/1ab4d79a236b871cfd40d36a1f9942906c630bd2b7822287bd3927addb62/multidict-6.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:9eec51891d3c210948ead894ec1483d48748abec08db5ce9af52cc13fef37aee", size = 246224, upload-time = "2025-06-24T22:14:47.316Z" },
+    { url = "https://files.pythonhosted.org/packages/78/dd/bf002fe04e952db73cad8ce10a5b5347358d0d17221aef156e050aff690b/multidict-6.5.1-cp312-cp312-win32.whl", hash = "sha256:189f0c2bd1c0ae5509e453707d0e187e030c9e873a0116d1f32d1c870d0fc347", size = 41354, upload-time = "2025-06-24T22:14:48.567Z" },
+    { url = "https://files.pythonhosted.org/packages/95/ce/508a8487d98fdc3e693755bc19c543a2af293f5ce96da398bd1974efb802/multidict-6.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:e81f23b4b6f2a588f15d5cb554b2d8b482bb6044223d64b86bc7079cae9ebaad", size = 45072, upload-time = "2025-06-24T22:14:50.898Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/da/4782cf2f274d0d56fff6c07fc5cc5a14acf821dec08350c17d66d0207a05/multidict-6.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:79d13e06d5241f9c8479dfeaf0f7cce8f453a4a302c9a0b1fa9b1a6869ff7757", size = 42149, upload-time = "2025-06-24T22:14:53.138Z" },
+    { url = "https://files.pythonhosted.org/packages/07/9f/d4719ce55a1d8bf6619e8bb92f1e2e7399026ea85ae0c324ec77ee06c050/multidict-6.5.1-py3-none-any.whl", hash = "sha256:895354f4a38f53a1df2cc3fa2223fa714cff2b079a9f018a76cad35e7f0f044c", size = 12185, upload-time = "2025-06-24T22:16:03.816Z" },
+]
+
+[[package]]
+name = "propcache"
+version = "0.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/16/43264e4a779dd8588c21a70f0709665ee8f611211bdd2c87d952cfa7c776/propcache-0.3.2.tar.gz", hash = "sha256:20d7d62e4e7ef05f221e0db2856b979540686342e7dd9973b815599c7057e168", size = 44139, upload-time = "2025-06-09T22:56:06.081Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/42/9ca01b0a6f48e81615dca4765a8f1dd2c057e0540f6116a27dc5ee01dfb6/propcache-0.3.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:8de106b6c84506b31c27168582cd3cb3000a6412c16df14a8628e5871ff83c10", size = 73674, upload-time = "2025-06-09T22:54:30.551Z" },
+    { url = "https://files.pythonhosted.org/packages/af/6e/21293133beb550f9c901bbece755d582bfaf2176bee4774000bd4dd41884/propcache-0.3.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:28710b0d3975117239c76600ea351934ac7b5ff56e60953474342608dbbb6154", size = 43570, upload-time = "2025-06-09T22:54:32.296Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/c8/0393a0a3a2b8760eb3bde3c147f62b20044f0ddac81e9d6ed7318ec0d852/propcache-0.3.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ce26862344bdf836650ed2487c3d724b00fbfec4233a1013f597b78c1cb73615", size = 43094, upload-time = "2025-06-09T22:54:33.929Z" },
+    { url = "https://files.pythonhosted.org/packages/37/2c/489afe311a690399d04a3e03b069225670c1d489eb7b044a566511c1c498/propcache-0.3.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bca54bd347a253af2cf4544bbec232ab982f4868de0dd684246b67a51bc6b1db", size = 226958, upload-time = "2025-06-09T22:54:35.186Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/ca/63b520d2f3d418c968bf596839ae26cf7f87bead026b6192d4da6a08c467/propcache-0.3.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:55780d5e9a2ddc59711d727226bb1ba83a22dd32f64ee15594b9392b1f544eb1", size = 234894, upload-time = "2025-06-09T22:54:36.708Z" },
+    { url = "https://files.pythonhosted.org/packages/11/60/1d0ed6fff455a028d678df30cc28dcee7af77fa2b0e6962ce1df95c9a2a9/propcache-0.3.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:035e631be25d6975ed87ab23153db6a73426a48db688070d925aa27e996fe93c", size = 233672, upload-time = "2025-06-09T22:54:38.062Z" },
+    { url = "https://files.pythonhosted.org/packages/37/7c/54fd5301ef38505ab235d98827207176a5c9b2aa61939b10a460ca53e123/propcache-0.3.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ee6f22b6eaa39297c751d0e80c0d3a454f112f5c6481214fcf4c092074cecd67", size = 224395, upload-time = "2025-06-09T22:54:39.634Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/1a/89a40e0846f5de05fdc6779883bf46ba980e6df4d2ff8fb02643de126592/propcache-0.3.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7ca3aee1aa955438c4dba34fc20a9f390e4c79967257d830f137bd5a8a32ed3b", size = 212510, upload-time = "2025-06-09T22:54:41.565Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/33/ca98368586c9566a6b8d5ef66e30484f8da84c0aac3f2d9aec6d31a11bd5/propcache-0.3.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7a4f30862869fa2b68380d677cc1c5fcf1e0f2b9ea0cf665812895c75d0ca3b8", size = 222949, upload-time = "2025-06-09T22:54:43.038Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/11/ace870d0aafe443b33b2f0b7efdb872b7c3abd505bfb4890716ad7865e9d/propcache-0.3.2-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:b77ec3c257d7816d9f3700013639db7491a434644c906a2578a11daf13176251", size = 217258, upload-time = "2025-06-09T22:54:44.376Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/d2/86fd6f7adffcfc74b42c10a6b7db721d1d9ca1055c45d39a1a8f2a740a21/propcache-0.3.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:cab90ac9d3f14b2d5050928483d3d3b8fb6b4018893fc75710e6aa361ecb2474", size = 213036, upload-time = "2025-06-09T22:54:46.243Z" },
+    { url = "https://files.pythonhosted.org/packages/07/94/2d7d1e328f45ff34a0a284cf5a2847013701e24c2a53117e7c280a4316b3/propcache-0.3.2-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:0b504d29f3c47cf6b9e936c1852246c83d450e8e063d50562115a6be6d3a2535", size = 227684, upload-time = "2025-06-09T22:54:47.63Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/05/37ae63a0087677e90b1d14710e532ff104d44bc1efa3b3970fff99b891dc/propcache-0.3.2-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:ce2ac2675a6aa41ddb2a0c9cbff53780a617ac3d43e620f8fd77ba1c84dcfc06", size = 234562, upload-time = "2025-06-09T22:54:48.982Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/7c/3f539fcae630408d0bd8bf3208b9a647ccad10976eda62402a80adf8fc34/propcache-0.3.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:62b4239611205294cc433845b914131b2a1f03500ff3c1ed093ed216b82621e1", size = 222142, upload-time = "2025-06-09T22:54:50.424Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/d2/34b9eac8c35f79f8a962546b3e97e9d4b990c420ee66ac8255d5d9611648/propcache-0.3.2-cp312-cp312-win32.whl", hash = "sha256:df4a81b9b53449ebc90cc4deefb052c1dd934ba85012aa912c7ea7b7e38b60c1", size = 37711, upload-time = "2025-06-09T22:54:52.072Z" },
+    { url = "https://files.pythonhosted.org/packages/19/61/d582be5d226cf79071681d1b46b848d6cb03d7b70af7063e33a2787eaa03/propcache-0.3.2-cp312-cp312-win_amd64.whl", hash = "sha256:7046e79b989d7fe457bb755844019e10f693752d169076138abf17f31380800c", size = 41479, upload-time = "2025-06-09T22:54:53.234Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/35/cc0aaecf278bb4575b8555f2b137de5ab821595ddae9da9d3cd1da4072c7/propcache-0.3.2-py3-none-any.whl", hash = "sha256:98f1ec44fb675f5052cccc8e609c46ed23a35a1cfd18545ad4e29002d858a43f", size = 12663, upload-time = "2025-06-09T22:56:04.484Z" },
+]
+
+[[package]]
+name = "yarl"
+version = "1.20.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "multidict" },
+    { name = "propcache" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3c/fb/efaa23fa4e45537b827620f04cf8f3cd658b76642205162e072703a5b963/yarl-1.20.1.tar.gz", hash = "sha256:d017a4997ee50c91fd5466cef416231bb82177b93b029906cefc542ce14c35ac", size = 186428, upload-time = "2025-06-10T00:46:09.923Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/9a/cb7fad7d73c69f296eda6815e4a2c7ed53fc70c2f136479a91c8e5fbdb6d/yarl-1.20.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:bdcc4cd244e58593a4379fe60fdee5ac0331f8eb70320a24d591a3be197b94a9", size = 133667, upload-time = "2025-06-10T00:43:44.369Z" },
+    { url = "https://files.pythonhosted.org/packages/67/38/688577a1cb1e656e3971fb66a3492501c5a5df56d99722e57c98249e5b8a/yarl-1.20.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b29a2c385a5f5b9c7d9347e5812b6f7ab267193c62d282a540b4fc528c8a9d2a", size = 91025, upload-time = "2025-06-10T00:43:46.295Z" },
+    { url = "https://files.pythonhosted.org/packages/50/ec/72991ae51febeb11a42813fc259f0d4c8e0507f2b74b5514618d8b640365/yarl-1.20.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1112ae8154186dfe2de4732197f59c05a83dc814849a5ced892b708033f40dc2", size = 89709, upload-time = "2025-06-10T00:43:48.22Z" },
+    { url = "https://files.pythonhosted.org/packages/99/da/4d798025490e89426e9f976702e5f9482005c548c579bdae792a4c37769e/yarl-1.20.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:90bbd29c4fe234233f7fa2b9b121fb63c321830e5d05b45153a2ca68f7d310ee", size = 352287, upload-time = "2025-06-10T00:43:49.924Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/26/54a15c6a567aac1c61b18aa0f4b8aa2e285a52d547d1be8bf48abe2b3991/yarl-1.20.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:680e19c7ce3710ac4cd964e90dad99bf9b5029372ba0c7cbfcd55e54d90ea819", size = 345429, upload-time = "2025-06-10T00:43:51.7Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/95/9dcf2386cb875b234353b93ec43e40219e14900e046bf6ac118f94b1e353/yarl-1.20.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4a979218c1fdb4246a05efc2cc23859d47c89af463a90b99b7c56094daf25a16", size = 365429, upload-time = "2025-06-10T00:43:53.494Z" },
+    { url = "https://files.pythonhosted.org/packages/91/b2/33a8750f6a4bc224242a635f5f2cff6d6ad5ba651f6edcccf721992c21a0/yarl-1.20.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:255b468adf57b4a7b65d8aad5b5138dce6a0752c139965711bdcb81bc370e1b6", size = 363862, upload-time = "2025-06-10T00:43:55.766Z" },
+    { url = "https://files.pythonhosted.org/packages/98/28/3ab7acc5b51f4434b181b0cee8f1f4b77a65919700a355fb3617f9488874/yarl-1.20.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a97d67108e79cfe22e2b430d80d7571ae57d19f17cda8bb967057ca8a7bf5bfd", size = 355616, upload-time = "2025-06-10T00:43:58.056Z" },
+    { url = "https://files.pythonhosted.org/packages/36/a3/f666894aa947a371724ec7cd2e5daa78ee8a777b21509b4252dd7bd15e29/yarl-1.20.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8570d998db4ddbfb9a590b185a0a33dbf8aafb831d07a5257b4ec9948df9cb0a", size = 339954, upload-time = "2025-06-10T00:43:59.773Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/81/5f466427e09773c04219d3450d7a1256138a010b6c9f0af2d48565e9ad13/yarl-1.20.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:97c75596019baae7c71ccf1d8cc4738bc08134060d0adfcbe5642f778d1dca38", size = 365575, upload-time = "2025-06-10T00:44:02.051Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/e3/e4b0ad8403e97e6c9972dd587388940a032f030ebec196ab81a3b8e94d31/yarl-1.20.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:1c48912653e63aef91ff988c5432832692ac5a1d8f0fb8a33091520b5bbe19ef", size = 365061, upload-time = "2025-06-10T00:44:04.196Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/99/b8a142e79eb86c926f9f06452eb13ecb1bb5713bd01dc0038faf5452e544/yarl-1.20.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:4c3ae28f3ae1563c50f3d37f064ddb1511ecc1d5584e88c6b7c63cf7702a6d5f", size = 364142, upload-time = "2025-06-10T00:44:06.527Z" },
+    { url = "https://files.pythonhosted.org/packages/34/f2/08ed34a4a506d82a1a3e5bab99ccd930a040f9b6449e9fd050320e45845c/yarl-1.20.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:c5e9642f27036283550f5f57dc6156c51084b458570b9d0d96100c8bebb186a8", size = 381894, upload-time = "2025-06-10T00:44:08.379Z" },
+    { url = "https://files.pythonhosted.org/packages/92/f8/9a3fbf0968eac704f681726eff595dce9b49c8a25cd92bf83df209668285/yarl-1.20.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:2c26b0c49220d5799f7b22c6838409ee9bc58ee5c95361a4d7831f03cc225b5a", size = 383378, upload-time = "2025-06-10T00:44:10.51Z" },
+    { url = "https://files.pythonhosted.org/packages/af/85/9363f77bdfa1e4d690957cd39d192c4cacd1c58965df0470a4905253b54f/yarl-1.20.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:564ab3d517e3d01c408c67f2e5247aad4019dcf1969982aba3974b4093279004", size = 374069, upload-time = "2025-06-10T00:44:12.834Z" },
+    { url = "https://files.pythonhosted.org/packages/35/99/9918c8739ba271dcd935400cff8b32e3cd319eaf02fcd023d5dcd487a7c8/yarl-1.20.1-cp312-cp312-win32.whl", hash = "sha256:daea0d313868da1cf2fac6b2d3a25c6e3a9e879483244be38c8e6a41f1d876a5", size = 81249, upload-time = "2025-06-10T00:44:14.731Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/83/5d9092950565481b413b31a23e75dd3418ff0a277d6e0abf3729d4d1ce25/yarl-1.20.1-cp312-cp312-win_amd64.whl", hash = "sha256:48ea7d7f9be0487339828a4de0360d7ce0efc06524a48e1810f945c45b813698", size = 86710, upload-time = "2025-06-10T00:44:16.716Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/2d/2345fce04cfd4bee161bf1e7d9cdc702e3e16109021035dbb24db654a622/yarl-1.20.1-py3-none-any.whl", hash = "sha256:83b8eb083fe4683c6115795d9fc1cfaf2cbbefb19b3a1cb68f6527460f483a77", size = 46542, upload-time = "2025-06-10T00:46:07.521Z" },
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ dependencies = [
     "alembic<2.0.0,>=1.14.0",
     "aiomysql==0.2.0",
     "httpx~=0.28.0",
-    "aiohttp~=3.10.10",
     "memray<2.0.0,>=1.14.0",
     "py-spy>=0.4.0",
     "asyncpg~=0.30.0",
@@ -41,6 +40,7 @@ dependencies = [
     "opentelemetry-instrumentation-psycopg>=0.54b0,<1.0.0",
     "opentelemetry-instrumentation-sqlalchemy>=0.54b0,<1.0.0",
     "opentelemetry-exporter-otlp-proto-grpc>=1.33.1,<2.0.0",
+    "requests>=2.32.3",
 ]
 
 [tool.uv]

--- a/tests/batch/indexer_Company_List_test.py
+++ b/tests/batch/indexer_Company_List_test.py
@@ -50,15 +50,9 @@ def caplog(caplog: pytest.LogCaptureFixture):
 class MockResponse:
     def __init__(self, data: object, status_code: int = 200):
         self.data = data
-        self.status = status_code
+        self.status_code = status_code
 
-    async def __aexit__(self, exc_type, exc, tb):
-        pass
-
-    async def __aenter__(self):
-        return self
-
-    async def json(self) -> object:
+    def json(self) -> object:
         return self.data
 
 
@@ -70,7 +64,7 @@ class TestProcessor:
 
     # <Normal_1>
     # 0 record
-    @mock.patch("aiohttp.client.ClientSession.get")
+    @mock.patch("requests.get")
     async def test_normal_1(self, mock_get, processor, session):
         # Prepare data
         _company = Company()
@@ -97,7 +91,7 @@ class TestProcessor:
         mock_get.side_effect = [MockResponse([])]
 
         # Run target process
-        await processor.process()
+        processor.process()
 
         # Assertion
         session.rollback()
@@ -108,7 +102,7 @@ class TestProcessor:
 
     # <Normal_2>
     # 1 record
-    @mock.patch("aiohttp.client.ClientSession.get")
+    @mock.patch("requests.get")
     async def test_normal_2(self, mock_get, processor, session):
         # Prepare data
         _company = Company()
@@ -146,7 +140,7 @@ class TestProcessor:
         ]
 
         # Run target process
-        await processor.process()
+        processor.process()
 
         # Assertion
         _company_list: Sequence[Company] = session.scalars(
@@ -163,7 +157,7 @@ class TestProcessor:
 
     # <Normal_3>
     # 2 record
-    @mock.patch("aiohttp.client.ClientSession.get")
+    @mock.patch("requests.get")
     async def test_normal_3(self, mock_get, processor, session):
         # Prepare data
         _company = Company()
@@ -206,7 +200,7 @@ class TestProcessor:
         ]
 
         # Run target process
-        await processor.process()
+        processor.process()
 
         # Assertion
         _company_list: Sequence[Company] = session.scalars(
@@ -232,7 +226,7 @@ class TestProcessor:
     # Insert SKIP
     # type error
     # address
-    @mock.patch("aiohttp.client.ClientSession.get")
+    @mock.patch("requests.get")
     async def test_normal_4_1_1(self, mock_get, processor, session):
         # Prepare data
         _company = Company()
@@ -276,7 +270,7 @@ class TestProcessor:
         ]
 
         # Run target process
-        await processor.process()
+        processor.process()
 
         # Assertion
         _company_list: Sequence[Company] = session.scalars(
@@ -295,7 +289,7 @@ class TestProcessor:
     # Insert SKIP
     # type error
     # corporate_name
-    @mock.patch("aiohttp.client.ClientSession.get")
+    @mock.patch("requests.get")
     async def test_normal_4_1_2(self, mock_get, processor, session):
         # Prepare data
         _company = Company()
@@ -339,7 +333,7 @@ class TestProcessor:
         ]
 
         # Run target process
-        await processor.process()
+        processor.process()
 
         # Assertion
         _company_list: Sequence[Company] = session.scalars(
@@ -358,7 +352,7 @@ class TestProcessor:
     # Insert SKIP
     # type error
     # rsa_publickey
-    @mock.patch("aiohttp.client.ClientSession.get")
+    @mock.patch("requests.get")
     async def test_normal_4_1_3(self, mock_get, processor, session):
         # Prepare data
         _company = Company()
@@ -402,7 +396,7 @@ class TestProcessor:
         ]
 
         # Run target process
-        await processor.process()
+        processor.process()
 
         # Assertion
         _company_list: Sequence[Company] = session.scalars(
@@ -421,7 +415,7 @@ class TestProcessor:
     # Insert SKIP
     # type error
     # homepage
-    @mock.patch("aiohttp.client.ClientSession.get")
+    @mock.patch("requests.get")
     async def test_normal_4_1_4(self, mock_get, processor, session):
         # Prepare data
         _company = Company()
@@ -465,7 +459,7 @@ class TestProcessor:
         ]
 
         # Run target process
-        await processor.process()
+        processor.process()
 
         # Assertion
         _company_list: Sequence[Company] = session.scalars(
@@ -484,7 +478,7 @@ class TestProcessor:
     # Insert SKIP
     # required error
     # address
-    @mock.patch("aiohttp.client.ClientSession.get")
+    @mock.patch("requests.get")
     async def test_normal_4_2_1(self, mock_get, processor, session):
         # Prepare data
         _company = Company()
@@ -527,7 +521,7 @@ class TestProcessor:
         ]
 
         # Run target process
-        await processor.process()
+        processor.process()
 
         # Assertion
         _company_list: Sequence[Company] = session.scalars(
@@ -546,7 +540,7 @@ class TestProcessor:
     # Insert SKIP
     # required error
     # corporate_name
-    @mock.patch("aiohttp.client.ClientSession.get")
+    @mock.patch("requests.get")
     async def test_normal_4_2_2(self, mock_get, processor, session):
         # Prepare data
         _company = Company()
@@ -589,7 +583,7 @@ class TestProcessor:
         ]
 
         # Run target process
-        await processor.process()
+        processor.process()
 
         # Assertion
         _company_list: Sequence[Company] = session.scalars(
@@ -608,7 +602,7 @@ class TestProcessor:
     # Insert SKIP
     # required error
     # address
-    @mock.patch("aiohttp.client.ClientSession.get")
+    @mock.patch("requests.get")
     async def test_normal_4_2_3(self, mock_get, processor, session):
         # Prepare data
         _company = Company()
@@ -651,7 +645,7 @@ class TestProcessor:
         ]
 
         # Run target process
-        await processor.process()
+        processor.process()
 
         # Assertion
         _company_list: Sequence[Company] = session.scalars(
@@ -669,7 +663,7 @@ class TestProcessor:
     # <Normal_4_3>
     # Insert SKIP
     # invalid address error
-    @mock.patch("aiohttp.client.ClientSession.get")
+    @mock.patch("requests.get")
     async def test_normal_4_3(self, mock_get, processor, session):
         # Prepare data
         _company = Company()
@@ -713,7 +707,7 @@ class TestProcessor:
         ]
 
         # Run target process
-        await processor.process()
+        processor.process()
 
         # Assertion
         _company_list: Sequence[Company] = session.scalars(
@@ -731,7 +725,7 @@ class TestProcessor:
     # <Normal_5_1>
     # There are no differences from last time
     # -> Skip this cycle
-    @mock.patch("aiohttp.client.ClientSession.get")
+    @mock.patch("requests.get")
     async def test_normal_5_1(self, mock_get, processor, session, caplog):
         # Run target process: 1st time
         mock_get.side_effect = [
@@ -752,7 +746,7 @@ class TestProcessor:
                 ]
             )
         ]
-        await processor.process()
+        processor.process()
 
         # Run target process: 2nd time
         mock_get.side_effect = [
@@ -773,7 +767,7 @@ class TestProcessor:
                 ]
             )
         ]
-        await processor.process()
+        processor.process()
 
         # Assertion
         _company_list: Sequence[Company] = session.scalars(
@@ -807,7 +801,7 @@ class TestProcessor:
 
     # <Normal_5_2>
     # There are differences from the previous cycle
-    @mock.patch("aiohttp.client.ClientSession.get")
+    @mock.patch("requests.get")
     async def test_normal_5_2(self, mock_get, processor, session, caplog):
         # Run target process: 1st time
         mock_get.side_effect = [
@@ -828,7 +822,7 @@ class TestProcessor:
                 ]
             )
         ]
-        await processor.process()
+        processor.process()
 
         # Run target process: 2nd time
         mock_get.side_effect = [
@@ -843,7 +837,7 @@ class TestProcessor:
                 ]
             )
         ]
-        await processor.process()
+        processor.process()
 
         # Assertion
         _company_list: Sequence[Company] = session.scalars(
@@ -875,7 +869,7 @@ class TestProcessor:
     # API error
     # Connection error
     @mock.patch(
-        "aiohttp.client.ClientSession.get",
+        "requests.get",
         MagicMock(side_effect=requests.exceptions.ConnectionError),
     )
     async def test_error_1_1(self, processor, session):
@@ -901,7 +895,7 @@ class TestProcessor:
         session.commit()
 
         # Run target process
-        await processor.process()
+        processor.process()
 
         # Assertion
         _company_list: Sequence[Company] = session.scalars(
@@ -912,7 +906,7 @@ class TestProcessor:
     # <Error_1_2>
     # API error
     # not succeed api
-    @mock.patch("aiohttp.client.ClientSession.get")
+    @mock.patch("requests.get")
     async def test_error_1_2(self, mock_get, processor, session):
         # Prepare data
         _company = Company()
@@ -939,7 +933,7 @@ class TestProcessor:
         mock_get.side_effect = [MockResponse([], 400)]
 
         # Run target process
-        await processor.process()
+        processor.process()
 
         # Assertion
         _company_list: Sequence[Company] = session.scalars(
@@ -950,7 +944,7 @@ class TestProcessor:
     # <Error_2>
     # not decode response
     @mock.patch(
-        "aiohttp.client.ClientSession.get",
+        "requests.get",
         MagicMock(side_effect=json.decoder.JSONDecodeError),
     )
     async def test_error_2(self, processor, session):
@@ -976,7 +970,7 @@ class TestProcessor:
         session.commit()
 
         # Run target process
-        await processor.process()
+        processor.process()
 
         # Assertion
         _company_list: Sequence[Company] = session.scalars(
@@ -986,7 +980,7 @@ class TestProcessor:
 
     # <Error_3>
     # other error
-    @mock.patch("aiohttp.client.ClientSession.get")
+    @mock.patch("requests.get")
     async def test_error_3(self, mock_get, processor, session):
         # Prepare data
         _company = Company()
@@ -1026,7 +1020,7 @@ class TestProcessor:
 
         # Run target process
         with pytest.raises(Exception):
-            await processor.process()
+            processor.process()
 
         # Assertion
         _company_list: Sequence[Company] = session.scalars(

--- a/tests/batch/indexer_PublicInfo_PublicAccountList_test.py
+++ b/tests/batch/indexer_PublicInfo_PublicAccountList_test.py
@@ -50,15 +50,9 @@ def caplog(caplog: pytest.LogCaptureFixture):
 class MockResponse:
     def __init__(self, data: object, status_code: int = 200):
         self.data = data
-        self.status = status_code
+        self.status_code = status_code
 
-    async def __aexit__(self, exc_type, exc, tb):
-        pass
-
-    async def __aenter__(self):
-        return self
-
-    async def json(self) -> object:
+    def json(self) -> object:
         return self.data
 
 
@@ -78,7 +72,7 @@ class TestProcessor:
 
     # <Normal_1>
     # 0 record
-    @mock.patch("aiohttp.client.ClientSession.get")
+    @mock.patch("requests.get")
     async def test_normal_1(self, mock_get, processor, async_session):
         # Prepare data
         _account_list = PublicAccountList()
@@ -93,7 +87,7 @@ class TestProcessor:
         mock_get.side_effect = [MockResponse([])]
 
         # Run target process
-        await processor.process()
+        processor.process()
 
         # Assertion
         # - The cleanup process should remove all data.
@@ -105,7 +99,7 @@ class TestProcessor:
 
     # <Normal_2>
     # Multiple records
-    @mock.patch("aiohttp.client.ClientSession.get")
+    @mock.patch("requests.get")
     async def test_normal_2(self, mock_get, processor, async_session):
         # Prepare data
         _account_list = PublicAccountList()
@@ -137,7 +131,7 @@ class TestProcessor:
         ]
 
         # Run target process
-        await processor.process()
+        processor.process()
 
         # Assertion
         # - The cleanup process should remove all data.
@@ -169,7 +163,7 @@ class TestProcessor:
     # <Normal_3_1>
     # There are no differences from last time
     # -> Skip this cycle
-    @mock.patch("aiohttp.client.ClientSession.get")
+    @mock.patch("requests.get")
     async def test_normal_3_1(self, mock_get, processor, async_session, caplog):
         # Run target process: 1st time
         mock_get.side_effect = [
@@ -190,7 +184,7 @@ class TestProcessor:
                 ]
             )
         ]
-        await processor.process()
+        processor.process()
 
         # Run target process: 2nd time
         mock_get.side_effect = [
@@ -211,7 +205,7 @@ class TestProcessor:
                 ]
             )
         ]
-        await processor.process()
+        processor.process()
 
         # Assertion
         # - The cleanup process should remove all of your data.
@@ -250,7 +244,7 @@ class TestProcessor:
 
     # <Normal_3_2>
     # There are differences from last time
-    @mock.patch("aiohttp.client.ClientSession.get")
+    @mock.patch("requests.get")
     async def test_normal_3_2(self, mock_get, processor, async_session, caplog):
         # Run target process: 1st time
         mock_get.side_effect = [
@@ -271,7 +265,7 @@ class TestProcessor:
                 ]
             )
         ]
-        await processor.process()
+        processor.process()
 
         # Run target process: 2nd time
         mock_get.side_effect = [
@@ -286,7 +280,7 @@ class TestProcessor:
                 ]
             )
         ]
-        await processor.process()
+        processor.process()
 
         # Assertion
         # - The cleanup process should remove all data.
@@ -323,7 +317,7 @@ class TestProcessor:
     # <Error_1_1>
     # API error: ConnectionError
     @mock.patch(
-        "aiohttp.client.ClientSession.get",
+        "requests.get",
         MagicMock(side_effect=requests.exceptions.ConnectionError),
     )
     async def test_error_1_1(self, processor, async_session):
@@ -337,7 +331,7 @@ class TestProcessor:
         await async_session.commit()
 
         # Run target process
-        await processor.process()
+        processor.process()
 
         # Assertion
         # - The cleanup process should be rolled back and
@@ -362,7 +356,7 @@ class TestProcessor:
 
     # <Error_1_2>
     # API error: Not succeed request
-    @mock.patch("aiohttp.client.ClientSession.get")
+    @mock.patch("requests.get")
     async def test_error_1_2(self, mock_get, processor, async_session):
         # Prepare data
         _account_list = PublicAccountList()
@@ -377,7 +371,7 @@ class TestProcessor:
         mock_get.side_effect = [MockResponse([], 400)]
 
         # Run target process
-        await processor.process()
+        processor.process()
 
         # Assertion
         # - The cleanup process should be rolled back and
@@ -403,7 +397,7 @@ class TestProcessor:
     # <Error_1_3>
     # API error: JSONDecodeError
     @mock.patch(
-        "aiohttp.client.ClientSession.get",
+        "requests.get",
         MagicMock(side_effect=json.decoder.JSONDecodeError),
     )
     async def test_error_1_3(self, processor, async_session):
@@ -417,7 +411,7 @@ class TestProcessor:
         await async_session.commit()
 
         # Run target process
-        await processor.process()
+        processor.process()
 
         # Assertion
         # - The cleanup process should be rolled back and
@@ -443,7 +437,7 @@ class TestProcessor:
     # <Error_2>
     # Invalid type error
     # -> Skip processing
-    @mock.patch("aiohttp.client.ClientSession.get")
+    @mock.patch("requests.get")
     @pytest.mark.parametrize(
         "invalid_record",
         [
@@ -513,7 +507,7 @@ class TestProcessor:
         mock_get.side_effect = [MockResponse([invalid_record])]
 
         # Run target process
-        await processor.process()
+        processor.process()
 
         # Assertion
         await async_session.rollback()
@@ -528,7 +522,7 @@ class TestProcessor:
 
     # <Error_3>
     # Other error
-    @mock.patch("aiohttp.client.ClientSession.get")
+    @mock.patch("requests.get")
     async def test_error_3(self, mock_get, processor, async_session):
         # Mock
         mock_get.side_effect = [
@@ -547,7 +541,7 @@ class TestProcessor:
 
         # Run target process
         with pytest.raises(Exception):
-            await processor.process()
+            processor.process()
 
         # Assertion
         await async_session.rollback()

--- a/tests/batch/processor_Send_Chat_Webhook_test.py
+++ b/tests/batch/processor_Send_Chat_Webhook_test.py
@@ -20,7 +20,7 @@ SPDX-License-Identifier: Apache-2.0
 import json
 import logging
 from unittest import mock
-from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
 
 import pytest
 from sqlalchemy import select
@@ -53,10 +53,8 @@ class TestProcessorSendChatWebhook:
     # No unsent hook exists
     async def test_normal_1(self, processor, async_session, caplog):
         # Run processor
-        with mock.patch(
-            "aiohttp.client.ClientSession.post", AsyncMock(side_effect=None)
-        ):
-            await processor.process()
+        with mock.patch("requests.post", MagicMock(side_effect=None)):
+            processor.process()
             await async_session.commit()
 
         # Assertion
@@ -75,10 +73,8 @@ class TestProcessorSendChatWebhook:
         await async_session.commit()
 
         # Run processor
-        with mock.patch(
-            "aiohttp.client.ClientSession.post", AsyncMock(side_effect=None)
-        ):
-            await processor.process()
+        with mock.patch("requests.post", MagicMock(side_effect=None)):
+            processor.process()
             await async_session.commit()
 
         # Assertion
@@ -96,10 +92,8 @@ class TestProcessorSendChatWebhook:
         await async_session.commit()
 
         # Run processor
-        with mock.patch(
-            "aiohttp.client.ClientSession.post", AsyncMock(side_effect=Exception())
-        ):
-            await processor.process()
+        with mock.patch("requests.post", MagicMock(side_effect=Exception())):
+            processor.process()
             await async_session.commit()
 
         # Assertion
@@ -126,13 +120,11 @@ class TestProcessorSendChatWebhook:
 
         # Run processor
         with (
-            mock.patch(
-                "aiohttp.client.ClientSession.post", AsyncMock(side_effect=None)
-            ),
+            mock.patch("requests.post", MagicMock(side_effect=None)),
             mock.patch.object(Session, "commit", side_effect=SQLAlchemyError()),
             pytest.raises(SQLAlchemyError),
         ):
-            await processor.process()
+            processor.process()
             await async_session.commit()
 
         # Assertion

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "aiohttp"
-version = "3.10.11"
+version = "3.12.13"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohappyeyeballs" },
@@ -21,25 +21,28 @@ dependencies = [
     { name = "attrs" },
     { name = "frozenlist" },
     { name = "multidict" },
+    { name = "propcache" },
     { name = "yarl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/25/a8/8e2ba36c6e3278d62e0c88aa42bb92ddbef092ac363b390dab4421da5cf5/aiohttp-3.10.11.tar.gz", hash = "sha256:9dc2b8f3dcab2e39e0fa309c8da50c3b55e6f34ab25f1a71d3288f24924d33a7", size = 7551886, upload-time = "2024-11-13T16:40:33.335Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/42/6e/ab88e7cb2a4058bed2f7870276454f85a7c56cd6da79349eb314fc7bbcaa/aiohttp-3.12.13.tar.gz", hash = "sha256:47e2da578528264a12e4e3dd8dd72a7289e5f812758fe086473fab037a10fcce", size = 7819160, upload-time = "2025-06-14T15:15:41.354Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/16/077057ef3bd684dbf9a8273a5299e182a8d07b4b252503712ff8b5364fd1/aiohttp-3.10.11-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:7480519f70e32bfb101d71fb9a1f330fbd291655a4c1c922232a48c458c52710", size = 584830, upload-time = "2024-11-13T16:37:49.608Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/cf/348b93deb9597c61a51b6682e81f7c7d79290249e886022ef0705d858d90/aiohttp-3.10.11-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:f65267266c9aeb2287a6622ee2bb39490292552f9fbf851baabc04c9f84e048d", size = 397090, upload-time = "2024-11-13T16:37:51.539Z" },
-    { url = "https://files.pythonhosted.org/packages/70/bf/903df5cd739dfaf5b827b3d8c9d68ff4fcea16a0ca1aeb948c9da30f56c8/aiohttp-3.10.11-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7400a93d629a0608dc1d6c55f1e3d6e07f7375745aaa8bd7f085571e4d1cee97", size = 392361, upload-time = "2024-11-13T16:37:53.586Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/97/e4792675448a2ac5bd56f377a095233b805dd1315235c940c8ba5624e3cb/aiohttp-3.10.11-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f34b97e4b11b8d4eb2c3a4f975be626cc8af99ff479da7de49ac2c6d02d35725", size = 1309839, upload-time = "2024-11-13T16:37:55.68Z" },
-    { url = "https://files.pythonhosted.org/packages/96/d0/ba19b1260da6fbbda4d5b1550d8a53ba3518868f2c143d672aedfdbc6172/aiohttp-3.10.11-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1e7b825da878464a252ccff2958838f9caa82f32a8dbc334eb9b34a026e2c636", size = 1348116, upload-time = "2024-11-13T16:37:58.232Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/b9/15100ee7113a2638bfdc91aecc54641609a92a7ce4fe533ebeaa8d43ff93/aiohttp-3.10.11-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f9f92a344c50b9667827da308473005f34767b6a2a60d9acff56ae94f895f385", size = 1391402, upload-time = "2024-11-13T16:38:00.522Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/36/831522618ac0dcd0b28f327afd18df7fb6bbf3eaf302f912a40e87714846/aiohttp-3.10.11-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc6f1ab987a27b83c5268a17218463c2ec08dbb754195113867a27b166cd6087", size = 1304239, upload-time = "2024-11-13T16:38:04.195Z" },
-    { url = "https://files.pythonhosted.org/packages/60/9f/b7230d0c48b076500ae57adb717aa0656432acd3d8febb1183dedfaa4e75/aiohttp-3.10.11-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1dc0f4ca54842173d03322793ebcf2c8cc2d34ae91cc762478e295d8e361e03f", size = 1256565, upload-time = "2024-11-13T16:38:07.218Z" },
-    { url = "https://files.pythonhosted.org/packages/63/c2/35c7b4699f4830b3b0a5c3d5619df16dca8052ae8b488e66065902d559f6/aiohttp-3.10.11-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7ce6a51469bfaacff146e59e7fb61c9c23006495d11cc24c514a455032bcfa03", size = 1269285, upload-time = "2024-11-13T16:38:09.396Z" },
-    { url = "https://files.pythonhosted.org/packages/51/48/bc20ea753909bdeb09f9065260aefa7453e3a57f6a51f56f5216adc1a5e7/aiohttp-3.10.11-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:aad3cd91d484d065ede16f3cf15408254e2469e3f613b241a1db552c5eb7ab7d", size = 1276716, upload-time = "2024-11-13T16:38:12.039Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/7b/a8708616b3810f55ead66f8e189afa9474795760473aea734bbea536cd64/aiohttp-3.10.11-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:f4df4b8ca97f658c880fb4b90b1d1ec528315d4030af1ec763247ebfd33d8b9a", size = 1315023, upload-time = "2024-11-13T16:38:15.155Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/d6/dfe9134a921e05b01661a127a37b7d157db93428905450e32f9898eef27d/aiohttp-3.10.11-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:2e4e18a0a2d03531edbc06c366954e40a3f8d2a88d2b936bbe78a0c75a3aab3e", size = 1342735, upload-time = "2024-11-13T16:38:17.539Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/1a/3bd7f18e3909eabd57e5d17ecdbf5ea4c5828d91341e3676a07de7c76312/aiohttp-3.10.11-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6ce66780fa1a20e45bc753cda2a149daa6dbf1561fc1289fa0c308391c7bc0a4", size = 1302618, upload-time = "2024-11-13T16:38:19.865Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/51/d063133781cda48cfdd1e11fc8ef45ab3912b446feba41556385b3ae5087/aiohttp-3.10.11-cp312-cp312-win32.whl", hash = "sha256:a919c8957695ea4c0e7a3e8d16494e3477b86f33067478f43106921c2fef15bb", size = 360497, upload-time = "2024-11-13T16:38:21.996Z" },
-    { url = "https://files.pythonhosted.org/packages/55/4e/f29def9ed39826fe8f85955f2e42fe5cc0cbe3ebb53c97087f225368702e/aiohttp-3.10.11-cp312-cp312-win_amd64.whl", hash = "sha256:b5e29706e6389a2283a91611c91bf24f218962717c8f3b4e528ef529d112ee27", size = 380577, upload-time = "2024-11-13T16:38:24.247Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/6a/ce40e329788013cd190b1d62bbabb2b6a9673ecb6d836298635b939562ef/aiohttp-3.12.13-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0aa580cf80558557285b49452151b9c69f2fa3ad94c5c9e76e684719a8791b73", size = 700491, upload-time = "2025-06-14T15:14:00.048Z" },
+    { url = "https://files.pythonhosted.org/packages/28/d9/7150d5cf9163e05081f1c5c64a0cdf3c32d2f56e2ac95db2a28fe90eca69/aiohttp-3.12.13-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b103a7e414b57e6939cc4dece8e282cfb22043efd0c7298044f6594cf83ab347", size = 475104, upload-time = "2025-06-14T15:14:01.691Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/91/d42ba4aed039ce6e449b3e2db694328756c152a79804e64e3da5bc19dffc/aiohttp-3.12.13-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:78f64e748e9e741d2eccff9597d09fb3cd962210e5b5716047cbb646dc8fe06f", size = 467948, upload-time = "2025-06-14T15:14:03.561Z" },
+    { url = "https://files.pythonhosted.org/packages/99/3b/06f0a632775946981d7c4e5a865cddb6e8dfdbaed2f56f9ade7bb4a1039b/aiohttp-3.12.13-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c955989bf4c696d2ededc6b0ccb85a73623ae6e112439398935362bacfaaf6", size = 1714742, upload-time = "2025-06-14T15:14:05.558Z" },
+    { url = "https://files.pythonhosted.org/packages/92/a6/2552eebad9ec5e3581a89256276009e6a974dc0793632796af144df8b740/aiohttp-3.12.13-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:d640191016763fab76072c87d8854a19e8e65d7a6fcfcbf017926bdbbb30a7e5", size = 1697393, upload-time = "2025-06-14T15:14:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/9f/bd08fdde114b3fec7a021381b537b21920cdd2aa29ad48c5dffd8ee314f1/aiohttp-3.12.13-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4dc507481266b410dede95dd9f26c8d6f5a14315372cc48a6e43eac652237d9b", size = 1752486, upload-time = "2025-06-14T15:14:08.808Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/e1/affdea8723aec5bd0959171b5490dccd9a91fcc505c8c26c9f1dca73474d/aiohttp-3.12.13-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8a94daa873465d518db073bd95d75f14302e0208a08e8c942b2f3f1c07288a75", size = 1798643, upload-time = "2025-06-14T15:14:10.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/9d/666d856cc3af3a62ae86393baa3074cc1d591a47d89dc3bf16f6eb2c8d32/aiohttp-3.12.13-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:177f52420cde4ce0bb9425a375d95577fe082cb5721ecb61da3049b55189e4e6", size = 1718082, upload-time = "2025-06-14T15:14:12.38Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/ce/3c185293843d17be063dada45efd2712bb6bf6370b37104b4eda908ffdbd/aiohttp-3.12.13-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0f7df1f620ec40f1a7fbcb99ea17d7326ea6996715e78f71a1c9a021e31b96b8", size = 1633884, upload-time = "2025-06-14T15:14:14.415Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/5b/f3413f4b238113be35dfd6794e65029250d4b93caa0974ca572217745bdb/aiohttp-3.12.13-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3062d4ad53b36e17796dce1c0d6da0ad27a015c321e663657ba1cc7659cfc710", size = 1694943, upload-time = "2025-06-14T15:14:16.48Z" },
+    { url = "https://files.pythonhosted.org/packages/82/c8/0e56e8bf12081faca85d14a6929ad5c1263c146149cd66caa7bc12255b6d/aiohttp-3.12.13-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:8605e22d2a86b8e51ffb5253d9045ea73683d92d47c0b1438e11a359bdb94462", size = 1716398, upload-time = "2025-06-14T15:14:18.589Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f3/33192b4761f7f9b2f7f4281365d925d663629cfaea093a64b658b94fc8e1/aiohttp-3.12.13-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:54fbbe6beafc2820de71ece2198458a711e224e116efefa01b7969f3e2b3ddae", size = 1657051, upload-time = "2025-06-14T15:14:20.223Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/0b/26ddd91ca8f84c48452431cb4c5dd9523b13bc0c9766bda468e072ac9e29/aiohttp-3.12.13-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:050bd277dfc3768b606fd4eae79dd58ceda67d8b0b3c565656a89ae34525d15e", size = 1736611, upload-time = "2025-06-14T15:14:21.988Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/8d/e04569aae853302648e2c138a680a6a2f02e374c5b6711732b29f1e129cc/aiohttp-3.12.13-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:2637a60910b58f50f22379b6797466c3aa6ae28a6ab6404e09175ce4955b4e6a", size = 1764586, upload-time = "2025-06-14T15:14:23.979Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/98/c193c1d1198571d988454e4ed75adc21c55af247a9fda08236602921c8c8/aiohttp-3.12.13-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e986067357550d1aaa21cfe9897fa19e680110551518a5a7cf44e6c5638cb8b5", size = 1724197, upload-time = "2025-06-14T15:14:25.692Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/9e/07bb8aa11eec762c6b1ff61575eeeb2657df11ab3d3abfa528d95f3e9337/aiohttp-3.12.13-cp312-cp312-win32.whl", hash = "sha256:ac941a80aeea2aaae2875c9500861a3ba356f9ff17b9cb2dbfb5cbf91baaf5bf", size = 421771, upload-time = "2025-06-14T15:14:27.364Z" },
+    { url = "https://files.pythonhosted.org/packages/52/66/3ce877e56ec0813069cdc9607cd979575859c597b6fb9b4182c6d5f31886/aiohttp-3.12.13-cp312-cp312-win_amd64.whl", hash = "sha256:671f41e6146a749b6c81cb7fd07f5a8356d46febdaaaf07b0e774ff04830461e", size = 447869, upload-time = "2025-06-14T15:14:29.05Z" },
 ]
 
 [[package]]
@@ -897,6 +900,16 @@ dev = [
 name = "ibet-wallet-api-explorer"
 version = "0.1.0"
 source = { editable = "cmd/explorer" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "async-cache" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "aiohttp", specifier = ">=3.12.13" },
+    { name = "async-cache", specifier = ">=1.1.1" },
+]
 
 [[package]]
 name = "identify"

--- a/uv.lock
+++ b/uv.lock
@@ -774,7 +774,6 @@ name = "ibet-wallet-api"
 version = "25.6"
 source = { virtual = "." }
 dependencies = [
-    { name = "aiohttp" },
     { name = "aiomysql" },
     { name = "alembic" },
     { name = "asyncpg" },
@@ -803,6 +802,7 @@ dependencies = [
     { name = "pymysql", extra = ["rsa"] },
     { name = "pyroscope-io" },
     { name = "pyroscope-otel" },
+    { name = "requests" },
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "tzdata" },
     { name = "uvicorn", extra = ["standard"] },
@@ -836,7 +836,6 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aiohttp", specifier = "~=3.10.10" },
     { name = "aiomysql", specifier = "==0.2.0" },
     { name = "alembic", specifier = ">=1.14.0,<2.0.0" },
     { name = "async-cache", marker = "extra == 'ibet-explorer'", specifier = "~=1.1.1" },
@@ -867,6 +866,7 @@ requires-dist = [
     { name = "pymysql", extras = ["rsa"], specifier = "~=1.1.0" },
     { name = "pyroscope-io", specifier = ">=0.8.11" },
     { name = "pyroscope-otel", specifier = ">=0.4.1" },
+    { name = "requests", specifier = ">=2.32.3" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.33,<3.0.0" },
     { name = "textual", marker = "extra == 'ibet-explorer'", specifier = "~=0.44.1" },
     { name = "typer", marker = "extra == 'ibet-explorer'", specifier = "~=0.12.3" },


### PR DESCRIPTION
## 📌 Description

- Replace aiohttp with requests
  - Network connections through proxy configurations using HTTPS_PROXY environment variables don't function properly with aiohttp. To address this limitation, we're switching the HTTP client in specific batch processes to use requests instead.

## ✅ Related Issues

- None

## 🔄 Changes

<!-- List the major changes in this PR. -->

- Replaced aiohttp with requests in batch processing modules

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
