### PR TITLE
Replace aiohttp with requests in batch processing modules (25.9)

### DIFF
--- a/batch/indexer_Company_List.py
+++ b/batch/indexer_Company_List.py
@@ -17,27 +17,32 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
-import asyncio
 import hashlib
 import json
 import sys
 import time
 
-import aiohttp
-from aiohttp import ClientTimeout
+import requests
 from eth_utils import to_checksum_address
 from sqlalchemy import delete
+from sqlalchemy.engine.create import create_engine
 from sqlalchemy.exc import SQLAlchemyError
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm.session import Session
 
-from app.config import COMPANY_LIST_SLEEP_INTERVAL, COMPANY_LIST_URL, REQUEST_TIMEOUT
-from app.database import BatchAsyncSessionLocal
+from app.config import (
+    COMPANY_LIST_SLEEP_INTERVAL,
+    COMPANY_LIST_URL,
+    DATABASE_URL,
+    REQUEST_TIMEOUT,
+)
 from app.errors import ServiceUnavailable
 from app.model.db import Company
 from batch import free_malloc, log
 
 process_name = "INDEXER-COMPANY-LIST"
 LOG = log.get_logger(process_name=process_name)
+
+db_engine = create_engine(DATABASE_URL, echo=False, pool_pre_ping=True)
 
 
 class Processor:
@@ -46,21 +51,15 @@ class Processor:
     def __init__(self):
         self.company_list_digest = None
 
-    async def process(self):
+    def process(self):
         LOG.info("Syncing company list")
 
         # Get from COMPANY_LIST_URL
         try:
-            async with aiohttp.ClientSession(trust_env=True) as session:
-                async with session.get(
-                    COMPANY_LIST_URL,
-                    timeout=ClientTimeout(
-                        connect=REQUEST_TIMEOUT[0], total=REQUEST_TIMEOUT[1]
-                    ),
-                ) as response:
-                    if response.status != 200:
-                        raise Exception(f"status code={response.status}")
-                    company_list_json = await response.json()
+            _resp = requests.get(COMPANY_LIST_URL, timeout=REQUEST_TIMEOUT)
+            if _resp.status_code != 200:
+                raise Exception(f"status code={_resp.status_code}")
+            company_list_json = _resp.json()
         except Exception:
             LOG.exception("Failed to get company list")
             return
@@ -76,10 +75,10 @@ class Processor:
             self.company_list_digest = _resp_digest
 
         # Update DB data
-        db_session = BatchAsyncSessionLocal()
+        db_session = Session(autocommit=False, autoflush=True, bind=db_engine)
         try:
             # Delete all company list from DB
-            await db_session.execute(delete(Company))
+            db_session.execute(delete(Company))
 
             # Insert company list
             for i, company in enumerate(company_list_json):
@@ -105,7 +104,7 @@ class Processor:
                     except ValueError:
                         LOG.notice(f"Invalid address: index={i} address={address}")
                         continue
-                    await self.__sink_on_company(
+                    self.__sink_on_company(
                         db_session=db_session,
                         address=to_checksum_address(address),
                         corporate_name=corporate_name,
@@ -116,17 +115,17 @@ class Processor:
                     LOG.notice(f"Missing required field: index={i}")
                     continue
 
-            await db_session.commit()
-        except Exception as e:
-            await db_session.rollback()
-            raise e
+            db_session.commit()
+        except Exception:
+            db_session.rollback()
+            raise
         finally:
-            await db_session.close()
+            db_session.close()
         LOG.info("Sync job has been completed")
 
     @staticmethod
-    async def __sink_on_company(
-        db_session: AsyncSession,
+    def __sink_on_company(
+        db_session: Session,
         address: str,
         corporate_name: str,
         rsa_publickey: str,
@@ -137,17 +136,17 @@ class Processor:
         _company.corporate_name = corporate_name
         _company.rsa_publickey = rsa_publickey
         _company.homepage = homepage
-        await db_session.merge(_company)
+        db_session.merge(_company)
 
 
-async def main():
+def main():
     LOG.info("Service started successfully")
     processor = Processor()
     while True:
         start_time = time.time()
 
         try:
-            await processor.process()
+            processor.process()
         except ServiceUnavailable:
             LOG.notice("An external service was unavailable")
         except SQLAlchemyError as sa_err:
@@ -156,12 +155,12 @@ async def main():
             LOG.exception("An exception occurred during processing")
 
         elapsed_time = time.time() - start_time
-        await asyncio.sleep(max(COMPANY_LIST_SLEEP_INTERVAL - elapsed_time, 0))
+        time.sleep(max(COMPANY_LIST_SLEEP_INTERVAL - elapsed_time, 0))
         free_malloc()
 
 
 if __name__ == "__main__":
     try:
-        asyncio.run(main())
+        main()
     except KeyboardInterrupt:
         sys.exit(1)

--- a/batch/indexer_PublicInfo_PublicAccountList.py
+++ b/batch/indexer_PublicInfo_PublicAccountList.py
@@ -17,31 +17,32 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
-import asyncio
 import hashlib
 import json
 import sys
 import time
 
-import aiohttp
-from aiohttp import ClientTimeout
+import requests
 from eth_utils import to_checksum_address
 from sqlalchemy import delete
+from sqlalchemy.engine.create import create_engine
 from sqlalchemy.exc import SQLAlchemyError
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm.session import Session
 
 from app.config import (
+    DATABASE_URL,
     PUBLIC_ACCOUNT_LIST_SLEEP_INTERVAL,
     PUBLIC_ACCOUNT_LIST_URL,
     REQUEST_TIMEOUT,
 )
-from app.database import BatchAsyncSessionLocal
 from app.errors import ServiceUnavailable
 from app.model.db import PublicAccountList
 from batch import free_malloc, log
 
 process_name = "INDEXER-PUBLIC-INFO-PUBLIC-ACCOUNT"
 LOG = log.get_logger(process_name=process_name)
+
+db_engine = create_engine(DATABASE_URL, echo=False, pool_pre_ping=True)
 
 
 class Processor:
@@ -50,21 +51,15 @@ class Processor:
     def __init__(self):
         self.account_list_digest = None
 
-    async def process(self):
+    def process(self):
         LOG.info("Syncing public account list")
 
         # Get data from PUBLIC_ACCOUNT_LIST_URL
         try:
-            async with aiohttp.ClientSession(trust_env=True) as session:
-                async with session.get(
-                    PUBLIC_ACCOUNT_LIST_URL,
-                    timeout=ClientTimeout(
-                        connect=REQUEST_TIMEOUT[0], total=REQUEST_TIMEOUT[1]
-                    ),
-                ) as response:
-                    if response.status != 200:
-                        raise Exception(f"status code={response.status}")
-                    account_list_json = await response.json()
+            _resp = requests.get(PUBLIC_ACCOUNT_LIST_URL, timeout=REQUEST_TIMEOUT)
+            if _resp.status_code != 200:
+                raise Exception(f"status code={_resp.status_code}")
+            account_list_json = _resp.json()
         except Exception:
             LOG.exception("Failed to get public account list")
             return
@@ -80,10 +75,10 @@ class Processor:
             self.account_list_digest = _resp_digest
 
         # Update DB data
-        db_session = BatchAsyncSessionLocal()
+        db_session = Session(autocommit=False, autoflush=True, bind=db_engine)
         try:
             # Delete all account list from DB
-            await db_session.execute(delete(PublicAccountList))
+            db_session.execute(delete(PublicAccountList))
 
             # Insert account list
             for i, _account in enumerate(account_list_json):
@@ -109,7 +104,7 @@ class Processor:
                         f"Invalid address: index={i} account_address={account_address}"
                     )
                     continue
-                await self.__sink_on_account_list(
+                self.__sink_on_account_list(
                     db_session=db_session,
                     key_manager=key_manager,
                     key_manager_name=key_manager_name,
@@ -117,18 +112,18 @@ class Processor:
                     account_address=account_address,
                 )
 
-            await db_session.commit()
+            db_session.commit()
         except Exception as e:
-            await db_session.rollback()
+            db_session.rollback()
             raise e
         finally:
-            await db_session.close()
+            db_session.close()
 
         LOG.info("Sync job has been completed")
 
     @staticmethod
-    async def __sink_on_account_list(
-        db_session: AsyncSession,
+    def __sink_on_account_list(
+        db_session: Session,
         key_manager: str,
         key_manager_name: str,
         account_type: int,
@@ -139,17 +134,17 @@ class Processor:
         _account_list.key_manager_name = key_manager_name
         _account_list.account_type = account_type
         _account_list.account_address = account_address
-        await db_session.merge(_account_list)
+        db_session.merge(_account_list)
 
 
-async def main():
+def main():
     LOG.info("Service started successfully")
     processor = Processor()
     while True:
         start_time = time.time()
 
         try:
-            await processor.process()
+            processor.process()
         except ServiceUnavailable:
             LOG.notice("An external service was unavailable")
         except SQLAlchemyError as sa_err:
@@ -158,12 +153,12 @@ async def main():
             LOG.exception("An exception occurred during processing")
 
         elapsed_time = time.time() - start_time
-        await asyncio.sleep(max(PUBLIC_ACCOUNT_LIST_SLEEP_INTERVAL - elapsed_time, 0))
+        time.sleep(max(PUBLIC_ACCOUNT_LIST_SLEEP_INTERVAL - elapsed_time, 0))
         free_malloc()
 
 
 if __name__ == "__main__":
     try:
-        asyncio.run(main())
+        main()
     except KeyboardInterrupt:
         sys.exit(1)

--- a/batch/indexer_PublicInfo_TokenList.py
+++ b/batch/indexer_PublicInfo_TokenList.py
@@ -17,27 +17,32 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
-import asyncio
 import hashlib
 import json
 import sys
 import time
 
-import aiohttp
-from aiohttp import ClientTimeout
+import requests
 from eth_utils import to_checksum_address
 from sqlalchemy import delete
+from sqlalchemy.engine.create import create_engine
 from sqlalchemy.exc import SQLAlchemyError
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm.session import Session
 
-from app.config import REQUEST_TIMEOUT, TOKEN_LIST_SLEEP_INTERVAL, TOKEN_LIST_URL
-from app.database import BatchAsyncSessionLocal
+from app.config import (
+    DATABASE_URL,
+    REQUEST_TIMEOUT,
+    TOKEN_LIST_SLEEP_INTERVAL,
+    TOKEN_LIST_URL,
+)
 from app.errors import ServiceUnavailable
 from app.model.db import TokenList
 from batch import free_malloc, log
 
 process_name = "INDEXER-PUBLIC-INFO-TOKEN-LIST"
 LOG = log.get_logger(process_name=process_name)
+
+db_engine = create_engine(DATABASE_URL, echo=False, pool_pre_ping=True)
 
 
 class Processor:
@@ -46,21 +51,15 @@ class Processor:
     def __init__(self):
         self.token_list_digest = None
 
-    async def process(self):
+    def process(self):
         LOG.info("Syncing token list")
 
         # Get from TOKEN_LIST_URL
         try:
-            async with aiohttp.ClientSession(trust_env=True) as session:
-                async with session.get(
-                    TOKEN_LIST_URL,
-                    timeout=ClientTimeout(
-                        connect=REQUEST_TIMEOUT[0], total=REQUEST_TIMEOUT[1]
-                    ),
-                ) as response:
-                    if response.status != 200:
-                        raise Exception(f"status code={response.status}")
-                    token_list_json = await response.json()
+            _resp = requests.get(TOKEN_LIST_URL, timeout=REQUEST_TIMEOUT)
+            if _resp.status_code != 200:
+                raise Exception(f"status code={_resp.status_code}")
+            token_list_json = _resp.json()
         except Exception:
             LOG.exception("Failed to get token list")
             return
@@ -74,10 +73,10 @@ class Processor:
             self.token_list_digest = _resp_digest
 
         # Update DB data
-        db_session = BatchAsyncSessionLocal()
+        db_session = Session(autocommit=False, autoflush=True, bind=db_engine)
         try:
             # Delete all token list from DB
-            await db_session.execute(delete(TokenList))
+            db_session.execute(delete(TokenList))
 
             # Insert token list
             for i, token in enumerate(token_list_json):
@@ -104,7 +103,7 @@ class Processor:
                     )
                     continue
 
-                await self.__sink_on_token_list(
+                self.__sink_on_token_list(
                     db_session=db_session,
                     token_address=token_address,
                     token_template=token_template,
@@ -112,18 +111,18 @@ class Processor:
                     product_type=product_type,
                 )
 
-            await db_session.commit()
+            db_session.commit()
         except Exception as e:
-            await db_session.rollback()
+            db_session.rollback()
             raise e
         finally:
-            await db_session.close()
+            db_session.close()
 
         LOG.info("Sync job has been completed")
 
     @staticmethod
-    async def __sink_on_token_list(
-        db_session: AsyncSession,
+    def __sink_on_token_list(
+        db_session: Session,
         token_address: str,
         token_template: str,
         key_manager: list[str],
@@ -134,17 +133,17 @@ class Processor:
         _token_list.token_template = token_template
         _token_list.key_manager = key_manager
         _token_list.product_type = product_type
-        await db_session.merge(_token_list)
+        db_session.merge(_token_list)
 
 
-async def main():
+def main():
     LOG.info("Service started successfully")
     processor = Processor()
     while True:
         start_time = time.time()
 
         try:
-            await processor.process()
+            processor.process()
         except ServiceUnavailable:
             LOG.notice("An external service was unavailable")
         except SQLAlchemyError as sa_err:
@@ -153,12 +152,12 @@ async def main():
             LOG.exception("An exception occurred during processing")
 
         elapsed_time = time.time() - start_time
-        await asyncio.sleep(max(TOKEN_LIST_SLEEP_INTERVAL - elapsed_time, 0))
+        time.sleep(max(TOKEN_LIST_SLEEP_INTERVAL - elapsed_time, 0))
         free_malloc()
 
 
 if __name__ == "__main__":
     try:
-        asyncio.run(main())
+        main()
     except KeyboardInterrupt:
         sys.exit(1)

--- a/batch/processor_Send_Chat_Webhook.py
+++ b/batch/processor_Send_Chat_Webhook.py
@@ -17,67 +17,68 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
-import asyncio
 import sys
 import time
 from typing import Sequence
 
-import aiohttp
+import requests
 from sqlalchemy import select
+from sqlalchemy.engine.create import create_engine
 from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm.session import Session
 
-from app.config import CHAT_WEBHOOK_URL
-from app.database import BatchAsyncSessionLocal
+from app.config import CHAT_WEBHOOK_URL, DATABASE_URL
 from app.model.db import ChatWebhook
 from batch import free_malloc, log
 
 LOG = log.get_logger(process_name="PROCESSOR-SEND-CHAT-WEBHOOK")
 
+db_engine = create_engine(DATABASE_URL, echo=False, pool_pre_ping=True)
+
 
 class Processor:
-    async def process(self):
-        db_session = BatchAsyncSessionLocal()
+    def process(self):
+        db_session = Session(autocommit=False, autoflush=True, bind=db_engine)
         try:
             hook_list: Sequence[ChatWebhook] = (
-                await db_session.scalars(select(ChatWebhook))
+                db_session.scalars(select(ChatWebhook))
             ).all()
             if len(hook_list) > 0:
                 LOG.info("Process start")
 
                 for hook in hook_list:
                     try:
-                        async with aiohttp.ClientSession(trust_env=True) as session:
-                            await session.post(CHAT_WEBHOOK_URL, json=hook.message)
+                        requests.post(CHAT_WEBHOOK_URL, json=hook.message)
                     except Exception:
                         LOG.exception("Failed to send chat webhook")
                     finally:
                         # Delete the message regardless of the status code of the response.
-                        await db_session.delete(hook)
-                        await db_session.commit()
+                        db_session.delete(hook)
+                        db_session.commit()
                 LOG.info("Process end")
         finally:
-            await db_session.close()
+            db_session.close()
 
 
-async def main():
+def main():
     LOG.info("Service started successfully")
     processor = Processor()
     while True:
         start_time = time.time()
         try:
-            await processor.process()
+            processor.process()
         except SQLAlchemyError as sa_err:
             LOG.error(f"A database error has occurred: code={sa_err.code}\n{sa_err}")
         except Exception as ex:
             LOG.exception(ex)
 
         elapsed_time = time.time() - start_time
-        await asyncio.sleep(max(30 - elapsed_time, 0))
+        time.sleep(max(30 - elapsed_time, 0))
         free_malloc()
 
 
 if __name__ == "__main__":
     try:
-        asyncio.run(main())
+        main()
     except KeyboardInterrupt:
         sys.exit(1)

--- a/cmd/explorer/pyproject.toml
+++ b/cmd/explorer/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     {name = "BOOSTRY Co., Ltd.", email = "dev@boostry.co.jp"},
 ]
 readme = "README.md"
-requires-python = "==3.12.2"
+requires-python = "==3.12.9"
 dependencies = []
 
 [project.scripts]

--- a/cmd/explorer/uv.lock
+++ b/cmd/explorer/uv.lock
@@ -1,5 +1,6 @@
 version = 1
-requires-python = "==3.12.2"
+revision = 2
+requires-python = "==3.12.9"
 
 [[package]]
 name = "ibet-wallet-api-explorer"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ dependencies = [
     "alembic<2.0.0,>=1.14.0",
     "aiomysql==0.2.0",
     "httpx~=0.28.0",
-    "aiohttp~=3.10.10",
     "memray<2.0.0,>=1.14.0",
     "py-spy>=0.4.0",
     "asyncpg~=0.30.0",
@@ -41,6 +40,7 @@ dependencies = [
     "opentelemetry-instrumentation-psycopg>=0.54b0,<1.0.0",
     "opentelemetry-instrumentation-sqlalchemy>=0.54b0,<1.0.0",
     "opentelemetry-exporter-otlp-proto-grpc>=1.33.1,<2.0.0",
+    "requests>=2.32.3",
 ]
 
 [tool.uv]
@@ -66,6 +66,8 @@ ibet-explorer = [
     "textual~=0.44.1",
     "async-cache~=1.1.1",
     "typer~=0.12.3",
+    "aiohttp~=3.12.13",
+    "async-cache==1.1.1",
 ]
 
 [tool.uv.sources]

--- a/tests/batch/indexer_Company_List_test.py
+++ b/tests/batch/indexer_Company_List_test.py
@@ -50,15 +50,9 @@ def caplog(caplog: pytest.LogCaptureFixture):
 class MockResponse:
     def __init__(self, data: object, status_code: int = 200):
         self.data = data
-        self.status = status_code
+        self.status_code = status_code
 
-    async def __aexit__(self, exc_type, exc, tb):
-        pass
-
-    async def __aenter__(self):
-        return self
-
-    async def json(self) -> object:
+    def json(self) -> object:
         return self.data
 
 
@@ -70,7 +64,7 @@ class TestProcessor:
 
     # <Normal_1>
     # 0 record
-    @mock.patch("aiohttp.client.ClientSession.get")
+    @mock.patch("requests.get")
     async def test_normal_1(self, mock_get, processor, session):
         # Prepare data
         _company = Company()
@@ -97,7 +91,7 @@ class TestProcessor:
         mock_get.side_effect = [MockResponse([])]
 
         # Run target process
-        await processor.process()
+        processor.process()
 
         # Assertion
         session.rollback()
@@ -108,7 +102,7 @@ class TestProcessor:
 
     # <Normal_2>
     # 1 record
-    @mock.patch("aiohttp.client.ClientSession.get")
+    @mock.patch("requests.get")
     async def test_normal_2(self, mock_get, processor, session):
         # Prepare data
         _company = Company()
@@ -146,7 +140,7 @@ class TestProcessor:
         ]
 
         # Run target process
-        await processor.process()
+        processor.process()
 
         # Assertion
         _company_list: Sequence[Company] = session.scalars(
@@ -163,7 +157,7 @@ class TestProcessor:
 
     # <Normal_3>
     # 2 record
-    @mock.patch("aiohttp.client.ClientSession.get")
+    @mock.patch("requests.get")
     async def test_normal_3(self, mock_get, processor, session):
         # Prepare data
         _company = Company()
@@ -206,7 +200,7 @@ class TestProcessor:
         ]
 
         # Run target process
-        await processor.process()
+        processor.process()
 
         # Assertion
         _company_list: Sequence[Company] = session.scalars(
@@ -232,7 +226,7 @@ class TestProcessor:
     # Insert SKIP
     # type error
     # address
-    @mock.patch("aiohttp.client.ClientSession.get")
+    @mock.patch("requests.get")
     async def test_normal_4_1_1(self, mock_get, processor, session):
         # Prepare data
         _company = Company()
@@ -276,7 +270,7 @@ class TestProcessor:
         ]
 
         # Run target process
-        await processor.process()
+        processor.process()
 
         # Assertion
         _company_list: Sequence[Company] = session.scalars(
@@ -295,7 +289,7 @@ class TestProcessor:
     # Insert SKIP
     # type error
     # corporate_name
-    @mock.patch("aiohttp.client.ClientSession.get")
+    @mock.patch("requests.get")
     async def test_normal_4_1_2(self, mock_get, processor, session):
         # Prepare data
         _company = Company()
@@ -339,7 +333,7 @@ class TestProcessor:
         ]
 
         # Run target process
-        await processor.process()
+        processor.process()
 
         # Assertion
         _company_list: Sequence[Company] = session.scalars(
@@ -358,7 +352,7 @@ class TestProcessor:
     # Insert SKIP
     # type error
     # rsa_publickey
-    @mock.patch("aiohttp.client.ClientSession.get")
+    @mock.patch("requests.get")
     async def test_normal_4_1_3(self, mock_get, processor, session):
         # Prepare data
         _company = Company()
@@ -402,7 +396,7 @@ class TestProcessor:
         ]
 
         # Run target process
-        await processor.process()
+        processor.process()
 
         # Assertion
         _company_list: Sequence[Company] = session.scalars(
@@ -421,7 +415,7 @@ class TestProcessor:
     # Insert SKIP
     # type error
     # homepage
-    @mock.patch("aiohttp.client.ClientSession.get")
+    @mock.patch("requests.get")
     async def test_normal_4_1_4(self, mock_get, processor, session):
         # Prepare data
         _company = Company()
@@ -465,7 +459,7 @@ class TestProcessor:
         ]
 
         # Run target process
-        await processor.process()
+        processor.process()
 
         # Assertion
         _company_list: Sequence[Company] = session.scalars(
@@ -484,7 +478,7 @@ class TestProcessor:
     # Insert SKIP
     # required error
     # address
-    @mock.patch("aiohttp.client.ClientSession.get")
+    @mock.patch("requests.get")
     async def test_normal_4_2_1(self, mock_get, processor, session):
         # Prepare data
         _company = Company()
@@ -527,7 +521,7 @@ class TestProcessor:
         ]
 
         # Run target process
-        await processor.process()
+        processor.process()
 
         # Assertion
         _company_list: Sequence[Company] = session.scalars(
@@ -546,7 +540,7 @@ class TestProcessor:
     # Insert SKIP
     # required error
     # corporate_name
-    @mock.patch("aiohttp.client.ClientSession.get")
+    @mock.patch("requests.get")
     async def test_normal_4_2_2(self, mock_get, processor, session):
         # Prepare data
         _company = Company()
@@ -589,7 +583,7 @@ class TestProcessor:
         ]
 
         # Run target process
-        await processor.process()
+        processor.process()
 
         # Assertion
         _company_list: Sequence[Company] = session.scalars(
@@ -608,7 +602,7 @@ class TestProcessor:
     # Insert SKIP
     # required error
     # address
-    @mock.patch("aiohttp.client.ClientSession.get")
+    @mock.patch("requests.get")
     async def test_normal_4_2_3(self, mock_get, processor, session):
         # Prepare data
         _company = Company()
@@ -651,7 +645,7 @@ class TestProcessor:
         ]
 
         # Run target process
-        await processor.process()
+        processor.process()
 
         # Assertion
         _company_list: Sequence[Company] = session.scalars(
@@ -669,7 +663,7 @@ class TestProcessor:
     # <Normal_4_3>
     # Insert SKIP
     # invalid address error
-    @mock.patch("aiohttp.client.ClientSession.get")
+    @mock.patch("requests.get")
     async def test_normal_4_3(self, mock_get, processor, session):
         # Prepare data
         _company = Company()
@@ -713,7 +707,7 @@ class TestProcessor:
         ]
 
         # Run target process
-        await processor.process()
+        processor.process()
 
         # Assertion
         _company_list: Sequence[Company] = session.scalars(
@@ -731,7 +725,7 @@ class TestProcessor:
     # <Normal_5_1>
     # There are no differences from last time
     # -> Skip this cycle
-    @mock.patch("aiohttp.client.ClientSession.get")
+    @mock.patch("requests.get")
     async def test_normal_5_1(self, mock_get, processor, session, caplog):
         # Run target process: 1st time
         mock_get.side_effect = [
@@ -752,7 +746,7 @@ class TestProcessor:
                 ]
             )
         ]
-        await processor.process()
+        processor.process()
 
         # Run target process: 2nd time
         mock_get.side_effect = [
@@ -773,7 +767,7 @@ class TestProcessor:
                 ]
             )
         ]
-        await processor.process()
+        processor.process()
 
         # Assertion
         _company_list: Sequence[Company] = session.scalars(
@@ -807,7 +801,7 @@ class TestProcessor:
 
     # <Normal_5_2>
     # There are differences from the previous cycle
-    @mock.patch("aiohttp.client.ClientSession.get")
+    @mock.patch("requests.get")
     async def test_normal_5_2(self, mock_get, processor, session, caplog):
         # Run target process: 1st time
         mock_get.side_effect = [
@@ -828,7 +822,7 @@ class TestProcessor:
                 ]
             )
         ]
-        await processor.process()
+        processor.process()
 
         # Run target process: 2nd time
         mock_get.side_effect = [
@@ -843,7 +837,7 @@ class TestProcessor:
                 ]
             )
         ]
-        await processor.process()
+        processor.process()
 
         # Assertion
         _company_list: Sequence[Company] = session.scalars(
@@ -875,7 +869,7 @@ class TestProcessor:
     # API error
     # Connection error
     @mock.patch(
-        "aiohttp.client.ClientSession.get",
+        "requests.get",
         MagicMock(side_effect=requests.exceptions.ConnectionError),
     )
     async def test_error_1_1(self, processor, session):
@@ -901,7 +895,7 @@ class TestProcessor:
         session.commit()
 
         # Run target process
-        await processor.process()
+        processor.process()
 
         # Assertion
         _company_list: Sequence[Company] = session.scalars(
@@ -912,7 +906,7 @@ class TestProcessor:
     # <Error_1_2>
     # API error
     # not succeed api
-    @mock.patch("aiohttp.client.ClientSession.get")
+    @mock.patch("requests.get")
     async def test_error_1_2(self, mock_get, processor, session):
         # Prepare data
         _company = Company()
@@ -939,7 +933,7 @@ class TestProcessor:
         mock_get.side_effect = [MockResponse([], 400)]
 
         # Run target process
-        await processor.process()
+        processor.process()
 
         # Assertion
         _company_list: Sequence[Company] = session.scalars(
@@ -950,7 +944,7 @@ class TestProcessor:
     # <Error_2>
     # not decode response
     @mock.patch(
-        "aiohttp.client.ClientSession.get",
+        "requests.get",
         MagicMock(side_effect=json.decoder.JSONDecodeError),
     )
     async def test_error_2(self, processor, session):
@@ -976,7 +970,7 @@ class TestProcessor:
         session.commit()
 
         # Run target process
-        await processor.process()
+        processor.process()
 
         # Assertion
         _company_list: Sequence[Company] = session.scalars(
@@ -986,7 +980,7 @@ class TestProcessor:
 
     # <Error_3>
     # other error
-    @mock.patch("aiohttp.client.ClientSession.get")
+    @mock.patch("requests.get")
     async def test_error_3(self, mock_get, processor, session):
         # Prepare data
         _company = Company()
@@ -1026,7 +1020,7 @@ class TestProcessor:
 
         # Run target process
         with pytest.raises(Exception):
-            await processor.process()
+            processor.process()
 
         # Assertion
         _company_list: Sequence[Company] = session.scalars(

--- a/tests/batch/indexer_PublicInfo_PublicAccountList_test.py
+++ b/tests/batch/indexer_PublicInfo_PublicAccountList_test.py
@@ -50,15 +50,9 @@ def caplog(caplog: pytest.LogCaptureFixture):
 class MockResponse:
     def __init__(self, data: object, status_code: int = 200):
         self.data = data
-        self.status = status_code
+        self.status_code = status_code
 
-    async def __aexit__(self, exc_type, exc, tb):
-        pass
-
-    async def __aenter__(self):
-        return self
-
-    async def json(self) -> object:
+    def json(self) -> object:
         return self.data
 
 
@@ -78,7 +72,7 @@ class TestProcessor:
 
     # <Normal_1>
     # 0 record
-    @mock.patch("aiohttp.client.ClientSession.get")
+    @mock.patch("requests.get")
     async def test_normal_1(self, mock_get, processor, async_session):
         # Prepare data
         _account_list = PublicAccountList()
@@ -93,7 +87,7 @@ class TestProcessor:
         mock_get.side_effect = [MockResponse([])]
 
         # Run target process
-        await processor.process()
+        processor.process()
 
         # Assertion
         # - The cleanup process should remove all data.
@@ -105,7 +99,7 @@ class TestProcessor:
 
     # <Normal_2>
     # Multiple records
-    @mock.patch("aiohttp.client.ClientSession.get")
+    @mock.patch("requests.get")
     async def test_normal_2(self, mock_get, processor, async_session):
         # Prepare data
         _account_list = PublicAccountList()
@@ -137,7 +131,7 @@ class TestProcessor:
         ]
 
         # Run target process
-        await processor.process()
+        processor.process()
 
         # Assertion
         # - The cleanup process should remove all data.
@@ -169,7 +163,7 @@ class TestProcessor:
     # <Normal_3_1>
     # There are no differences from last time
     # -> Skip this cycle
-    @mock.patch("aiohttp.client.ClientSession.get")
+    @mock.patch("requests.get")
     async def test_normal_3_1(self, mock_get, processor, async_session, caplog):
         # Run target process: 1st time
         mock_get.side_effect = [
@@ -190,7 +184,7 @@ class TestProcessor:
                 ]
             )
         ]
-        await processor.process()
+        processor.process()
 
         # Run target process: 2nd time
         mock_get.side_effect = [
@@ -211,7 +205,7 @@ class TestProcessor:
                 ]
             )
         ]
-        await processor.process()
+        processor.process()
 
         # Assertion
         # - The cleanup process should remove all of your data.
@@ -250,7 +244,7 @@ class TestProcessor:
 
     # <Normal_3_2>
     # There are differences from last time
-    @mock.patch("aiohttp.client.ClientSession.get")
+    @mock.patch("requests.get")
     async def test_normal_3_2(self, mock_get, processor, async_session, caplog):
         # Run target process: 1st time
         mock_get.side_effect = [
@@ -271,7 +265,7 @@ class TestProcessor:
                 ]
             )
         ]
-        await processor.process()
+        processor.process()
 
         # Run target process: 2nd time
         mock_get.side_effect = [
@@ -286,7 +280,7 @@ class TestProcessor:
                 ]
             )
         ]
-        await processor.process()
+        processor.process()
 
         # Assertion
         # - The cleanup process should remove all data.
@@ -323,7 +317,7 @@ class TestProcessor:
     # <Error_1_1>
     # API error: ConnectionError
     @mock.patch(
-        "aiohttp.client.ClientSession.get",
+        "requests.get",
         MagicMock(side_effect=requests.exceptions.ConnectionError),
     )
     async def test_error_1_1(self, processor, async_session):
@@ -337,7 +331,7 @@ class TestProcessor:
         await async_session.commit()
 
         # Run target process
-        await processor.process()
+        processor.process()
 
         # Assertion
         # - The cleanup process should be rolled back and
@@ -362,7 +356,7 @@ class TestProcessor:
 
     # <Error_1_2>
     # API error: Not succeed request
-    @mock.patch("aiohttp.client.ClientSession.get")
+    @mock.patch("requests.get")
     async def test_error_1_2(self, mock_get, processor, async_session):
         # Prepare data
         _account_list = PublicAccountList()
@@ -377,7 +371,7 @@ class TestProcessor:
         mock_get.side_effect = [MockResponse([], 400)]
 
         # Run target process
-        await processor.process()
+        processor.process()
 
         # Assertion
         # - The cleanup process should be rolled back and
@@ -403,7 +397,7 @@ class TestProcessor:
     # <Error_1_3>
     # API error: JSONDecodeError
     @mock.patch(
-        "aiohttp.client.ClientSession.get",
+        "requests.get",
         MagicMock(side_effect=json.decoder.JSONDecodeError),
     )
     async def test_error_1_3(self, processor, async_session):
@@ -417,7 +411,7 @@ class TestProcessor:
         await async_session.commit()
 
         # Run target process
-        await processor.process()
+        processor.process()
 
         # Assertion
         # - The cleanup process should be rolled back and
@@ -443,7 +437,7 @@ class TestProcessor:
     # <Error_2>
     # Invalid type error
     # -> Skip processing
-    @mock.patch("aiohttp.client.ClientSession.get")
+    @mock.patch("requests.get")
     @pytest.mark.parametrize(
         "invalid_record",
         [
@@ -513,7 +507,7 @@ class TestProcessor:
         mock_get.side_effect = [MockResponse([invalid_record])]
 
         # Run target process
-        await processor.process()
+        processor.process()
 
         # Assertion
         await async_session.rollback()
@@ -528,7 +522,7 @@ class TestProcessor:
 
     # <Error_3>
     # Other error
-    @mock.patch("aiohttp.client.ClientSession.get")
+    @mock.patch("requests.get")
     async def test_error_3(self, mock_get, processor, async_session):
         # Mock
         mock_get.side_effect = [
@@ -547,7 +541,7 @@ class TestProcessor:
 
         # Run target process
         with pytest.raises(Exception):
-            await processor.process()
+            processor.process()
 
         # Assertion
         await async_session.rollback()

--- a/tests/batch/processor_Send_Chat_Webhook_test.py
+++ b/tests/batch/processor_Send_Chat_Webhook_test.py
@@ -20,7 +20,7 @@ SPDX-License-Identifier: Apache-2.0
 import json
 import logging
 from unittest import mock
-from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
 
 import pytest
 from sqlalchemy import select
@@ -53,10 +53,8 @@ class TestProcessorSendChatWebhook:
     # No unsent hook exists
     async def test_normal_1(self, processor, async_session, caplog):
         # Run processor
-        with mock.patch(
-            "aiohttp.client.ClientSession.post", AsyncMock(side_effect=None)
-        ):
-            await processor.process()
+        with mock.patch("requests.post", MagicMock(side_effect=None)):
+            processor.process()
             await async_session.commit()
 
         # Assertion
@@ -75,10 +73,8 @@ class TestProcessorSendChatWebhook:
         await async_session.commit()
 
         # Run processor
-        with mock.patch(
-            "aiohttp.client.ClientSession.post", AsyncMock(side_effect=None)
-        ):
-            await processor.process()
+        with mock.patch("requests.post", MagicMock(side_effect=None)):
+            processor.process()
             await async_session.commit()
 
         # Assertion
@@ -96,10 +92,8 @@ class TestProcessorSendChatWebhook:
         await async_session.commit()
 
         # Run processor
-        with mock.patch(
-            "aiohttp.client.ClientSession.post", AsyncMock(side_effect=Exception())
-        ):
-            await processor.process()
+        with mock.patch("requests.post", MagicMock(side_effect=Exception())):
+            processor.process()
             await async_session.commit()
 
         # Assertion
@@ -126,13 +120,11 @@ class TestProcessorSendChatWebhook:
 
         # Run processor
         with (
-            mock.patch(
-                "aiohttp.client.ClientSession.post", AsyncMock(side_effect=None)
-            ),
+            mock.patch("requests.post", MagicMock(side_effect=None)),
             mock.patch.object(Session, "commit", side_effect=SQLAlchemyError()),
             pytest.raises(SQLAlchemyError),
         ):
-            await processor.process()
+            processor.process()
             await async_session.commit()
 
         # Assertion

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "aiohttp"
-version = "3.10.11"
+version = "3.12.13"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohappyeyeballs" },
@@ -21,25 +21,28 @@ dependencies = [
     { name = "attrs" },
     { name = "frozenlist" },
     { name = "multidict" },
+    { name = "propcache" },
     { name = "yarl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/25/a8/8e2ba36c6e3278d62e0c88aa42bb92ddbef092ac363b390dab4421da5cf5/aiohttp-3.10.11.tar.gz", hash = "sha256:9dc2b8f3dcab2e39e0fa309c8da50c3b55e6f34ab25f1a71d3288f24924d33a7", size = 7551886, upload-time = "2024-11-13T16:40:33.335Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/42/6e/ab88e7cb2a4058bed2f7870276454f85a7c56cd6da79349eb314fc7bbcaa/aiohttp-3.12.13.tar.gz", hash = "sha256:47e2da578528264a12e4e3dd8dd72a7289e5f812758fe086473fab037a10fcce", size = 7819160, upload-time = "2025-06-14T15:15:41.354Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/16/077057ef3bd684dbf9a8273a5299e182a8d07b4b252503712ff8b5364fd1/aiohttp-3.10.11-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:7480519f70e32bfb101d71fb9a1f330fbd291655a4c1c922232a48c458c52710", size = 584830, upload-time = "2024-11-13T16:37:49.608Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/cf/348b93deb9597c61a51b6682e81f7c7d79290249e886022ef0705d858d90/aiohttp-3.10.11-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:f65267266c9aeb2287a6622ee2bb39490292552f9fbf851baabc04c9f84e048d", size = 397090, upload-time = "2024-11-13T16:37:51.539Z" },
-    { url = "https://files.pythonhosted.org/packages/70/bf/903df5cd739dfaf5b827b3d8c9d68ff4fcea16a0ca1aeb948c9da30f56c8/aiohttp-3.10.11-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7400a93d629a0608dc1d6c55f1e3d6e07f7375745aaa8bd7f085571e4d1cee97", size = 392361, upload-time = "2024-11-13T16:37:53.586Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/97/e4792675448a2ac5bd56f377a095233b805dd1315235c940c8ba5624e3cb/aiohttp-3.10.11-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f34b97e4b11b8d4eb2c3a4f975be626cc8af99ff479da7de49ac2c6d02d35725", size = 1309839, upload-time = "2024-11-13T16:37:55.68Z" },
-    { url = "https://files.pythonhosted.org/packages/96/d0/ba19b1260da6fbbda4d5b1550d8a53ba3518868f2c143d672aedfdbc6172/aiohttp-3.10.11-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1e7b825da878464a252ccff2958838f9caa82f32a8dbc334eb9b34a026e2c636", size = 1348116, upload-time = "2024-11-13T16:37:58.232Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/b9/15100ee7113a2638bfdc91aecc54641609a92a7ce4fe533ebeaa8d43ff93/aiohttp-3.10.11-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f9f92a344c50b9667827da308473005f34767b6a2a60d9acff56ae94f895f385", size = 1391402, upload-time = "2024-11-13T16:38:00.522Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/36/831522618ac0dcd0b28f327afd18df7fb6bbf3eaf302f912a40e87714846/aiohttp-3.10.11-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc6f1ab987a27b83c5268a17218463c2ec08dbb754195113867a27b166cd6087", size = 1304239, upload-time = "2024-11-13T16:38:04.195Z" },
-    { url = "https://files.pythonhosted.org/packages/60/9f/b7230d0c48b076500ae57adb717aa0656432acd3d8febb1183dedfaa4e75/aiohttp-3.10.11-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1dc0f4ca54842173d03322793ebcf2c8cc2d34ae91cc762478e295d8e361e03f", size = 1256565, upload-time = "2024-11-13T16:38:07.218Z" },
-    { url = "https://files.pythonhosted.org/packages/63/c2/35c7b4699f4830b3b0a5c3d5619df16dca8052ae8b488e66065902d559f6/aiohttp-3.10.11-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7ce6a51469bfaacff146e59e7fb61c9c23006495d11cc24c514a455032bcfa03", size = 1269285, upload-time = "2024-11-13T16:38:09.396Z" },
-    { url = "https://files.pythonhosted.org/packages/51/48/bc20ea753909bdeb09f9065260aefa7453e3a57f6a51f56f5216adc1a5e7/aiohttp-3.10.11-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:aad3cd91d484d065ede16f3cf15408254e2469e3f613b241a1db552c5eb7ab7d", size = 1276716, upload-time = "2024-11-13T16:38:12.039Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/7b/a8708616b3810f55ead66f8e189afa9474795760473aea734bbea536cd64/aiohttp-3.10.11-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:f4df4b8ca97f658c880fb4b90b1d1ec528315d4030af1ec763247ebfd33d8b9a", size = 1315023, upload-time = "2024-11-13T16:38:15.155Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/d6/dfe9134a921e05b01661a127a37b7d157db93428905450e32f9898eef27d/aiohttp-3.10.11-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:2e4e18a0a2d03531edbc06c366954e40a3f8d2a88d2b936bbe78a0c75a3aab3e", size = 1342735, upload-time = "2024-11-13T16:38:17.539Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/1a/3bd7f18e3909eabd57e5d17ecdbf5ea4c5828d91341e3676a07de7c76312/aiohttp-3.10.11-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6ce66780fa1a20e45bc753cda2a149daa6dbf1561fc1289fa0c308391c7bc0a4", size = 1302618, upload-time = "2024-11-13T16:38:19.865Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/51/d063133781cda48cfdd1e11fc8ef45ab3912b446feba41556385b3ae5087/aiohttp-3.10.11-cp312-cp312-win32.whl", hash = "sha256:a919c8957695ea4c0e7a3e8d16494e3477b86f33067478f43106921c2fef15bb", size = 360497, upload-time = "2024-11-13T16:38:21.996Z" },
-    { url = "https://files.pythonhosted.org/packages/55/4e/f29def9ed39826fe8f85955f2e42fe5cc0cbe3ebb53c97087f225368702e/aiohttp-3.10.11-cp312-cp312-win_amd64.whl", hash = "sha256:b5e29706e6389a2283a91611c91bf24f218962717c8f3b4e528ef529d112ee27", size = 380577, upload-time = "2024-11-13T16:38:24.247Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/6a/ce40e329788013cd190b1d62bbabb2b6a9673ecb6d836298635b939562ef/aiohttp-3.12.13-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0aa580cf80558557285b49452151b9c69f2fa3ad94c5c9e76e684719a8791b73", size = 700491, upload-time = "2025-06-14T15:14:00.048Z" },
+    { url = "https://files.pythonhosted.org/packages/28/d9/7150d5cf9163e05081f1c5c64a0cdf3c32d2f56e2ac95db2a28fe90eca69/aiohttp-3.12.13-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b103a7e414b57e6939cc4dece8e282cfb22043efd0c7298044f6594cf83ab347", size = 475104, upload-time = "2025-06-14T15:14:01.691Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/91/d42ba4aed039ce6e449b3e2db694328756c152a79804e64e3da5bc19dffc/aiohttp-3.12.13-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:78f64e748e9e741d2eccff9597d09fb3cd962210e5b5716047cbb646dc8fe06f", size = 467948, upload-time = "2025-06-14T15:14:03.561Z" },
+    { url = "https://files.pythonhosted.org/packages/99/3b/06f0a632775946981d7c4e5a865cddb6e8dfdbaed2f56f9ade7bb4a1039b/aiohttp-3.12.13-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c955989bf4c696d2ededc6b0ccb85a73623ae6e112439398935362bacfaaf6", size = 1714742, upload-time = "2025-06-14T15:14:05.558Z" },
+    { url = "https://files.pythonhosted.org/packages/92/a6/2552eebad9ec5e3581a89256276009e6a974dc0793632796af144df8b740/aiohttp-3.12.13-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:d640191016763fab76072c87d8854a19e8e65d7a6fcfcbf017926bdbbb30a7e5", size = 1697393, upload-time = "2025-06-14T15:14:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/9f/bd08fdde114b3fec7a021381b537b21920cdd2aa29ad48c5dffd8ee314f1/aiohttp-3.12.13-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4dc507481266b410dede95dd9f26c8d6f5a14315372cc48a6e43eac652237d9b", size = 1752486, upload-time = "2025-06-14T15:14:08.808Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/e1/affdea8723aec5bd0959171b5490dccd9a91fcc505c8c26c9f1dca73474d/aiohttp-3.12.13-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8a94daa873465d518db073bd95d75f14302e0208a08e8c942b2f3f1c07288a75", size = 1798643, upload-time = "2025-06-14T15:14:10.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/9d/666d856cc3af3a62ae86393baa3074cc1d591a47d89dc3bf16f6eb2c8d32/aiohttp-3.12.13-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:177f52420cde4ce0bb9425a375d95577fe082cb5721ecb61da3049b55189e4e6", size = 1718082, upload-time = "2025-06-14T15:14:12.38Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/ce/3c185293843d17be063dada45efd2712bb6bf6370b37104b4eda908ffdbd/aiohttp-3.12.13-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0f7df1f620ec40f1a7fbcb99ea17d7326ea6996715e78f71a1c9a021e31b96b8", size = 1633884, upload-time = "2025-06-14T15:14:14.415Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/5b/f3413f4b238113be35dfd6794e65029250d4b93caa0974ca572217745bdb/aiohttp-3.12.13-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3062d4ad53b36e17796dce1c0d6da0ad27a015c321e663657ba1cc7659cfc710", size = 1694943, upload-time = "2025-06-14T15:14:16.48Z" },
+    { url = "https://files.pythonhosted.org/packages/82/c8/0e56e8bf12081faca85d14a6929ad5c1263c146149cd66caa7bc12255b6d/aiohttp-3.12.13-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:8605e22d2a86b8e51ffb5253d9045ea73683d92d47c0b1438e11a359bdb94462", size = 1716398, upload-time = "2025-06-14T15:14:18.589Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f3/33192b4761f7f9b2f7f4281365d925d663629cfaea093a64b658b94fc8e1/aiohttp-3.12.13-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:54fbbe6beafc2820de71ece2198458a711e224e116efefa01b7969f3e2b3ddae", size = 1657051, upload-time = "2025-06-14T15:14:20.223Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/0b/26ddd91ca8f84c48452431cb4c5dd9523b13bc0c9766bda468e072ac9e29/aiohttp-3.12.13-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:050bd277dfc3768b606fd4eae79dd58ceda67d8b0b3c565656a89ae34525d15e", size = 1736611, upload-time = "2025-06-14T15:14:21.988Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/8d/e04569aae853302648e2c138a680a6a2f02e374c5b6711732b29f1e129cc/aiohttp-3.12.13-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:2637a60910b58f50f22379b6797466c3aa6ae28a6ab6404e09175ce4955b4e6a", size = 1764586, upload-time = "2025-06-14T15:14:23.979Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/98/c193c1d1198571d988454e4ed75adc21c55af247a9fda08236602921c8c8/aiohttp-3.12.13-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e986067357550d1aaa21cfe9897fa19e680110551518a5a7cf44e6c5638cb8b5", size = 1724197, upload-time = "2025-06-14T15:14:25.692Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/9e/07bb8aa11eec762c6b1ff61575eeeb2657df11ab3d3abfa528d95f3e9337/aiohttp-3.12.13-cp312-cp312-win32.whl", hash = "sha256:ac941a80aeea2aaae2875c9500861a3ba356f9ff17b9cb2dbfb5cbf91baaf5bf", size = 421771, upload-time = "2025-06-14T15:14:27.364Z" },
+    { url = "https://files.pythonhosted.org/packages/52/66/3ce877e56ec0813069cdc9607cd979575859c597b6fb9b4182c6d5f31886/aiohttp-3.12.13-cp312-cp312-win_amd64.whl", hash = "sha256:671f41e6146a749b6c81cb7fd07f5a8356d46febdaaaf07b0e774ff04830461e", size = 447869, upload-time = "2025-06-14T15:14:29.05Z" },
 ]
 
 [[package]]
@@ -774,7 +777,6 @@ name = "ibet-wallet-api"
 version = "25.6"
 source = { virtual = "." }
 dependencies = [
-    { name = "aiohttp" },
     { name = "aiomysql" },
     { name = "alembic" },
     { name = "asyncpg" },
@@ -803,6 +805,7 @@ dependencies = [
     { name = "pymysql", extra = ["rsa"] },
     { name = "pyroscope-io" },
     { name = "pyroscope-otel" },
+    { name = "requests" },
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "tzdata" },
     { name = "uvicorn", extra = ["standard"] },
@@ -811,6 +814,7 @@ dependencies = [
 
 [package.optional-dependencies]
 ibet-explorer = [
+    { name = "aiohttp" },
     { name = "async-cache" },
     { name = "ibet-wallet-api-explorer" },
     { name = "textual" },
@@ -836,9 +840,10 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aiohttp", specifier = "~=3.10.10" },
+    { name = "aiohttp", marker = "extra == 'ibet-explorer'", specifier = "~=3.12.13" },
     { name = "aiomysql", specifier = "==0.2.0" },
     { name = "alembic", specifier = ">=1.14.0,<2.0.0" },
+    { name = "async-cache", marker = "extra == 'ibet-explorer'", specifier = "==1.1.1" },
     { name = "async-cache", marker = "extra == 'ibet-explorer'", specifier = "~=1.1.1" },
     { name = "asyncpg", specifier = "~=0.30.0" },
     { name = "boto3", specifier = "~=1.37.0" },
@@ -867,6 +872,7 @@ requires-dist = [
     { name = "pymysql", extras = ["rsa"], specifier = "~=1.1.0" },
     { name = "pyroscope-io", specifier = ">=0.8.11" },
     { name = "pyroscope-otel", specifier = ">=0.4.1" },
+    { name = "requests", specifier = ">=2.32.3" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.33,<3.0.0" },
     { name = "textual", marker = "extra == 'ibet-explorer'", specifier = "~=0.44.1" },
     { name = "typer", marker = "extra == 'ibet-explorer'", specifier = "~=0.12.3" },


### PR DESCRIPTION
## 📌 Description

- Replace aiohttp with requests
  - Network connections through proxy configurations using HTTPS_PROXY environment variables don't function properly with aiohttp. To address this limitation, we're switching the HTTP client in specific batch processes to use requests instead.

## ✅ Related Issues

- Cherry pick from #1653 

## 🔄 Changes

<!-- List the major changes in this PR. -->

- Replaced aiohttp with requests in batch processing modules

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
