### PR TITLE
Refactor lock and transfer data models to remove deprecated inheritance message

### DIFF
--- a/app/model/db/__init__.py
+++ b/app/model/db/__init__.py
@@ -22,7 +22,7 @@ from .executable_contract import ExecutableContract
 from .idx_agreement import AgreementStatus, IDXAgreement
 from .idx_block_data import IDXBlockData, IDXBlockDataBlockNumber
 from .idx_consume_coupon import IDXConsumeCoupon
-from .idx_lock_unlock import IDXLock, IDXUnlock
+from .idx_lock_unlock import IDXLock, IDXUnlock, LockDataMessage, UnlockDataMessage
 from .idx_order import IDXOrder
 from .idx_position import (
     IDXLockedPosition,
@@ -42,10 +42,10 @@ from .idx_token import (
 )
 from .idx_token_list_register import IDXTokenListBlockNumber, IDXTokenListRegister
 from .idx_transfer import (
-    DataMessage,
     IDXTransfer,
     IDXTransferBlockNumber,
     IDXTransferSourceEventType,
+    TransferDataMessage,
 )
 from .idx_transfer_approval import IDXTransferApproval, IDXTransferApprovalBlockNumber
 from .idx_tx_data import IDXTxData

--- a/app/model/db/idx_lock_unlock.py
+++ b/app/model/db/idx_lock_unlock.py
@@ -18,8 +18,10 @@ SPDX-License-Identifier: Apache-2.0
 """
 
 from datetime import datetime, timedelta, timezone
+from enum import StrEnum
 from zoneinfo import ZoneInfo
 
+from pydantic import BaseModel
 from sqlalchemy import JSON, BigInteger, Boolean, DateTime, String
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -28,6 +30,26 @@ from app.model.db.base import Base
 
 UTC = timezone(timedelta(hours=0), "UTC")
 local_tz = ZoneInfo(TZ)
+
+
+class LockMessage(StrEnum):
+    garnishment = "garnishment"
+    force_lock = "force_lock"
+    ibet_wst_bridge = "ibet_wst_bridge"
+
+
+class LockDataMessage(BaseModel):
+    message: LockMessage
+
+
+class UnlockMessage(StrEnum):
+    garnishment = "garnishment"
+    force_unlock = "force_unlock"
+    ibet_wst_bridge = "ibet_wst_bridge"
+
+
+class UnlockDataMessage(BaseModel):
+    message: UnlockMessage
 
 
 class IDXLock(Base):
@@ -55,7 +77,7 @@ class IDXLock(Base):
     account_address: Mapped[str] = mapped_column(String(42), index=True, nullable=False)
     # Locked Amount
     value: Mapped[int] = mapped_column(BigInteger, index=True, nullable=False)
-    # Data
+    # Data(LockDataMessage)
     data: Mapped[dict] = mapped_column(JSON, nullable=False)
     # Lock Datetime
     block_timestamp: Mapped[datetime] = mapped_column(
@@ -135,7 +157,7 @@ class IDXUnlock(Base):
     )
     # Locked Amount
     value: Mapped[int] = mapped_column(BigInteger, index=True, nullable=False)
-    # Data
+    # Data(UnlockDataMessage)
     data: Mapped[dict] = mapped_column(JSON, nullable=False)
     # Lock Datetime
     block_timestamp: Mapped[datetime] = mapped_column(

--- a/app/model/db/idx_transfer.py
+++ b/app/model/db/idx_transfer.py
@@ -43,10 +43,9 @@ class IDXTransferSourceEventType(StrEnum):
     REALLOCATION = "Reallocation"
 
 
-class DataMessage(BaseModel):
+class TransferDataMessage(BaseModel):
     message: Literal[
         "garnishment",
-        "inheritance",
         "force_unlock",
         "ibet_wst_bridge",
     ]

--- a/batch/indexer_Position_Bond.py
+++ b/batch/indexer_Position_Bond.py
@@ -43,6 +43,8 @@ from app.model.db import (
     IDXPositionBondBlockNumber,
     IDXUnlock,
     Listing,
+    LockDataMessage,
+    UnlockDataMessage,
 )
 from app.model.schema.base import TokenType
 from app.utils.asyncio_utils import SemaphoreTaskGroup
@@ -1751,6 +1753,7 @@ class Processor:
         """
         try:
             data = json.loads(data_str)
+            LockDataMessage.model_validate(data)
         except Exception:
             data = {}
         lock = IDXLock()
@@ -1797,6 +1800,7 @@ class Processor:
         """
         try:
             data = json.loads(data_str)
+            UnlockDataMessage.model_validate(data)
         except:
             data = {}
         unlock = IDXUnlock()

--- a/batch/indexer_Position_Share.py
+++ b/batch/indexer_Position_Share.py
@@ -43,6 +43,8 @@ from app.model.db import (
     IDXPositionShareBlockNumber,
     IDXUnlock,
     Listing,
+    LockDataMessage,
+    UnlockDataMessage,
 )
 from app.model.schema.base import TokenType
 from app.utils.asyncio_utils import SemaphoreTaskGroup
@@ -1751,6 +1753,7 @@ class Processor:
         """
         try:
             data = json.loads(data_str)
+            LockDataMessage.model_validate(data)
         except Exception:
             data = {}
         lock = IDXLock()
@@ -1797,6 +1800,7 @@ class Processor:
         """
         try:
             data = json.loads(data_str)
+            UnlockDataMessage.model_validate(data)
         except:
             data = {}
         unlock = IDXUnlock()

--- a/batch/indexer_Transfer.py
+++ b/batch/indexer_Transfer.py
@@ -37,11 +37,11 @@ from app.contracts.contract import AsyncContractEventsView
 from app.database import BatchAsyncSessionLocal
 from app.errors import ServiceUnavailable
 from app.model.db import (
-    DataMessage,
     IDXTransfer,
     IDXTransferBlockNumber,
     IDXTransferSourceEventType,
     Listing,
+    TransferDataMessage,
 )
 from app.model.schema.base import TokenType
 from app.utils.web3_utils import AsyncWeb3Wrapper
@@ -183,7 +183,7 @@ class Processor:
         if data_str is not None:
             try:
                 data = json.loads(data_str)
-                validated_data = DataMessage(**data)
+                validated_data = TransferDataMessage(**data)
                 message = validated_data.message
             except ValidationError:
                 data = {}

--- a/migrations/versions/819325835c3d_v25_9_0_feature_1657.py
+++ b/migrations/versions/819325835c3d_v25_9_0_feature_1657.py
@@ -1,0 +1,47 @@
+"""v25_9_0_feature_1657
+
+Revision ID: 819325835c3d
+Revises: 9a28ed8d4afd
+Create Date: 2025-07-23 18:08:21.277260
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import update, cast, String
+
+
+from app.database import get_db_schema
+from app.model.db import IDXTransfer, IDXLock, IDXUnlock
+
+# revision identifiers, used by Alembic.
+revision = "819325835c3d"
+down_revision = "9a28ed8d4afd"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    connection = op.get_bind()
+
+    op.get_bind().execute(
+        update(IDXTransfer)
+        .values(message=None, data={})
+        .where(IDXTransfer.message == "inheritance")
+    )
+    op.get_bind().execute(
+        update(IDXLock)
+        .values(data={})
+        .where(cast(IDXLock.data, String).like(f"%inheritance%"))
+    )
+    op.get_bind().execute(
+        update(IDXUnlock)
+        .values(data={})
+        .where(cast(IDXUnlock.data, String).like(f"%inheritance%"))
+    )
+
+
+def downgrade():
+    connection = op.get_bind()
+
+    pass

--- a/tests/batch/indexer_Position_Bond_test.py
+++ b/tests/batch/indexer_Position_Bond_test.py
@@ -515,10 +515,13 @@ class TestProcessor:
 
         # Lock
         token_contract.functions.lock(
-            self.trader["account_address"], 1500, '{"message": "locked1"}'
+            self.trader["account_address"], 1500, '{"message": "garnishment"}'
         ).transact({"from": self.issuer["account_address"]})
         token_contract.functions.lock(
-            self.trader["account_address"], 1500, '{"message": "locked2"}'
+            self.trader["account_address"], 1500, '{"message": "ibet_wst_bridge"}'
+        ).transact({"from": self.issuer["account_address"]})
+        token_contract.functions.lock(
+            self.trader["account_address"], 1500, '{"message": "inheritance"}'
         ).transact({"from": self.issuer["account_address"]})
 
         # Run target process
@@ -541,7 +544,7 @@ class TestProcessor:
         _position = _position_list[0]
         assert _position.token_address == token["address"]
         assert _position.account_address == self.issuer["account_address"]
-        assert _position.balance == 1000000 - 3000
+        assert _position.balance == 1000000 - 4500
         assert _position.pending_transfer == 0
         assert _position.exchange_balance == 0
         assert _position.exchange_commitment == 0
@@ -554,12 +557,12 @@ class TestProcessor:
         assert _locked1.token_address == token["address"]
         assert _locked1.lock_address == self.trader["account_address"]
         assert _locked1.account_address == self.issuer["account_address"]
-        assert _locked1.value == 3000
+        assert _locked1.value == 4500
 
         _lock_list: Sequence[IDXLock] = session.scalars(
             select(IDXLock).order_by(IDXLock.id)
         ).all()
-        assert len(_lock_list) == 2
+        assert len(_lock_list) == 3
         _lock1 = _lock_list[0]
         assert _lock1.id == 1
         assert _lock1.token_address == token["address"]
@@ -567,7 +570,7 @@ class TestProcessor:
         assert _lock1.lock_address == self.trader["account_address"]
         assert _lock1.account_address == self.issuer["account_address"]
         assert _lock1.value == 1500
-        assert _lock1.data == {"message": "locked1"}
+        assert _lock1.data == {"message": "garnishment"}
         assert _lock1.is_forced is False
         _lock2 = _lock_list[1]
         assert _lock2.id == 2
@@ -576,8 +579,17 @@ class TestProcessor:
         assert _lock2.lock_address == self.trader["account_address"]
         assert _lock2.account_address == self.issuer["account_address"]
         assert _lock2.value == 1500
-        assert _lock2.data == {"message": "locked2"}
+        assert _lock2.data == {"message": "ibet_wst_bridge"}
         assert _lock2.is_forced is False
+        _lock3 = _lock_list[2]
+        assert _lock3.id == 3
+        assert _lock3.token_address == token["address"]
+        assert _lock3.msg_sender == self.issuer["account_address"]
+        assert _lock3.lock_address == self.trader["account_address"]
+        assert _lock3.account_address == self.issuer["account_address"]
+        assert _lock3.value == 1500
+        assert _lock3.data == {}
+        assert _lock3.is_forced is False
 
     # <Normal_4_2>
     # Single Token
@@ -611,13 +623,13 @@ class TestProcessor:
             self.issuer["account_address"],
             self.trader["account_address"],
             1500,
-            '{"message": "force_locked1"}',
+            '{"message": "force_lock"}',
         ).transact({"from": self.issuer["account_address"]})
         token_contract.functions.forceLock(
             self.issuer["account_address"],
             self.trader["account_address"],
             1500,
-            '{"message": "force_locked2"}',
+            '{"message": "force_lock"}',
         ).transact({"from": self.issuer["account_address"]})
 
         # Run target process
@@ -666,7 +678,7 @@ class TestProcessor:
         assert _lock1.lock_address == self.issuer["account_address"]
         assert _lock1.account_address == self.trader["account_address"]
         assert _lock1.value == 1500
-        assert _lock1.data == {"message": "force_locked1"}
+        assert _lock1.data == {"message": "force_lock"}
         assert _lock1.is_forced is True
         _lock2 = _lock_list[1]
         assert _lock2.id == 2
@@ -675,7 +687,7 @@ class TestProcessor:
         assert _lock2.lock_address == self.issuer["account_address"]
         assert _lock2.account_address == self.trader["account_address"]
         assert _lock2.value == 1500
-        assert _lock2.data == {"message": "force_locked2"}
+        assert _lock2.data == {"message": "force_lock"}
         assert _lock2.is_forced is True
 
     # <Normal_5_1>
@@ -698,7 +710,7 @@ class TestProcessor:
 
         # Lock
         token_contract.functions.lock(
-            self.trader["account_address"], 3000, '{"message": "locked1"}'
+            self.trader["account_address"], 3000, '{"message": "garnishment"}'
         ).transact({"from": self.issuer["account_address"]})
 
         # Unlock
@@ -706,7 +718,7 @@ class TestProcessor:
             self.issuer["account_address"],
             self.trader2["account_address"],
             100,
-            '{"message": "unlocked1"}',
+            '{"message": "garnishment"}',
         ).transact({"from": self.trader["account_address"]})
 
         # Run target process
@@ -781,7 +793,7 @@ class TestProcessor:
         assert _lock1.lock_address == self.trader["account_address"]
         assert _lock1.account_address == self.issuer["account_address"]
         assert _lock1.value == 3000
-        assert _lock1.data == {"message": "locked1"}
+        assert _lock1.data == {"message": "garnishment"}
 
         _unlock_list: Sequence[IDXUnlock] = session.scalars(
             select(IDXUnlock).order_by(IDXUnlock.id)
@@ -795,7 +807,7 @@ class TestProcessor:
         assert _unlock1.account_address == self.issuer["account_address"]
         assert _unlock1.recipient_address == self.trader2["account_address"]
         assert _unlock1.value == 100
-        assert _unlock1.data == {"message": "unlocked1"}
+        assert _unlock1.data == {"message": "garnishment"}
         assert _unlock1.is_forced is False
 
     # <Normal_5_2>
@@ -818,7 +830,7 @@ class TestProcessor:
 
         # Lock
         token_contract.functions.lock(
-            self.trader["account_address"], 3000, '{"message": "locked1"}'
+            self.trader["account_address"], 3000, '{"message": "garnishment"}'
         ).transact({"from": self.issuer["account_address"]})
 
         # ForceUnlock
@@ -827,7 +839,7 @@ class TestProcessor:
             self.issuer["account_address"],
             self.trader2["account_address"],
             100,
-            '{"message": "unlocked1"}',
+            '{"message": "garnishment"}',
         ).transact({"from": self.issuer["account_address"]})
 
         # Run target process
@@ -902,7 +914,7 @@ class TestProcessor:
         assert _lock1.lock_address == self.trader["account_address"]
         assert _lock1.account_address == self.issuer["account_address"]
         assert _lock1.value == 3000
-        assert _lock1.data == {"message": "locked1"}
+        assert _lock1.data == {"message": "garnishment"}
 
         _unlock_list: Sequence[IDXUnlock] = session.scalars(
             select(IDXUnlock).order_by(IDXUnlock.id)
@@ -916,7 +928,7 @@ class TestProcessor:
         assert _unlock1.account_address == self.issuer["account_address"]
         assert _unlock1.recipient_address == self.trader2["account_address"]
         assert _unlock1.value == 100
-        assert _unlock1.data == {"message": "unlocked1"}
+        assert _unlock1.data == {"message": "garnishment"}
         assert _unlock1.is_forced is True
 
     # <Normal_5_3>
@@ -954,7 +966,7 @@ class TestProcessor:
         token_contract.functions.lock(
             self.issuer["account_address"],  # lock address
             3000,
-            '{"message": "locked1"}',
+            '{"message": "garnishment"}',
         ).transact({"from": self.trader["account_address"]})
 
         # ForceChangeLockedAccount
@@ -963,7 +975,7 @@ class TestProcessor:
             self.trader["account_address"],  # before account address
             self.trader2["account_address"],  # after account address
             100,
-            '{"message": "force_changed"}',
+            '{"message": "ibet_wst_bridge"}',
         ).transact({"from": self.issuer["account_address"]})
 
         # Run target process
@@ -1026,7 +1038,7 @@ class TestProcessor:
         assert _lock1.lock_address == self.issuer["account_address"]
         assert _lock1.account_address == self.trader["account_address"]
         assert _lock1.value == 3000
-        assert _lock1.data == {"message": "locked1"}
+        assert _lock1.data == {"message": "garnishment"}
         _lock2 = _lock_list[1]
         assert _lock2.id == 2
         assert _lock2.token_address == token["address"]
@@ -1034,7 +1046,7 @@ class TestProcessor:
         assert _lock2.lock_address == self.issuer["account_address"]
         assert _lock2.account_address == self.trader2["account_address"]
         assert _lock2.value == 100
-        assert _lock2.data == {"message": "force_changed"}
+        assert _lock2.data == {"message": "ibet_wst_bridge"}
 
         _unlock_list: Sequence[IDXUnlock] = session.scalars(
             select(IDXUnlock).order_by(IDXUnlock.id)
@@ -1048,7 +1060,7 @@ class TestProcessor:
         assert _unlock1.account_address == self.trader["account_address"]
         assert _unlock1.recipient_address == self.trader2["account_address"]
         assert _unlock1.value == 100
-        assert _unlock1.data == {"message": "force_changed"}
+        assert _unlock1.data == {"message": "ibet_wst_bridge"}
         assert _unlock1.is_forced is True
 
     # <Normal_6>

--- a/tests/batch/indexer_Position_Share_test.py
+++ b/tests/batch/indexer_Position_Share_test.py
@@ -497,10 +497,13 @@ class TestProcessor:
 
         # Lock
         token_contract.functions.lock(
-            self.trader["account_address"], 1500, '{"message": "locked1"}'
+            self.trader["account_address"], 1500, '{"message": "garnishment"}'
         ).transact({"from": self.issuer["account_address"]})
         token_contract.functions.lock(
-            self.trader["account_address"], 1500, '{"message": "locked2"}'
+            self.trader["account_address"], 1500, '{"message": "ibet_wst_bridge"}'
+        ).transact({"from": self.issuer["account_address"]})
+        token_contract.functions.lock(
+            self.trader["account_address"], 1500, '{"message": "inheritance"}'
         ).transact({"from": self.issuer["account_address"]})
 
         # Run target process
@@ -523,7 +526,7 @@ class TestProcessor:
         _position = _position_list[0]
         assert _position.token_address == token["address"]
         assert _position.account_address == self.issuer["account_address"]
-        assert _position.balance == 1000000 - 3000
+        assert _position.balance == 1000000 - 4500
         assert _position.pending_transfer == 0
         assert _position.exchange_balance == 0
         assert _position.exchange_commitment == 0
@@ -537,10 +540,10 @@ class TestProcessor:
         assert _locked1.token_address == token["address"]
         assert _locked1.lock_address == self.trader["account_address"]
         assert _locked1.account_address == self.issuer["account_address"]
-        assert _locked1.value == 3000
+        assert _locked1.value == 4500
 
         _lock_list = session.scalars(select(IDXLock).order_by(IDXLock.id)).all()
-        assert len(_lock_list) == 2
+        assert len(_lock_list) == 3
 
         _lock1 = _lock_list[0]
         assert _lock1.id == 1
@@ -548,7 +551,7 @@ class TestProcessor:
         assert _lock1.lock_address == self.trader["account_address"]
         assert _lock1.account_address == self.issuer["account_address"]
         assert _lock1.value == 1500
-        assert _lock1.data == {"message": "locked1"}
+        assert _lock1.data == {"message": "garnishment"}
         assert _lock1.is_forced is False
         _lock2 = _lock_list[1]
         assert _lock2.id == 2
@@ -556,8 +559,16 @@ class TestProcessor:
         assert _lock2.lock_address == self.trader["account_address"]
         assert _lock2.account_address == self.issuer["account_address"]
         assert _lock2.value == 1500
-        assert _lock2.data == {"message": "locked2"}
+        assert _lock2.data == {"message": "ibet_wst_bridge"}
         assert _lock2.is_forced is False
+        _lock3 = _lock_list[2]
+        assert _lock3.id == 3
+        assert _lock3.token_address == token["address"]
+        assert _lock3.lock_address == self.trader["account_address"]
+        assert _lock3.account_address == self.issuer["account_address"]
+        assert _lock3.value == 1500
+        assert _lock3.data == {}
+        assert _lock3.is_forced is False
 
     # <Normal_4_2>
     # Single Token
@@ -591,13 +602,13 @@ class TestProcessor:
             self.issuer["account_address"],
             self.trader["account_address"],
             1500,
-            '{"message": "force_locked1"}',
+            '{"message": "force_lock"}',
         ).transact({"from": self.issuer["account_address"]})
         token_contract.functions.forceLock(
             self.issuer["account_address"],
             self.trader["account_address"],
             1500,
-            '{"message": "force_locked2"}',
+            '{"message": "force_lock"}',
         ).transact({"from": self.issuer["account_address"]})
 
         # Run target process
@@ -646,7 +657,7 @@ class TestProcessor:
         assert _lock1.lock_address == self.issuer["account_address"]
         assert _lock1.account_address == self.trader["account_address"]
         assert _lock1.value == 1500
-        assert _lock1.data == {"message": "force_locked1"}
+        assert _lock1.data == {"message": "force_lock"}
         assert _lock1.is_forced is True
         _lock2 = _lock_list[1]
         assert _lock2.id == 2
@@ -655,7 +666,7 @@ class TestProcessor:
         assert _lock2.lock_address == self.issuer["account_address"]
         assert _lock2.account_address == self.trader["account_address"]
         assert _lock2.value == 1500
-        assert _lock2.data == {"message": "force_locked2"}
+        assert _lock2.data == {"message": "force_lock"}
         assert _lock2.is_forced is True
 
     # <Normal_5_1>
@@ -678,7 +689,7 @@ class TestProcessor:
 
         # Lock
         token_contract.functions.lock(
-            self.trader["account_address"], 3000, '{"message": "locked1"}'
+            self.trader["account_address"], 3000, '{"message": "garnishment"}'
         ).transact({"from": self.issuer["account_address"]})
 
         # Unlock
@@ -686,7 +697,7 @@ class TestProcessor:
             self.issuer["account_address"],
             self.trader2["account_address"],
             100,
-            '{"message": "unlocked1"}',
+            '{"message": "garnishment"}',
         ).transact({"from": self.trader["account_address"]})
 
         # Run target process
@@ -759,7 +770,7 @@ class TestProcessor:
         assert _lock1.lock_address == self.trader["account_address"]
         assert _lock1.account_address == self.issuer["account_address"]
         assert _lock1.value == 3000
-        assert _lock1.data == {"message": "locked1"}
+        assert _lock1.data == {"message": "garnishment"}
 
         _unlock_list = session.scalars(select(IDXUnlock).order_by(IDXUnlock.id)).all()
         assert len(_unlock_list) == 1
@@ -771,7 +782,7 @@ class TestProcessor:
         assert _unlock1.account_address == self.issuer["account_address"]
         assert _unlock1.recipient_address == self.trader2["account_address"]
         assert _unlock1.value == 100
-        assert _unlock1.data == {"message": "unlocked1"}
+        assert _unlock1.data == {"message": "garnishment"}
         assert _unlock1.is_forced is False
 
     # <Normal_5_2>
@@ -794,7 +805,7 @@ class TestProcessor:
 
         # Lock
         token_contract.functions.lock(
-            self.trader["account_address"], 3000, '{"message": "locked1"}'
+            self.trader["account_address"], 3000, '{"message": "garnishment"}'
         ).transact({"from": self.issuer["account_address"]})
 
         # Unlock
@@ -803,7 +814,7 @@ class TestProcessor:
             self.issuer["account_address"],
             self.trader2["account_address"],
             100,
-            '{"message": "unlocked1"}',
+            '{"message": "garnishment"}',
         ).transact({"from": self.issuer["account_address"]})
 
         # Run target process
@@ -876,7 +887,7 @@ class TestProcessor:
         assert _lock1.lock_address == self.trader["account_address"]
         assert _lock1.account_address == self.issuer["account_address"]
         assert _lock1.value == 3000
-        assert _lock1.data == {"message": "locked1"}
+        assert _lock1.data == {"message": "garnishment"}
 
         _unlock_list = session.scalars(select(IDXUnlock).order_by(IDXUnlock.id)).all()
         assert len(_unlock_list) == 1
@@ -888,7 +899,7 @@ class TestProcessor:
         assert _unlock1.account_address == self.issuer["account_address"]
         assert _unlock1.recipient_address == self.trader2["account_address"]
         assert _unlock1.value == 100
-        assert _unlock1.data == {"message": "unlocked1"}
+        assert _unlock1.data == {"message": "garnishment"}
         assert _unlock1.is_forced is True
 
     # <Normal_5_3>
@@ -925,7 +936,7 @@ class TestProcessor:
         token_contract.functions.lock(
             self.issuer["account_address"],  # lock address
             3000,
-            '{"message": "locked1"}',
+            '{"message": "garnishment"}',
         ).transact({"from": self.trader["account_address"]})
 
         # ForceChangeLockedAccount
@@ -934,7 +945,7 @@ class TestProcessor:
             self.trader["account_address"],  # before account address
             self.trader2["account_address"],  # after account address
             100,
-            '{"message": "force_changed"}',
+            '{"message": "ibet_wst_bridge"}',
         ).transact({"from": self.issuer["account_address"]})
 
         # Run target process
@@ -995,7 +1006,7 @@ class TestProcessor:
         assert _lock1.lock_address == self.issuer["account_address"]
         assert _lock1.account_address == self.trader["account_address"]
         assert _lock1.value == 3000
-        assert _lock1.data == {"message": "locked1"}
+        assert _lock1.data == {"message": "garnishment"}
         _lock2 = _lock_list[1]
         assert _lock2.id == 2
         assert _lock2.token_address == token["address"]
@@ -1003,7 +1014,7 @@ class TestProcessor:
         assert _lock2.lock_address == self.issuer["account_address"]
         assert _lock2.account_address == self.trader2["account_address"]
         assert _lock2.value == 100
-        assert _lock2.data == {"message": "force_changed"}
+        assert _lock2.data == {"message": "ibet_wst_bridge"}
 
         _unlock_list = session.scalars(select(IDXUnlock).order_by(IDXUnlock.id)).all()
         assert len(_unlock_list) == 1
@@ -1015,7 +1026,7 @@ class TestProcessor:
         assert _unlock1.account_address == self.trader["account_address"]
         assert _unlock1.recipient_address == self.trader2["account_address"]
         assert _unlock1.value == 100
-        assert _unlock1.data == {"message": "force_changed"}
+        assert _unlock1.data == {"message": "ibet_wst_bridge"}
         assert _unlock1.is_forced is True
 
     # <Normal_6>

--- a/tests/batch/indexer_Transfer_test.py
+++ b/tests/batch/indexer_Transfer_test.py
@@ -668,8 +668,8 @@ class TestProcessor:
         assert idx_transfer.to_address == self.trader2["account_address"]
         assert idx_transfer.value == 30000
         assert idx_transfer.source_event == IDXTransferSourceEventType.UNLOCK
-        assert idx_transfer.data == {"message": "inheritance"}
-        assert idx_transfer.message == "inheritance"
+        assert idx_transfer.data == {}
+        assert idx_transfer.message is None
         assert idx_transfer.created is not None
         assert idx_transfer.modified is not None
 
@@ -682,8 +682,8 @@ class TestProcessor:
         assert idx_transfer.to_address == self.trader2["account_address"]
         assert idx_transfer.value == 30000
         assert idx_transfer.source_event == IDXTransferSourceEventType.UNLOCK
-        assert idx_transfer.data == {"message": "inheritance"}
-        assert idx_transfer.message == "inheritance"
+        assert idx_transfer.data == {}
+        assert idx_transfer.message is None
         assert idx_transfer.created is not None
         assert idx_transfer.modified is not None
 

--- a/tests/migrations/upgrade_test.py
+++ b/tests/migrations/upgrade_test.py
@@ -18,6 +18,7 @@ SPDX-License-Identifier: Apache-2.0
 """
 
 import importlib
+import json
 import logging
 from datetime import datetime
 from typing import Final
@@ -994,13 +995,22 @@ class TestMigrationsUpgrade:
                 text("SELECT * FROM transfer ORDER BY created ASC")
             )
             transfers = list(transfers)
-            assert transfers[0].data == {}
+            if engine.name == "mysql":
+                assert json.loads(transfers[0].data) == {}
+            else:
+                assert transfers[0].data == {}
             assert transfers[0].message is None
 
-            locks = conn.execute(text("SELECT * FROM lock ORDER BY created ASC"))
+            locks = conn.execute(text("SELECT * FROM `lock` ORDER BY created ASC"))
             locks = list(locks)
-            assert locks[0].data == {}
+            if engine.name == "mysql":
+                assert json.loads(locks[0].data) == {}
+            else:
+                assert locks[0].data == {}
 
-            unlocks = conn.execute(text("SELECT * FROM unlock ORDER BY created ASC"))
+            unlocks = conn.execute(text("SELECT * FROM `unlock` ORDER BY created ASC"))
             unlocks = list(unlocks)
-            assert unlocks[0].data == {}
+            if engine.name == "mysql":
+                assert json.loads(unlocks[0].data) == {}
+            else:
+                assert unlocks[0].data == {}

--- a/tests/migrations/upgrade_test.py
+++ b/tests/migrations/upgrade_test.py
@@ -1001,16 +1001,24 @@ class TestMigrationsUpgrade:
                 assert transfers[0].data == {}
             assert transfers[0].message is None
 
-            locks = conn.execute(text("SELECT * FROM `lock` ORDER BY created ASC"))
-            locks = list(locks)
             if engine.name == "mysql":
+                locks = conn.execute(text("SELECT * FROM `lock` ORDER BY created ASC"))
+                locks = list(locks)
                 assert json.loads(locks[0].data) == {}
             else:
+                locks = conn.execute(text("SELECT * FROM lock ORDER BY created ASC"))
+                locks = list(locks)
                 assert locks[0].data == {}
 
-            unlocks = conn.execute(text("SELECT * FROM `unlock` ORDER BY created ASC"))
-            unlocks = list(unlocks)
             if engine.name == "mysql":
+                unlocks = conn.execute(
+                    text("SELECT * FROM `unlock` ORDER BY created ASC")
+                )
+                unlocks = list(unlocks)
                 assert json.loads(unlocks[0].data) == {}
             else:
+                unlocks = conn.execute(
+                    text("SELECT * FROM unlock ORDER BY created ASC")
+                )
+                unlocks = list(unlocks)
                 assert unlocks[0].data == {}


### PR DESCRIPTION
## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->

This pull request introduces new data models for lock and unlock messages, refactors existing code to use these models, and updates database migration and test cases accordingly. The changes aim to improve data validation and consistency across the system.

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
- Close #1657 

## 🔄 Changes

<!-- List the major changes in this PR. -->

### Lock/Unlock Message Standardization
- Added `LockDataMessage` and `UnlockDataMessage` classes in `app/model/db/idx_lock_unlock.py` to define structured data models for lock and unlock messages using `pydantic` and `StrEnum`. [[1]](diffhunk://#diff-c893684e2e10ad7d92558365e56075adf8329acebb9bcaec1b7bdc6a1a7f775dR35-R54) [[2]](diffhunk://#diff-c893684e2e10ad7d92558365e56075adf8329acebb9bcaec1b7bdc6a1a7f775dL58-R80) [[3]](diffhunk://#diff-c893684e2e10ad7d92558365e56075adf8329acebb9bcaec1b7bdc6a1a7f775dL138-R160)
- Updated `IDXLock` and `IDXUnlock` models to explicitly document that the `data` field uses `LockDataMessage` and `UnlockDataMessage`. [[1]](diffhunk://#diff-c893684e2e10ad7d92558365e56075adf8329acebb9bcaec1b7bdc6a1a7f775dL58-R80) [[2]](diffhunk://#diff-c893684e2e10ad7d92558365e56075adf8329acebb9bcaec1b7bdc6a1a7f775dL138-R160)

### Data Validation
- Incorporated validation of lock and unlock data using `model_validate` in batch processing scripts (`indexer_Position_Bond.py` and `indexer_Position_Share.py`). [[1]](diffhunk://#diff-e6aee665fd2105ec8714613c9b50a178d710490eb24c89975f79782d6c70d9a8R1756) [[2]](diffhunk://#diff-e6aee665fd2105ec8714613c9b50a178d710490eb24c89975f79782d6c70d9a8R1803) [[3]](diffhunk://#diff-7c8731c28bc19df2012ab5b9793f86eada370544630547f35c1d6e28938c5b34R1756) [[4]](diffhunk://#diff-7c8731c28bc19df2012ab5b9793f86eada370544630547f35c1d6e28938c5b34R1803)

### Migration Script
- Added a migration script (`migrations/versions/819325835c3d_v25_9_0_feature_1657.py`) to clean up legacy data by removing references to the deprecated "inheritance" message type from `IDXTransfer`, `IDXLock`, and `IDXUnlock`.

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
