### PR TITLE
Refactor transaction retrieval to handle pruned transactions and improve error handling

### DIFF
--- a/batch/indexer_Position_Bond.py
+++ b/batch/indexer_Position_Bond.py
@@ -414,7 +414,9 @@ class Processor:
                     value = args.get("value", 0)
                     data = args.get("data", "")
                     event_created = await self.__gen_block_timestamp(event=event)
-                    tx = await async_web3.eth.get_transaction(event["transactionHash"])
+                    tx = await AsyncContract.get_transaction(
+                        event["transactionHash"], event["blockNumber"]
+                    )
                     msg_sender = tx["from"]
 
                     # Index Lock event
@@ -496,7 +498,9 @@ class Processor:
                     value = args.get("value", 0)
                     data = args.get("data", "")
                     event_created = await self.__gen_block_timestamp(event=event)
-                    tx = await async_web3.eth.get_transaction(event["transactionHash"])
+                    tx = await AsyncContract.get_transaction(
+                        event["transactionHash"], event["blockNumber"]
+                    )
                     msg_sender = tx["from"]
 
                     # Index Lock event
@@ -580,7 +584,9 @@ class Processor:
                     value = args.get("value", 0)
                     data = args.get("data", "")
                     event_created = await self.__gen_block_timestamp(event=event)
-                    tx = await async_web3.eth.get_transaction(event["transactionHash"])
+                    tx = await AsyncContract.get_transaction(
+                        event["transactionHash"], event["blockNumber"]
+                    )
                     msg_sender = tx["from"]
 
                     # Index Unlock event
@@ -664,7 +670,9 @@ class Processor:
                     value = args.get("value", 0)
                     data = args.get("data", "")
                     event_created = await self.__gen_block_timestamp(event=event)
-                    tx = await async_web3.eth.get_transaction(event["transactionHash"])
+                    tx = await AsyncContract.get_transaction(
+                        event["transactionHash"], event["blockNumber"]
+                    )
                     msg_sender = tx["from"]
 
                     # Index Unlock event
@@ -751,7 +759,9 @@ class Processor:
                     value = args.get("value", 0)
                     data = args.get("data", "")
                     event_created = await self.__gen_block_timestamp(event=event)
-                    tx = await async_web3.eth.get_transaction(event["transactionHash"])
+                    tx = await AsyncContract.get_transaction(
+                        event["transactionHash"], event["blockNumber"]
+                    )
                     msg_sender = tx["from"]
 
                     # Index Unlock event

--- a/batch/indexer_Position_Share.py
+++ b/batch/indexer_Position_Share.py
@@ -414,7 +414,9 @@ class Processor:
                     value = args.get("value", 0)
                     data = args.get("data", "")
                     event_created = await self.__gen_block_timestamp(event=event)
-                    tx = await async_web3.eth.get_transaction(event["transactionHash"])
+                    tx = await AsyncContract.get_transaction(
+                        event["transactionHash"], event["blockNumber"]
+                    )
                     msg_sender = tx["from"]
 
                     # Index Lock event
@@ -496,7 +498,9 @@ class Processor:
                     value = args.get("value", 0)
                     data = args.get("data", "")
                     event_created = await self.__gen_block_timestamp(event=event)
-                    tx = await async_web3.eth.get_transaction(event["transactionHash"])
+                    tx = await AsyncContract.get_transaction(
+                        event["transactionHash"], event["blockNumber"]
+                    )
                     msg_sender = tx["from"]
 
                     # Index Lock event
@@ -580,7 +584,9 @@ class Processor:
                     value = args.get("value", 0)
                     data = args.get("data", "")
                     event_created = await self.__gen_block_timestamp(event=event)
-                    tx = await async_web3.eth.get_transaction(event["transactionHash"])
+                    tx = await AsyncContract.get_transaction(
+                        event["transactionHash"], event["blockNumber"]
+                    )
                     msg_sender = tx["from"]
 
                     # Index Unlock event
@@ -664,7 +670,9 @@ class Processor:
                     value = args.get("value", 0)
                     data = args.get("data", "")
                     event_created = await self.__gen_block_timestamp(event=event)
-                    tx = await async_web3.eth.get_transaction(event["transactionHash"])
+                    tx = await AsyncContract.get_transaction(
+                        event["transactionHash"], event["blockNumber"]
+                    )
                     msg_sender = tx["from"]
 
                     # Index Unlock event
@@ -751,7 +759,9 @@ class Processor:
                     value = args.get("value", 0)
                     data = args.get("data", "")
                     event_created = await self.__gen_block_timestamp(event=event)
-                    tx = await async_web3.eth.get_transaction(event["transactionHash"])
+                    tx = await AsyncContract.get_transaction(
+                        event["transactionHash"], event["blockNumber"]
+                    )
                     msg_sender = tx["from"]
 
                     # Index Unlock event

--- a/batch/indexer_Transfer.py
+++ b/batch/indexer_Transfer.py
@@ -381,7 +381,9 @@ class Processor:
                         # Judge whether the transfer is a reallocation
                         transaction_hash = event["transactionHash"].to_0x_hex()
                         is_reallocation = False
-                        tx = await async_web3.eth.get_transaction(transaction_hash)
+                        tx = await AsyncContract.get_transaction(
+                            event["transactionHash"], event["blockNumber"]
+                        )
                         tx_data: HexBytes | None = tx.get("input")
                         # Check if the transaction data contains the reallocation marker("c0ffee00")
                         if "c0ffee00" in tx_data.hex():

--- a/tests/batch/indexer_Position_Bond_test.py
+++ b/tests/batch/indexer_Position_Bond_test.py
@@ -30,7 +30,7 @@ from sqlalchemy import and_, select
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 from web3 import Web3
-from web3.exceptions import ABIEventNotFound
+from web3.exceptions import ABIEventNotFound, TransactionNotFound
 from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
@@ -499,7 +499,8 @@ class TestProcessor:
     # Single Token
     # Single event logs
     # - Lock
-    async def test_normal_4_1(self, processor, shared_contract, session):
+    @pytest.mark.parametrize("is_old_token", [False, True])
+    async def test_normal_4_1(self, processor, shared_contract, session, is_old_token):
         # Issue Token
         token_list_contract = shared_contract["TokenList"]
         personal_info_contract = shared_contract["PersonalInfo"]
@@ -526,7 +527,14 @@ class TestProcessor:
 
         # Run target process
         block_number = web3.eth.block_number
-        await processor.sync_new_logs()
+        if is_old_token:
+            with mock.patch(
+                "web3.eth.async_eth.AsyncEth.get_transaction",
+                MagicMock(side_effect=TransactionNotFound(message="")),
+            ):
+                await processor.sync_new_logs()
+        else:
+            await processor.sync_new_logs()
 
         # Assertion
         _position_list: Sequence[IDXPosition] = session.scalars(
@@ -595,7 +603,8 @@ class TestProcessor:
     # Single Token
     # Single event logs
     # - ForceLock
-    async def test_normal_4_2(self, processor, shared_contract, session):
+    @pytest.mark.parametrize("is_old_token", [False, True])
+    async def test_normal_4_2(self, processor, shared_contract, session, is_old_token):
         # Issue Token
         token_list_contract = shared_contract["TokenList"]
         personal_info_contract = shared_contract["PersonalInfo"]
@@ -634,7 +643,14 @@ class TestProcessor:
 
         # Run target process
         block_number = web3.eth.block_number
-        await processor.sync_new_logs()
+        if is_old_token:
+            with mock.patch(
+                "web3.eth.async_eth.AsyncEth.get_transaction",
+                MagicMock(side_effect=TransactionNotFound(message="")),
+            ):
+                await processor.sync_new_logs()
+        else:
+            await processor.sync_new_logs()
 
         # Assertion
         _position_issuer: IDXPosition = session.scalars(
@@ -705,7 +721,8 @@ class TestProcessor:
     # Single Token
     # Single event logs
     # - Unlock
-    async def test_normal_5_1(self, processor, shared_contract, session):
+    @pytest.mark.parametrize("is_old_token", [False, True])
+    async def test_normal_5_1(self, processor, shared_contract, session, is_old_token):
         # Issue Token
         token_list_contract = shared_contract["TokenList"]
         personal_info_contract = shared_contract["PersonalInfo"]
@@ -734,7 +751,14 @@ class TestProcessor:
 
         # Run target process
         block_number = web3.eth.block_number
-        await processor.sync_new_logs()
+        if is_old_token:
+            with mock.patch(
+                "web3.eth.async_eth.AsyncEth.get_transaction",
+                MagicMock(side_effect=TransactionNotFound(message="")),
+            ):
+                await processor.sync_new_logs()
+        else:
+            await processor.sync_new_logs()
 
         # Assertion
         _position_list: Sequence[IDXPosition] = session.scalars(
@@ -825,7 +849,8 @@ class TestProcessor:
     # Single Token
     # Single event logs
     # - ForceUnlock
-    async def test_normal_5_2(self, processor, shared_contract, session):
+    @pytest.mark.parametrize("is_old_token", [False, True])
+    async def test_normal_5_2(self, processor, shared_contract, session, is_old_token):
         # Issue Token
         token_list_contract = shared_contract["TokenList"]
         personal_info_contract = shared_contract["PersonalInfo"]
@@ -855,7 +880,14 @@ class TestProcessor:
 
         # Run target process
         block_number = web3.eth.block_number
-        await processor.sync_new_logs()
+        if is_old_token:
+            with mock.patch(
+                "web3.eth.async_eth.AsyncEth.get_transaction",
+                MagicMock(side_effect=TransactionNotFound(message="")),
+            ):
+                await processor.sync_new_logs()
+        else:
+            await processor.sync_new_logs()
 
         # Assertion
         _position_list: Sequence[IDXPosition] = session.scalars(
@@ -946,7 +978,8 @@ class TestProcessor:
     # Single Token
     # Single event logs
     # - ForceChangeLockedAccount
-    async def test_normal_5_3(self, processor, shared_contract, session):
+    @pytest.mark.parametrize("is_old_token", [False, True])
+    async def test_normal_5_3(self, processor, shared_contract, session, is_old_token):
         # Issue Token
         token_list_contract = shared_contract["TokenList"]
         personal_info_contract = shared_contract["PersonalInfo"]
@@ -989,7 +1022,14 @@ class TestProcessor:
 
         # Run target process
         block_number = web3.eth.block_number
-        await processor.sync_new_logs()
+        if is_old_token:
+            with mock.patch(
+                "web3.eth.async_eth.AsyncEth.get_transaction",
+                MagicMock(side_effect=TransactionNotFound(message="")),
+            ):
+                await processor.sync_new_logs()
+        else:
+            await processor.sync_new_logs()
 
         # Assertion
         _position_issuer: IDXPosition = session.scalars(

--- a/tests/batch/indexer_Position_Share_test.py
+++ b/tests/batch/indexer_Position_Share_test.py
@@ -30,7 +30,7 @@ from sqlalchemy import and_, select
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 from web3 import Web3
-from web3.exceptions import ABIEventNotFound
+from web3.exceptions import ABIEventNotFound, TransactionNotFound
 from web3.middleware import ExtraDataToPOAMiddleware
 
 from app import config
@@ -481,7 +481,8 @@ class TestProcessor:
     # Single Token
     # Single event logs
     # - Lock
-    async def test_normal_4_1(self, processor, shared_contract, session):
+    @pytest.mark.parametrize("is_old_token", [False, True])
+    async def test_normal_4_1(self, processor, shared_contract, session, is_old_token):
         # Issue Token
         token_list_contract = shared_contract["TokenList"]
         personal_info_contract = shared_contract["PersonalInfo"]
@@ -508,7 +509,14 @@ class TestProcessor:
 
         # Run target process
         block_number = web3.eth.block_number
-        await processor.sync_new_logs()
+        if is_old_token:
+            with mock.patch(
+                "web3.eth.async_eth.AsyncEth.get_transaction",
+                MagicMock(side_effect=TransactionNotFound(message="")),
+            ):
+                await processor.sync_new_logs()
+        else:
+            await processor.sync_new_logs()
 
         # Assertion
         _position_list: Sequence[IDXPosition] = session.scalars(
@@ -574,7 +582,8 @@ class TestProcessor:
     # Single Token
     # Single event logs
     # - ForceLock
-    async def test_normal_4_2(self, processor, shared_contract, session):
+    @pytest.mark.parametrize("is_old_token", [False, True])
+    async def test_normal_4_2(self, processor, shared_contract, session, is_old_token):
         # Issue Token
         token_list_contract = shared_contract["TokenList"]
         personal_info_contract = shared_contract["PersonalInfo"]
@@ -613,7 +622,14 @@ class TestProcessor:
 
         # Run target process
         block_number = web3.eth.block_number
-        await processor.sync_new_logs()
+        if is_old_token:
+            with mock.patch(
+                "web3.eth.async_eth.AsyncEth.get_transaction",
+                MagicMock(side_effect=TransactionNotFound(message="")),
+            ):
+                await processor.sync_new_logs()
+        else:
+            await processor.sync_new_logs()
 
         # Assertion
         _position_issuer: IDXPosition = session.scalars(
@@ -684,7 +700,8 @@ class TestProcessor:
     # Single Token
     # Single event logs
     # - Unlock
-    async def test_normal_5_1(self, processor, shared_contract, session):
+    @pytest.mark.parametrize("is_old_token", [False, True])
+    async def test_normal_5_1(self, processor, shared_contract, session, is_old_token):
         # Issue Token
         token_list_contract = shared_contract["TokenList"]
         personal_info_contract = shared_contract["PersonalInfo"]
@@ -713,7 +730,14 @@ class TestProcessor:
 
         # Run target process
         block_number = web3.eth.block_number
-        await processor.sync_new_logs()
+        if is_old_token:
+            with mock.patch(
+                "web3.eth.async_eth.AsyncEth.get_transaction",
+                MagicMock(side_effect=TransactionNotFound(message="")),
+            ):
+                await processor.sync_new_logs()
+        else:
+            await processor.sync_new_logs()
 
         # Assertion
         _position_list: Sequence[IDXPosition] = session.scalars(
@@ -800,7 +824,8 @@ class TestProcessor:
     # Single Token
     # Single event logs
     # - ForceUnlock
-    async def test_normal_5_2(self, processor, shared_contract, session):
+    @pytest.mark.parametrize("is_old_token", [False, True])
+    async def test_normal_5_2(self, processor, shared_contract, session, is_old_token):
         # Issue Token
         token_list_contract = shared_contract["TokenList"]
         personal_info_contract = shared_contract["PersonalInfo"]
@@ -830,7 +855,14 @@ class TestProcessor:
 
         # Run target process
         block_number = web3.eth.block_number
-        await processor.sync_new_logs()
+        if is_old_token:
+            with mock.patch(
+                "web3.eth.async_eth.AsyncEth.get_transaction",
+                MagicMock(side_effect=TransactionNotFound(message="")),
+            ):
+                await processor.sync_new_logs()
+        else:
+            await processor.sync_new_logs()
 
         # Assertion
         _position_list: Sequence[IDXPosition] = session.scalars(
@@ -917,7 +949,8 @@ class TestProcessor:
     # Single Token
     # Single event logs
     # - ForceChangeLockedAccount
-    async def test_normal_5_3(self, processor, shared_contract, session):
+    @pytest.mark.parametrize("is_old_token", [False, True])
+    async def test_normal_5_3(self, processor, shared_contract, session, is_old_token):
         # Issue Token
         token_list_contract = shared_contract["TokenList"]
         personal_info_contract = shared_contract["PersonalInfo"]
@@ -959,7 +992,14 @@ class TestProcessor:
 
         # Run target process
         block_number = web3.eth.block_number
-        await processor.sync_new_logs()
+        if is_old_token:
+            with mock.patch(
+                "web3.eth.async_eth.AsyncEth.get_transaction",
+                MagicMock(side_effect=TransactionNotFound(message="")),
+            ):
+                await processor.sync_new_logs()
+        else:
+            await processor.sync_new_logs()
 
         # Assertion
         _position_issuer: IDXPosition = session.scalars(


### PR DESCRIPTION
## 📌 Description

This pull request refactors how transaction data is retrieved throughout the codebase to handle cases where the Ethereum node has pruned old transactions and they are no longer available via the standard API. It introduces a new method in `AsyncContract` for robust transaction retrieval, updates all usages to leverage this method, and enhances test coverage to ensure correct behavior for both pruned and non-pruned transactions.

## ✅ Related Issues

- Close #1669 

## 🔄 Changes

<!-- List the major changes in this PR. -->

**Transaction retrieval and error handling:**

* Added `AsyncContract.get_transaction`, which first attempts to fetch a transaction by hash and, if not found, falls back to retrieving it from block data. This handles pruned transactions gracefully. (`app/contracts/contract.py`)
* Updated all usages of `async_web3.eth.get_transaction` to use the new `AsyncContract.get_transaction` method, passing both transaction hash and block number. This change is reflected in event indexers for Position Bond, Position Share, and Transfer, as well as in API endpoints for transaction inspection. (`batch/indexer_Position_Bond.py`, `batch/indexer_Position_Share.py`, `batch/indexer_Transfer.py`, `app/api/routers/eth.py`) [[1]](diffhunk://#diff-e6aee665fd2105ec8714613c9b50a178d710490eb24c89975f79782d6c70d9a8L417-R419) [[2]](diffhunk://#diff-e6aee665fd2105ec8714613c9b50a178d710490eb24c89975f79782d6c70d9a8L499-R503) [[3]](diffhunk://#diff-e6aee665fd2105ec8714613c9b50a178d710490eb24c89975f79782d6c70d9a8L583-R589) [[4]](diffhunk://#diff-e6aee665fd2105ec8714613c9b50a178d710490eb24c89975f79782d6c70d9a8L667-R675) [[5]](diffhunk://#diff-e6aee665fd2105ec8714613c9b50a178d710490eb24c89975f79782d6c70d9a8L754-R764) [[6]](diffhunk://#diff-7c8731c28bc19df2012ab5b9793f86eada370544630547f35c1d6e28938c5b34L417-R419) [[7]](diffhunk://#diff-7c8731c28bc19df2012ab5b9793f86eada370544630547f35c1d6e28938c5b34L499-R503) [[8]](diffhunk://#diff-7c8731c28bc19df2012ab5b9793f86eada370544630547f35c1d6e28938c5b34L583-R589) [[9]](diffhunk://#diff-7c8731c28bc19df2012ab5b9793f86eada370544630547f35c1d6e28938c5b34L667-R675) [[10]](diffhunk://#diff-7c8731c28bc19df2012ab5b9793f86eada370544630547f35c1d6e28938c5b34L754-R764) [[11]](diffhunk://#diff-26279c42268d5591a5d3a60f9283de3fdf4776300a976ef0a89815f6872c6df2L384-R386) [[12]](diffhunk://#diff-922de168d9c30792927c6bc64cd4dd27a1a355257cf18c770c8001511b9e848cL289-R289) [[13]](diffhunk://#diff-922de168d9c30792927c6bc64cd4dd27a1a355257cf18c770c8001511b9e848cL521-R521) [[14]](diffhunk://#diff-922de168d9c30792927c6bc64cd4dd27a1a355257cf18c770c8001511b9e848cL534-R535)

**Testing improvements:**

* Enhanced tests to cover both scenarios: when transactions are available and when they are pruned. This is done by parameterizing tests and using mocking to simulate the `TransactionNotFound` exception. (`tests/batch/indexer_Position_Bond_test.py`) [[1]](diffhunk://#diff-0355c39ac2f1f5441c52876e2d485b732d184f7871ac682fb2d944936056decbL502-R503) [[2]](diffhunk://#diff-0355c39ac2f1f5441c52876e2d485b732d184f7871ac682fb2d944936056decbR530-R536) [[3]](diffhunk://#diff-0355c39ac2f1f5441c52876e2d485b732d184f7871ac682fb2d944936056decbL598-R607) [[4]](diffhunk://#diff-0355c39ac2f1f5441c52876e2d485b732d184f7871ac682fb2d944936056decbR646-R652) [[5]](diffhunk://#diff-0355c39ac2f1f5441c52876e2d485b732d184f7871ac682fb2d944936056decbL708-R725) [[6]](diffhunk://#diff-0355c39ac2f1f5441c52876e2d485b732d184f7871ac682fb2d944936056decbR754-R760) [[7]](diffhunk://#diff-0355c39ac2f1f5441c52876e2d485b732d184f7871ac682fb2d944936056decbL828-R853) [[8]](diffhunk://#diff-0355c39ac2f1f5441c52876e2d485b732d184f7871ac682fb2d944936056decbR883-R889) [[9]](diffhunk://#diff-0355c39ac2f1f5441c52876e2d485b732d184f7871ac682fb2d944936056decbL949-R982) [[10]](diffhunk://#diff-0355c39ac2f1f5441c52876e2d485b732d184f7871ac682fb2d944936056decbR1025-R1031)

**Type and import updates:**

* Updated type annotations and imports to use `BlockIdentifier` and handle new exception types, ensuring compatibility and clarity in the codebase. (`app/api/routers/eth.py`, `app/contracts/contract.py`, `tests/batch/indexer_Position_Bond_test.py`) [[1]](diffhunk://#diff-922de168d9c30792927c6bc64cd4dd27a1a355257cf18c770c8001511b9e848cL31-R31) [[2]](diffhunk://#diff-18459b8b530d37e57f5e6ac49baa33db793be503020c594386510bcdf7058d11L21-R33) [[3]](diffhunk://#diff-0355c39ac2f1f5441c52876e2d485b732d184f7871ac682fb2d944936056decbL33-R33)

These changes improve the reliability of transaction indexing and inspection, especially for older transactions that may have been pruned by the node.

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
