### PR TITLE
Add watchers for ChangeToRedeemed and ChangeToCanceled events with notification processing

### DIFF
--- a/app/model/db/notification.py
+++ b/app/model/db/notification.py
@@ -203,6 +203,8 @@ class NotificationType(StrEnum):
     CANCEL_TRANSFER = "CancelTransfer"
     FORCE_LOCK = "ForceLock"
     FORCE_UNLOCK = "ForceUnlock"
+    CHANGE_TO_REDEEMED = "ChangeToRedeemed"
+    CHANGE_TO_CANCELED = "ChangeToCanceled"
 
 
 class NotificationBlockNumber(Base):

--- a/tests/app/notification_Notifications_GET_test.py
+++ b/tests/app/notification_Notifications_GET_test.py
@@ -544,10 +544,10 @@ class TestNotificationsGet:
                 {
                     "type": "enum",
                     "loc": ["query", "notification_type"],
-                    "msg": "Input should be 'NewOrder', 'NewOrderCounterpart', 'CancelOrder', 'CancelOrderCounterpart', 'ForceCancelOrder', 'BuyAgreement', 'BuySettlementOK', 'BuySettlementNG', 'SellAgreement', 'SellSettlementOK', 'SellSettlementNG', 'Transfer', 'ApplyForTransfer', 'ApproveTransfer', 'CancelTransfer', 'ForceLock' or 'ForceUnlock'",
+                    "msg": "Input should be 'NewOrder', 'NewOrderCounterpart', 'CancelOrder', 'CancelOrderCounterpart', 'ForceCancelOrder', 'BuyAgreement', 'BuySettlementOK', 'BuySettlementNG', 'SellAgreement', 'SellSettlementOK', 'SellSettlementNG', 'Transfer', 'ApplyForTransfer', 'ApproveTransfer', 'CancelTransfer', 'ForceLock', 'ForceUnlock', 'ChangeToRedeemed' or 'ChangeToCanceled'",
                     "input": "hoge",
                     "ctx": {
-                        "expected": "'NewOrder', 'NewOrderCounterpart', 'CancelOrder', 'CancelOrderCounterpart', 'ForceCancelOrder', 'BuyAgreement', 'BuySettlementOK', 'BuySettlementNG', 'SellAgreement', 'SellSettlementOK', 'SellSettlementNG', 'Transfer', 'ApplyForTransfer', 'ApproveTransfer', 'CancelTransfer', 'ForceLock' or 'ForceUnlock'"
+                        "expected": "'NewOrder', 'NewOrderCounterpart', 'CancelOrder', 'CancelOrderCounterpart', 'ForceCancelOrder', 'BuyAgreement', 'BuySettlementOK', 'BuySettlementNG', 'SellAgreement', 'SellSettlementOK', 'SellSettlementNG', 'Transfer', 'ApplyForTransfer', 'ApproveTransfer', 'CancelTransfer', 'ForceLock', 'ForceUnlock', 'ChangeToRedeemed' or 'ChangeToCanceled'"
                     },
                 },
                 {

--- a/tests/batch/processor_Notifications_Token_test.py
+++ b/tests/batch/processor_Notifications_Token_test.py
@@ -42,16 +42,20 @@ from app.model.db import (
 from tests.account_config import eth_account
 from tests.conftest import DeployedContract, SharedContract, UnitTestAccount
 from tests.contract_modules import (
+    bond_change_to_redeemed,
     coupon_register_list,
     coupon_transfer_to_exchange,
     coupon_withdraw_from_exchange,
+    issue_bond_token,
     issue_coupon_token,
     issue_share_token,
+    register_bond_list,
     register_personalinfo,
     register_share_list,
     share_apply_for_transfer,
     share_approve_transfer,
     share_cancel_transfer,
+    share_change_to_canceled,
     share_force_lock,
     share_force_unlock,
     share_set_transfer_approval_required,
@@ -108,6 +112,64 @@ async def prepare_coupon_token(
     }
     token = issue_coupon_token(issuer, args)
     coupon_register_list(issuer, token, token_list)
+
+    _listing = Listing()
+    _listing.token_address = token["address"]
+    _listing.is_public = True
+    _listing.max_holding_quantity = 1000000
+    _listing.max_sell_amount = 1000000
+    _listing.owner_address = issuer["account_address"]
+    async_session.add(_listing)
+    await async_session.commit()
+
+    return token
+
+
+async def prepare_bond_token(
+    issuer: UnitTestAccount,
+    exchange: DeployedContract,
+    token_list: DeployedContract,
+    personal_info: DeployedContract,
+    async_session: AsyncSession,
+):
+    # Issue token
+    args = {
+        "name": "テスト債券",
+        "symbol": "BOND",
+        "totalSupply": 1000000,
+        "tradableExchange": exchange["address"],
+        "faceValue": 10000,
+        "interestRate": 602,
+        "interestPaymentDate1": "0101",
+        "interestPaymentDate2": "0201",
+        "interestPaymentDate3": "0301",
+        "interestPaymentDate4": "0401",
+        "interestPaymentDate5": "0501",
+        "interestPaymentDate6": "0601",
+        "interestPaymentDate7": "0701",
+        "interestPaymentDate8": "0801",
+        "interestPaymentDate9": "0901",
+        "interestPaymentDate10": "1001",
+        "interestPaymentDate11": "1101",
+        "interestPaymentDate12": "1201",
+        "redemptionDate": "20191231",
+        "redemptionValue": 10000,
+        "returnDate": "20191231",
+        "returnAmount": "商品券をプレゼント",
+        "purpose": "新商品の開発資金として利用。",
+        "memo": "メモ",
+        "contactInformation": "問い合わせ先",
+        "privacyPolicy": "プライバシーポリシー",
+        "personalInfoAddress": personal_info["address"],
+        "transferable": True,
+        "isRedeemed": False,
+        "faceValueCurrency": "JPY",
+        "interestPaymentCurrency": "JPY",
+        "redemptionValueCurrency": "JPY",
+        "baseFxRate": "",
+    }
+    token = issue_bond_token(issuer, args)
+    register_bond_list(issuer, token, token_list)
 
     _listing = Listing()
     _listing.token_address = token["address"]
@@ -2206,6 +2268,796 @@ class TestWatchForceUnlock:
         self, watcher_factory, async_session, shared_contract, mocked_company_list
     ):
         watcher = watcher_factory("WatchForceUnlock")
+        exchange_contract = shared_contract["IbetShareExchange"]
+        token_list_contract = shared_contract["TokenList"]
+        personal_info_contract = shared_contract["PersonalInfo"]
+
+        # Issue token
+        token = await prepare_share_token(
+            self.issuer,
+            exchange_contract,
+            token_list_contract,
+            personal_info_contract,
+            async_session,
+        )
+
+        idx_token_list_item = IDXTokenListRegister()
+        idx_token_list_item.token_address = token["address"]
+        idx_token_list_item.owner_address = self.issuer["account_address"]
+        idx_token_list_item.token_template = "IbetShare"
+        async_session.add(idx_token_list_item)
+        await async_session.commit()
+
+        # Run target process
+        await watcher.loop()
+
+        # Assertion
+        _notification = (
+            await async_session.scalars(
+                select(Notification).order_by(Notification.created).limit(1)
+            )
+        ).first()
+        assert _notification is None
+
+        _notification_block_number = (
+            await async_session.scalars(select(NotificationBlockNumber).limit(1))
+        ).first()
+        assert _notification_block_number is None
+
+
+@pytest.mark.asyncio
+class TestWatchChangeToRedeemed:
+    issuer = eth_account["issuer"]
+    lock_account = eth_account["user1"]
+
+    ###########################################################################
+    # Normal Case
+    ###########################################################################
+
+    # <Normal_1>
+    # Initial Sync
+    async def test_normal_1(
+        self, watcher_factory, async_session, shared_contract, mocked_company_list
+    ):
+        watcher = watcher_factory("WatchChangeToRedeemed")
+        exchange_contract = shared_contract["IbetStraightBondExchange"]
+        token_list_contract = shared_contract["TokenList"]
+        personal_info_contract = shared_contract["PersonalInfo"]
+
+        # Issue token
+        token = await prepare_bond_token(
+            self.issuer,
+            exchange_contract,
+            token_list_contract,
+            personal_info_contract,
+            async_session,
+        )
+
+        idx_token_list_item = IDXTokenListRegister()
+        idx_token_list_item.token_address = token["address"]
+        idx_token_list_item.owner_address = self.issuer["account_address"]
+        idx_token_list_item.token_template = "IbetStraightBond"
+        async_session.add(idx_token_list_item)
+        await async_session.commit()
+
+        # Run target process
+        await watcher.loop()
+
+        # Assertion
+        block_number = web3.eth.block_number
+
+        _notification = (
+            await async_session.scalars(
+                select(Notification)
+                .where(
+                    Notification.notification_id
+                    == "0x{:012x}{:06x}{:06x}{:02x}".format(block_number, 0, 0, 0)
+                )
+                .limit(1)
+            )
+        ).first()
+        assert _notification is None
+
+        _notification_block_number: NotificationBlockNumber = (
+            await async_session.scalars(
+                select(NotificationBlockNumber)
+                .where(
+                    and_(
+                        NotificationBlockNumber.notification_type
+                        == NotificationType.CHANGE_TO_REDEEMED,
+                        NotificationBlockNumber.contract_address == token["address"],
+                    )
+                )
+                .limit(1)
+            )
+        ).first()
+        assert _notification_block_number.latest_block_number == block_number
+
+    # <Normal_2>
+    # Single event logs
+    async def test_normal_2(
+        self, watcher_factory, async_session, shared_contract, mocked_company_list
+    ):
+        watcher = watcher_factory("WatchChangeToRedeemed")
+        exchange_contract = shared_contract["IbetStraightBondExchange"]
+        token_list_contract = shared_contract["TokenList"]
+        personal_info_contract = shared_contract["PersonalInfo"]
+
+        # Issue token
+        token = await prepare_bond_token(
+            self.issuer,
+            exchange_contract,
+            token_list_contract,
+            personal_info_contract,
+            async_session,
+        )
+
+        idx_token_list_item = IDXTokenListRegister()
+        idx_token_list_item.token_address = token["address"]
+        idx_token_list_item.owner_address = self.issuer["account_address"]
+        idx_token_list_item.token_template = "IbetStraightBond"
+        async_session.add(idx_token_list_item)
+
+        notification_block_number = NotificationBlockNumber()
+        notification_block_number.notification_type = (
+            NotificationType.CHANGE_TO_REDEEMED
+        )
+        notification_block_number.contract_address = token["address"]
+        notification_block_number.latest_block_number = web3.eth.block_number
+        async_session.add(notification_block_number)
+        await async_session.commit()
+
+        # Emit ChangeToRedeemed event
+        bond_change_to_redeemed(
+            invoker=self.issuer,
+            token=token,
+        )
+
+        # Run target process
+        await watcher.loop()
+
+        # Assertion
+        block_number = web3.eth.block_number
+
+        async_session.expunge_all()
+
+        _notification_list = (await async_session.scalars(select(Notification))).all()
+        assert len(_notification_list) == 1
+        assert (
+            _notification_list[0].notification_type
+            == NotificationType.CHANGE_TO_REDEEMED
+        )
+        assert _notification_list[0].priority == 0
+        assert _notification_list[0].address is None
+        assert _notification_list[0].args == {}
+        assert _notification_list[0].metainfo == {
+            "company_name": "株式会社DEMO",
+            "exchange_address": "",
+            "token_address": token["address"],
+            "token_name": "テスト債券",
+            "token_type": "IbetStraightBond",
+        }
+
+        _notification_block_number: NotificationBlockNumber = (
+            await async_session.scalars(
+                select(NotificationBlockNumber)
+                .where(
+                    and_(
+                        NotificationBlockNumber.notification_type
+                        == NotificationType.CHANGE_TO_REDEEMED,
+                        NotificationBlockNumber.contract_address == token["address"],
+                    )
+                )
+                .limit(1)
+            )
+        ).first()
+        assert _notification_block_number.latest_block_number == block_number
+
+    # <Normal_3>
+    # Multi event logs
+    async def test_normal_3(
+        self, watcher_factory, async_session, shared_contract, mocked_company_list
+    ):
+        watcher = watcher_factory("WatchChangeToRedeemed")
+        exchange_contract = shared_contract["IbetStraightBondExchange"]
+        token_list_contract = shared_contract["TokenList"]
+        personal_info_contract = shared_contract["PersonalInfo"]
+
+        # Issue token
+        token = await prepare_bond_token(
+            self.issuer,
+            exchange_contract,
+            token_list_contract,
+            personal_info_contract,
+            async_session,
+        )
+
+        idx_token_list_item = IDXTokenListRegister()
+        idx_token_list_item.token_address = token["address"]
+        idx_token_list_item.owner_address = self.issuer["account_address"]
+        idx_token_list_item.token_template = "IbetStraightBond"
+        async_session.add(idx_token_list_item)
+
+        notification_block_number = NotificationBlockNumber()
+        notification_block_number.notification_type = (
+            NotificationType.CHANGE_TO_REDEEMED
+        )
+        notification_block_number.contract_address = token["address"]
+        notification_block_number.latest_block_number = web3.eth.block_number
+        async_session.add(notification_block_number)
+        await async_session.commit()
+
+        # Emit ChangeToRedeemed event
+        bond_change_to_redeemed(
+            invoker=self.issuer,
+            token=token,
+        )
+        bond_change_to_redeemed(
+            invoker=self.issuer,
+            token=token,
+        )
+
+        # Run target process
+        await watcher.loop()
+
+        # Assertion
+        block_number = web3.eth.block_number
+
+        async_session.expunge_all()
+
+        _notification_list = (await async_session.scalars(select(Notification))).all()
+        assert len(_notification_list) == 2
+        assert (
+            _notification_list[0].notification_type
+            == NotificationType.CHANGE_TO_REDEEMED
+        )
+        assert _notification_list[0].priority == 0
+        assert _notification_list[0].address is None
+        assert _notification_list[0].args == {}
+        assert _notification_list[0].metainfo == {
+            "company_name": "株式会社DEMO",
+            "exchange_address": "",
+            "token_address": token["address"],
+            "token_name": "テスト債券",
+            "token_type": "IbetStraightBond",
+        }
+        assert (
+            _notification_list[1].notification_type
+            == NotificationType.CHANGE_TO_REDEEMED
+        )
+        assert _notification_list[1].priority == 0
+        assert _notification_list[1].address is None
+        assert _notification_list[1].args == {}
+        assert _notification_list[1].metainfo == {
+            "company_name": "株式会社DEMO",
+            "exchange_address": "",
+            "token_address": token["address"],
+            "token_name": "テスト債券",
+            "token_type": "IbetStraightBond",
+        }
+
+        _notification_block_number: NotificationBlockNumber = (
+            await async_session.scalars(
+                select(NotificationBlockNumber)
+                .where(
+                    and_(
+                        NotificationBlockNumber.notification_type
+                        == NotificationType.CHANGE_TO_REDEEMED,
+                        NotificationBlockNumber.contract_address == token["address"],
+                    )
+                )
+                .limit(1)
+            )
+        ).first()
+        assert _notification_block_number.latest_block_number == block_number
+
+    # <Normal_4>
+    # No event logs
+    async def test_normal_4(
+        self, watcher_factory, async_session, shared_contract, mocked_company_list
+    ):
+        watcher = watcher_factory("WatchChangeToRedeemed")
+        exchange_contract = shared_contract["IbetStraightBondExchange"]
+        token_list_contract = shared_contract["TokenList"]
+        personal_info_contract = shared_contract["PersonalInfo"]
+
+        # Issue token
+        token = await prepare_bond_token(
+            self.issuer,
+            exchange_contract,
+            token_list_contract,
+            personal_info_contract,
+            async_session,
+        )
+
+        idx_token_list_item = IDXTokenListRegister()
+        idx_token_list_item.token_address = token["address"]
+        idx_token_list_item.owner_address = self.issuer["account_address"]
+        idx_token_list_item.token_template = "IbetStraightBond"
+        async_session.add(idx_token_list_item)
+
+        notification_block_number = NotificationBlockNumber()
+        notification_block_number.notification_type = (
+            NotificationType.CHANGE_TO_REDEEMED
+        )
+        notification_block_number.contract_address = token["address"]
+        notification_block_number.latest_block_number = web3.eth.block_number
+        async_session.add(notification_block_number)
+        await async_session.commit()
+
+        # Not emit ChangeToRedeemed event
+        pass
+
+        # Run target process
+        await watcher.loop()
+
+        # Assertion
+        block_number = web3.eth.block_number
+
+        _notification_list = (await async_session.scalars(select(Notification))).all()
+        assert len(_notification_list) == 0
+
+        _notification_block_number = (
+            await async_session.scalars(select(NotificationBlockNumber).limit(1))
+        ).first()
+        assert _notification_block_number.latest_block_number == block_number
+
+    # <Normal_5>
+    # Skip past data on initial sync
+    async def test_normal_5(
+        self, watcher_factory, async_session, shared_contract, mocked_company_list
+    ):
+        watcher = watcher_factory("WatchChangeToRedeemed")
+        exchange_contract = shared_contract["IbetStraightBondExchange"]
+        token_list_contract = shared_contract["TokenList"]
+        personal_info_contract = shared_contract["PersonalInfo"]
+
+        # Issue token
+        token = await prepare_bond_token(
+            self.issuer,
+            exchange_contract,
+            token_list_contract,
+            personal_info_contract,
+            async_session,
+        )
+
+        idx_token_list_item = IDXTokenListRegister()
+        idx_token_list_item.token_address = token["address"]
+        idx_token_list_item.owner_address = self.issuer["account_address"]
+        idx_token_list_item.token_template = "IbetStraightBond"
+        async_session.add(idx_token_list_item)
+        await async_session.commit()
+
+        # Emit ChangeToRedeemed event
+        bond_change_to_redeemed(
+            invoker=self.issuer,
+            token=token,
+        )
+        web3.provider.make_request(RPCEndpoint("evm_mine"), [])
+
+        # Run target process
+        await watcher.loop()
+
+        # Assertion
+        block_number = web3.eth.block_number
+
+        _notification_list = (await async_session.scalars(select(Notification))).all()
+        assert len(_notification_list) == 0
+
+        _notification_block_number = (
+            await async_session.scalars(select(NotificationBlockNumber).limit(1))
+        ).first()
+        assert _notification_block_number.latest_block_number == block_number
+
+    # ###########################################################################
+    # # Error Case
+    # ###########################################################################
+
+    # <Error_1>
+    # Error occur
+    @mock.patch(
+        "web3.eth.async_eth.AsyncEth.get_logs",
+        MagicMock(side_effect=Exception()),
+    )
+    async def test_error_1(
+        self, watcher_factory, async_session, shared_contract, mocked_company_list
+    ):
+        watcher = watcher_factory("WatchChangeToRedeemed")
+        exchange_contract = shared_contract["IbetStraightBondExchange"]
+        token_list_contract = shared_contract["TokenList"]
+        personal_info_contract = shared_contract["PersonalInfo"]
+
+        # Issue token
+        token = await prepare_bond_token(
+            self.issuer,
+            exchange_contract,
+            token_list_contract,
+            personal_info_contract,
+            async_session,
+        )
+
+        idx_token_list_item = IDXTokenListRegister()
+        idx_token_list_item.token_address = token["address"]
+        idx_token_list_item.owner_address = self.issuer["account_address"]
+        idx_token_list_item.token_template = "IbetStraightBond"
+        async_session.add(idx_token_list_item)
+        await async_session.commit()
+
+        # Run target process
+        await watcher.loop()
+
+        # Assertion
+        _notification = (
+            await async_session.scalars(
+                select(Notification).order_by(Notification.created).limit(1)
+            )
+        ).first()
+        assert _notification is None
+
+        _notification_block_number = (
+            await async_session.scalars(select(NotificationBlockNumber).limit(1))
+        ).first()
+        assert _notification_block_number is None
+
+
+@pytest.mark.asyncio
+class TestWatchChangeToCanceled:
+    issuer = eth_account["issuer"]
+    lock_account = eth_account["user1"]
+
+    ###########################################################################
+    # Normal Case
+    ###########################################################################
+
+    # <Normal_1>
+    # Initial Sync
+    async def test_normal_1(
+        self, watcher_factory, async_session, shared_contract, mocked_company_list
+    ):
+        watcher = watcher_factory("WatchChangeToCanceled")
+        exchange_contract = shared_contract["IbetShareExchange"]
+        token_list_contract = shared_contract["TokenList"]
+        personal_info_contract = shared_contract["PersonalInfo"]
+
+        # Issue token
+        token = await prepare_share_token(
+            self.issuer,
+            exchange_contract,
+            token_list_contract,
+            personal_info_contract,
+            async_session,
+        )
+
+        idx_token_list_item = IDXTokenListRegister()
+        idx_token_list_item.token_address = token["address"]
+        idx_token_list_item.owner_address = self.issuer["account_address"]
+        idx_token_list_item.token_template = "IbetShare"
+        async_session.add(idx_token_list_item)
+        await async_session.commit()
+
+        # Run target process
+        await watcher.loop()
+
+        # Assertion
+        block_number = web3.eth.block_number
+
+        _notification = (
+            await async_session.scalars(
+                select(Notification)
+                .where(
+                    Notification.notification_id
+                    == "0x{:012x}{:06x}{:06x}{:02x}".format(block_number, 0, 0, 0)
+                )
+                .limit(1)
+            )
+        ).first()
+        assert _notification is None
+
+        _notification_block_number: NotificationBlockNumber = (
+            await async_session.scalars(
+                select(NotificationBlockNumber)
+                .where(
+                    and_(
+                        NotificationBlockNumber.notification_type
+                        == NotificationType.CHANGE_TO_CANCELED,
+                        NotificationBlockNumber.contract_address == token["address"],
+                    )
+                )
+                .limit(1)
+            )
+        ).first()
+        assert _notification_block_number.latest_block_number == block_number
+
+    # <Normal_2>
+    # Single event logs
+    async def test_normal_2(
+        self, watcher_factory, async_session, shared_contract, mocked_company_list
+    ):
+        watcher = watcher_factory("WatchChangeToCanceled")
+        exchange_contract = shared_contract["IbetShareExchange"]
+        token_list_contract = shared_contract["TokenList"]
+        personal_info_contract = shared_contract["PersonalInfo"]
+
+        # Issue token
+        token = await prepare_share_token(
+            self.issuer,
+            exchange_contract,
+            token_list_contract,
+            personal_info_contract,
+            async_session,
+        )
+
+        idx_token_list_item = IDXTokenListRegister()
+        idx_token_list_item.token_address = token["address"]
+        idx_token_list_item.owner_address = self.issuer["account_address"]
+        idx_token_list_item.token_template = "IbetShare"
+        async_session.add(idx_token_list_item)
+
+        notification_block_number = NotificationBlockNumber()
+        notification_block_number.notification_type = (
+            NotificationType.CHANGE_TO_CANCELED
+        )
+        notification_block_number.contract_address = token["address"]
+        notification_block_number.latest_block_number = web3.eth.block_number
+        async_session.add(notification_block_number)
+        await async_session.commit()
+
+        # Emit ChangeToCanceled event
+        share_change_to_canceled(
+            invoker=self.issuer,
+            token=token,
+        )
+
+        # Run target process
+        await watcher.loop()
+
+        # Assertion
+        block_number = web3.eth.block_number
+
+        async_session.expunge_all()
+
+        _notification_list = (await async_session.scalars(select(Notification))).all()
+        assert len(_notification_list) == 1
+        assert (
+            _notification_list[0].notification_type
+            == NotificationType.CHANGE_TO_CANCELED
+        )
+        assert _notification_list[0].priority == 0
+        assert _notification_list[0].address is None
+        assert _notification_list[0].args == {}
+        assert _notification_list[0].metainfo == {
+            "company_name": "株式会社DEMO",
+            "exchange_address": "",
+            "token_address": token["address"],
+            "token_name": "テスト株式",
+            "token_type": "IbetShare",
+        }
+
+        _notification_block_number: NotificationBlockNumber = (
+            await async_session.scalars(
+                select(NotificationBlockNumber)
+                .where(
+                    and_(
+                        NotificationBlockNumber.notification_type
+                        == NotificationType.CHANGE_TO_CANCELED,
+                        NotificationBlockNumber.contract_address == token["address"],
+                    )
+                )
+                .limit(1)
+            )
+        ).first()
+        assert _notification_block_number.latest_block_number == block_number
+
+    # <Normal_3>
+    # Multi event logs
+    async def test_normal_3(
+        self, watcher_factory, async_session, shared_contract, mocked_company_list
+    ):
+        watcher = watcher_factory("WatchChangeToCanceled")
+        exchange_contract = shared_contract["IbetShareExchange"]
+        token_list_contract = shared_contract["TokenList"]
+        personal_info_contract = shared_contract["PersonalInfo"]
+
+        # Issue token
+        token = await prepare_share_token(
+            self.issuer,
+            exchange_contract,
+            token_list_contract,
+            personal_info_contract,
+            async_session,
+        )
+
+        idx_token_list_item = IDXTokenListRegister()
+        idx_token_list_item.token_address = token["address"]
+        idx_token_list_item.owner_address = self.issuer["account_address"]
+        idx_token_list_item.token_template = "IbetShare"
+        async_session.add(idx_token_list_item)
+
+        notification_block_number = NotificationBlockNumber()
+        notification_block_number.notification_type = (
+            NotificationType.CHANGE_TO_CANCELED
+        )
+        notification_block_number.contract_address = token["address"]
+        notification_block_number.latest_block_number = web3.eth.block_number
+        async_session.add(notification_block_number)
+        await async_session.commit()
+
+        # Emit ChangeToCanceled event
+        share_change_to_canceled(
+            invoker=self.issuer,
+            token=token,
+        )
+        share_change_to_canceled(
+            invoker=self.issuer,
+            token=token,
+        )
+
+        # Run target process
+        await watcher.loop()
+
+        # Assertion
+        block_number = web3.eth.block_number
+
+        async_session.expunge_all()
+
+        _notification_list = (await async_session.scalars(select(Notification))).all()
+        assert len(_notification_list) == 2
+        assert (
+            _notification_list[0].notification_type
+            == NotificationType.CHANGE_TO_CANCELED
+        )
+        assert _notification_list[0].priority == 0
+        assert _notification_list[0].address is None
+        assert _notification_list[0].args == {}
+        assert _notification_list[0].metainfo == {
+            "company_name": "株式会社DEMO",
+            "exchange_address": "",
+            "token_address": token["address"],
+            "token_name": "テスト株式",
+            "token_type": "IbetShare",
+        }
+        assert (
+            _notification_list[1].notification_type
+            == NotificationType.CHANGE_TO_CANCELED
+        )
+        assert _notification_list[1].priority == 0
+        assert _notification_list[1].address is None
+        assert _notification_list[1].args == {}
+        assert _notification_list[1].metainfo == {
+            "company_name": "株式会社DEMO",
+            "exchange_address": "",
+            "token_address": token["address"],
+            "token_name": "テスト株式",
+            "token_type": "IbetShare",
+        }
+
+        _notification_block_number: NotificationBlockNumber = (
+            await async_session.scalars(
+                select(NotificationBlockNumber)
+                .where(
+                    and_(
+                        NotificationBlockNumber.notification_type
+                        == NotificationType.CHANGE_TO_CANCELED,
+                        NotificationBlockNumber.contract_address == token["address"],
+                    )
+                )
+                .limit(1)
+            )
+        ).first()
+        assert _notification_block_number.latest_block_number == block_number
+
+    # <Normal_4>
+    # No event logs
+    async def test_normal_4(
+        self, watcher_factory, async_session, shared_contract, mocked_company_list
+    ):
+        watcher = watcher_factory("WatchChangeToCanceled")
+        exchange_contract = shared_contract["IbetShareExchange"]
+        token_list_contract = shared_contract["TokenList"]
+        personal_info_contract = shared_contract["PersonalInfo"]
+
+        # Issue token
+        token = await prepare_share_token(
+            self.issuer,
+            exchange_contract,
+            token_list_contract,
+            personal_info_contract,
+            async_session,
+        )
+
+        idx_token_list_item = IDXTokenListRegister()
+        idx_token_list_item.token_address = token["address"]
+        idx_token_list_item.owner_address = self.issuer["account_address"]
+        idx_token_list_item.token_template = "IbetShare"
+        async_session.add(idx_token_list_item)
+
+        notification_block_number = NotificationBlockNumber()
+        notification_block_number.notification_type = (
+            NotificationType.CHANGE_TO_CANCELED
+        )
+        notification_block_number.contract_address = token["address"]
+        notification_block_number.latest_block_number = web3.eth.block_number
+        async_session.add(notification_block_number)
+        await async_session.commit()
+
+        # Not emit ChangeToCanceled event
+        pass
+
+        # Run target process
+        await watcher.loop()
+
+        # Assertion
+        block_number = web3.eth.block_number
+
+        _notification_list = (await async_session.scalars(select(Notification))).all()
+        assert len(_notification_list) == 0
+
+        _notification_block_number = (
+            await async_session.scalars(select(NotificationBlockNumber).limit(1))
+        ).first()
+        assert _notification_block_number.latest_block_number == block_number
+
+    # <Normal_5>
+    # Skip past data on initial sync
+    async def test_normal_5(
+        self, watcher_factory, async_session, shared_contract, mocked_company_list
+    ):
+        watcher = watcher_factory("WatchChangeToCanceled")
+        exchange_contract = shared_contract["IbetShareExchange"]
+        token_list_contract = shared_contract["TokenList"]
+        personal_info_contract = shared_contract["PersonalInfo"]
+
+        # Issue token
+        token = await prepare_share_token(
+            self.issuer,
+            exchange_contract,
+            token_list_contract,
+            personal_info_contract,
+            async_session,
+        )
+
+        idx_token_list_item = IDXTokenListRegister()
+        idx_token_list_item.token_address = token["address"]
+        idx_token_list_item.owner_address = self.issuer["account_address"]
+        idx_token_list_item.token_template = "IbetShare"
+        async_session.add(idx_token_list_item)
+        await async_session.commit()
+
+        # Emit ChangeToCanceled event
+        share_change_to_canceled(
+            invoker=self.issuer,
+            token=token,
+        )
+        web3.provider.make_request(RPCEndpoint("evm_mine"), [])
+
+        # Run target process
+        await watcher.loop()
+
+        # Assertion
+        block_number = web3.eth.block_number
+
+        _notification_list = (await async_session.scalars(select(Notification))).all()
+        assert len(_notification_list) == 0
+
+        _notification_block_number = (
+            await async_session.scalars(select(NotificationBlockNumber).limit(1))
+        ).first()
+        assert _notification_block_number.latest_block_number == block_number
+
+    # ###########################################################################
+    # # Error Case
+    # ###########################################################################
+
+    # <Error_1>
+    # Error occur
+    @mock.patch(
+        "web3.eth.async_eth.AsyncEth.get_logs",
+        MagicMock(side_effect=Exception()),
+    )
+    async def test_error_1(
+        self, watcher_factory, async_session, shared_contract, mocked_company_list
+    ):
+        watcher = watcher_factory("WatchChangeToCanceled")
         exchange_contract = shared_contract["IbetShareExchange"]
         token_list_contract = shared_contract["TokenList"]
         personal_info_contract = shared_contract["PersonalInfo"]

--- a/tests/contract_modules.py
+++ b/tests/contract_modules.py
@@ -381,6 +381,15 @@ def bond_set_tradable_exchange(invoker, token, exchange_address: str):
     )
 
 
+# BONDトークン：償還状態に変更
+def bond_change_to_redeemed(invoker, token):
+    web3.eth.default_account = invoker["account_address"]
+    TokenContract = Contract.get_contract("IbetStraightBond", token["address"])
+    TokenContract.functions.changeToRedeemed().transact(
+        {"from": invoker["account_address"]}
+    )
+
+
 ###############################################################
 # Share Token
 ###############################################################
@@ -661,6 +670,15 @@ def share_set_tradable_exchange(invoker, token, exchange_address: str):
 
     TokenContract = Contract.get_contract("IbetShare", token["address"])
     TokenContract.functions.setTradableExchange(exchange_address).transact(
+        {"from": invoker["account_address"]}
+    )
+
+
+# SHAREトークン：消却状態に変更
+def share_change_to_canceled(invoker, token):
+    web3.eth.default_account = invoker["account_address"]
+    TokenContract = Contract.get_contract("IbetShare", token["address"])
+    TokenContract.functions.changeToCanceled().transact(
         {"from": invoker["account_address"]}
     )
 


### PR DESCRIPTION
## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->

This pull request introduces support for two new notification types, `ChangeToRedeemed` and `ChangeToCanceled`, and updates the notification processing system to handle these events. Additionally, it includes utility functions for testing these events in the contract modules.

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
- Close #1650 

## 🔄 Changes

<!-- List the major changes in this PR. -->

### Notification System Enhancements:
* Added new notification types `CHANGE_TO_REDEEMED` and `CHANGE_TO_CANCELED` to the `NotificationType` enum in `app/model/db/notification.py`.
* Extended the `Watcher` class to support filtering by `token_type_list` and skipping past data during initial synchronization. [[1]](diffhunk://#diff-8a0136971d97939fea94c7295338b9ec2ba7cf41120ee6ed90ffa78dbbec145dL73-R88) [[2]](diffhunk://#diff-8a0136971d97939fea94c7295338b9ec2ba7cf41120ee6ed90ffa78dbbec145dL94-R118) [[3]](diffhunk://#diff-8a0136971d97939fea94c7295338b9ec2ba7cf41120ee6ed90ffa78dbbec145dL129-R147) [[4]](diffhunk://#diff-8a0136971d97939fea94c7295338b9ec2ba7cf41120ee6ed90ffa78dbbec145dR157-R158) [[5]](diffhunk://#diff-8a0136971d97939fea94c7295338b9ec2ba7cf41120ee6ed90ffa78dbbec145dL213-R237) [[6]](diffhunk://#diff-8a0136971d97939fea94c7295338b9ec2ba7cf41120ee6ed90ffa78dbbec145dR249-R250)
* Introduced two new watcher classes, `WatchChangeToRedeemed` and `WatchChangeToCanceled`, to handle the respective events for bond tokens and share tokens. These classes include logic for creating notifications with relevant metadata.
* Updated the `main` function to include the new watcher classes in the list of active watchers.

### Testing Utilities:
* Added `bond_change_to_redeemed` utility function to simulate the `ChangeToRedeemed` event for bond tokens in `tests/contract_modules.py`.
* Added `share_change_to_canceled` utility function to simulate the `ChangeToCanceled` event for share tokens in `tests/contract_modules.py`.

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
