### PR TITLE
Update transfer tests and models to include 'ibet_wst_bridge' message

### DIFF
--- a/app/model/db/idx_transfer.py
+++ b/app/model/db/idx_transfer.py
@@ -47,6 +47,7 @@ class DataMessage(BaseModel):
         "garnishment",
         "inheritance",
         "force_unlock",
+        "ibet_wst_bridge",
     ]
 
 
@@ -81,7 +82,7 @@ class IDXTransfer(Base):
     #   source_event = "Transfer"
     #     => None
     #   source_event = "Unlock"
-    #     => "force_unlock", "garnishment" or "inheritance"
+    #     => "force_unlock", "garnishment", "inheritance" or "ibet_wst_bridge"
     message: Mapped[str | None] = mapped_column(String(50), index=True)
 
     @staticmethod

--- a/app/model/schema/token.py
+++ b/app/model/schema/token.py
@@ -407,6 +407,7 @@ class TransferHistoryBase(BaseModel):
             "garnishment",
             "inheritance",
             "force_unlock",
+            "ibet_wst_bridge",
         ]
         | None
     )
@@ -427,6 +428,7 @@ class DataMessage(BaseModel):
         "garnishment",
         "inheritance",
         "force_unlock",
+        "ibet_wst_bridge",
     ]
 
 

--- a/tests/batch/indexer_Transfer_test.py
+++ b/tests/batch/indexer_Transfer_test.py
@@ -568,7 +568,7 @@ class TestProcessor:
             target=self.trader["account_address"],
             recipient=self.trader2["account_address"],
             amount=10000,
-            data_str=json.dumps({"message": "force_unlock"}),
+            data_str=json.dumps({"message": "ibet_wst_bridge"}),
         )
         block_number_6 = web3.eth.block_number
         share_force_change_locked_account(
@@ -578,7 +578,7 @@ class TestProcessor:
             before_account_address=self.trader["account_address"],
             after_account_address=self.trader2["account_address"],
             amount=10000,
-            data_str=json.dumps({"message": "force_change"}),
+            data_str=json.dumps({"message": "ibet_wst_bridge"}),
         )
         block_number_7 = web3.eth.block_number
         share_force_change_locked_account(
@@ -588,7 +588,7 @@ class TestProcessor:
             before_account_address=self.trader["account_address"],
             after_account_address=self.trader2["account_address"],
             amount=10000,
-            data_str="",
+            data_str=json.dumps({"message": "ibet_wst_bridge"}),
         )
         block_number_8 = web3.eth.block_number
 
@@ -680,8 +680,8 @@ class TestProcessor:
         assert idx_transfer.to_address == self.trader2["account_address"]
         assert idx_transfer.value == 10000
         assert idx_transfer.source_event == IDXTransferSourceEventType.FORCE_UNLOCK
-        assert idx_transfer.data == {"message": "force_unlock"}
-        assert idx_transfer.message == "force_unlock"
+        assert idx_transfer.data == {"message": "ibet_wst_bridge"}
+        assert idx_transfer.message == "ibet_wst_bridge"
         assert idx_transfer.created is not None
         assert idx_transfer.modified is not None
 
@@ -697,8 +697,8 @@ class TestProcessor:
             idx_transfer.source_event
             == IDXTransferSourceEventType.FORCE_CHANGE_LOCKED_ACCOUNT
         )
-        assert idx_transfer.data == {}
-        assert idx_transfer.message is None
+        assert idx_transfer.data == {"message": "ibet_wst_bridge"}
+        assert idx_transfer.message == "ibet_wst_bridge"
         assert idx_transfer.created is not None
         assert idx_transfer.modified is not None
 
@@ -714,8 +714,8 @@ class TestProcessor:
             idx_transfer.source_event
             == IDXTransferSourceEventType.FORCE_CHANGE_LOCKED_ACCOUNT
         )
-        assert idx_transfer.data == {}
-        assert idx_transfer.message is None
+        assert idx_transfer.data == {"message": "ibet_wst_bridge"}
+        assert idx_transfer.message == "ibet_wst_bridge"
         assert idx_transfer.created is not None
         assert idx_transfer.modified is not None
 


### PR DESCRIPTION
## 📌 Description

This pull request introduces support for a new message type, `"ibet_wst_bridge"`, across the database models, schema, and test cases. The changes ensure consistent handling of this message type throughout the application.

## ✅ Related Issues

- Related to #1647 

## 🔄 Changes

### Updates to database models and schema:
* Added `"ibet_wst_bridge"` to the `DataMessage` class in `app/model/db/idx_transfer.py` and `app/model/schema/token.py`. This expands the list of valid message types. [[1]](diffhunk://#diff-8004d43cd0ab067d85d3e2ef24ecd1ab7b07dc3d22f3766a557cbcdf105e33e8R50) [[2]](diffhunk://#diff-f4e88ec2faaf9af2e2935776f1749ab69fefaed04940ac5ce0d6933603961b46R431)
* Updated the `IDXTransfer` class in `app/model/db/idx_transfer.py` to include `"ibet_wst_bridge"` as a possible value for the `source_event` field.
* Added `"ibet_wst_bridge"` to the `TransferHistoryBase` class in `app/model/schema/token.py`.

### Updates to test cases:
* Modified the `test_normal_2` test case in `tests/batch/indexer_Transfer_test.py` to validate the handling of the `"ibet_wst_bridge"` message type. This includes updating assertions and test data to reflect the new message type. [[1]](diffhunk://#diff-3f7e4fd0fbf142bde4c3eb0085d83d7a30d96a6fe068b7b5a8769bb277a4d181L571-R571) [[2]](diffhunk://#diff-3f7e4fd0fbf142bde4c3eb0085d83d7a30d96a6fe068b7b5a8769bb277a4d181L581-R581) [[3]](diffhunk://#diff-3f7e4fd0fbf142bde4c3eb0085d83d7a30d96a6fe068b7b5a8769bb277a4d181L591-R591) [[4]](diffhunk://#diff-3f7e4fd0fbf142bde4c3eb0085d83d7a30d96a6fe068b7b5a8769bb277a4d181L683-R684) [[5]](diffhunk://#diff-3f7e4fd0fbf142bde4c3eb0085d83d7a30d96a6fe068b7b5a8769bb277a4d181L700-R701) [[6]](diffhunk://#diff-3f7e4fd0fbf142bde4c3eb0085d83d7a30d96a6fe068b7b5a8769bb277a4d181L717-R718)

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
