### PR TITLE
Add retry mechanism to HTTP requests in company_list/token_list/account_list indexer

### DIFF
--- a/batch/indexer_Company_List.py
+++ b/batch/indexer_Company_List.py
@@ -28,6 +28,7 @@ from sqlalchemy import delete
 from sqlalchemy.engine.create import create_engine
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm.session import Session
+from urllib3 import Retry
 
 from app.config import (
     COMPANY_LIST_SLEEP_INTERVAL,
@@ -56,7 +57,11 @@ class Processor:
 
         # Get from COMPANY_LIST_URL
         try:
-            _resp = requests.get(COMPANY_LIST_URL, timeout=REQUEST_TIMEOUT)
+            _resp = requests.get(
+                COMPANY_LIST_URL,
+                timeout=REQUEST_TIMEOUT,
+                retry=Retry(total=3, allowed_methods=["GET"]),
+            )
             if _resp.status_code != 200:
                 raise Exception(f"status code={_resp.status_code}")
             company_list_json = _resp.json()

--- a/batch/indexer_Company_List.py
+++ b/batch/indexer_Company_List.py
@@ -24,6 +24,7 @@ import time
 
 import requests
 from eth_utils import to_checksum_address
+from requests.adapters import HTTPAdapter
 from sqlalchemy import delete
 from sqlalchemy.engine.create import create_engine
 from sqlalchemy.exc import SQLAlchemyError
@@ -57,14 +58,17 @@ class Processor:
 
         # Get from COMPANY_LIST_URL
         try:
-            _resp = requests.get(
-                COMPANY_LIST_URL,
-                timeout=REQUEST_TIMEOUT,
-                retry=Retry(total=3, allowed_methods=["GET"]),
-            )
-            if _resp.status_code != 200:
-                raise Exception(f"status code={_resp.status_code}")
-            company_list_json = _resp.json()
+            with requests.Session() as session:
+                adapter = HTTPAdapter(max_retries=Retry(3, allowed_methods=["GET"]))
+                session.mount("http://", adapter)
+                session.mount("https://", adapter)
+                _resp = session.get(
+                    url=COMPANY_LIST_URL,
+                    timeout=REQUEST_TIMEOUT,
+                )
+                if _resp.status_code != 200:
+                    raise Exception(f"status code={_resp.status_code}")
+                company_list_json = _resp.json()
         except Exception:
             LOG.exception("Failed to get company list")
             return

--- a/batch/indexer_PublicInfo_PublicAccountList.py
+++ b/batch/indexer_PublicInfo_PublicAccountList.py
@@ -28,6 +28,7 @@ from sqlalchemy import delete
 from sqlalchemy.engine.create import create_engine
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm.session import Session
+from urllib3 import Retry
 
 from app.config import (
     DATABASE_URL,
@@ -56,7 +57,11 @@ class Processor:
 
         # Get data from PUBLIC_ACCOUNT_LIST_URL
         try:
-            _resp = requests.get(PUBLIC_ACCOUNT_LIST_URL, timeout=REQUEST_TIMEOUT)
+            _resp = requests.get(
+                PUBLIC_ACCOUNT_LIST_URL,
+                timeout=REQUEST_TIMEOUT,
+                retry=Retry(total=3, allowed_methods=["GET"]),
+            )
             if _resp.status_code != 200:
                 raise Exception(f"status code={_resp.status_code}")
             account_list_json = _resp.json()

--- a/batch/indexer_PublicInfo_PublicAccountList.py
+++ b/batch/indexer_PublicInfo_PublicAccountList.py
@@ -24,6 +24,7 @@ import time
 
 import requests
 from eth_utils import to_checksum_address
+from requests.adapters import HTTPAdapter
 from sqlalchemy import delete
 from sqlalchemy.engine.create import create_engine
 from sqlalchemy.exc import SQLAlchemyError
@@ -57,13 +58,16 @@ class Processor:
 
         # Get data from PUBLIC_ACCOUNT_LIST_URL
         try:
-            _resp = requests.get(
-                PUBLIC_ACCOUNT_LIST_URL,
-                timeout=REQUEST_TIMEOUT,
-                retry=Retry(total=3, allowed_methods=["GET"]),
-            )
-            if _resp.status_code != 200:
-                raise Exception(f"status code={_resp.status_code}")
+            with requests.Session() as session:
+                adapter = HTTPAdapter(max_retries=Retry(3, allowed_methods=["GET"]))
+                session.mount("http://", adapter)
+                session.mount("https://", adapter)
+                _resp = session.get(
+                    url=PUBLIC_ACCOUNT_LIST_URL,
+                    timeout=REQUEST_TIMEOUT,
+                )
+                if _resp.status_code != 200:
+                    raise Exception(f"status code={_resp.status_code}")
             account_list_json = _resp.json()
         except Exception:
             LOG.exception("Failed to get public account list")

--- a/batch/indexer_PublicInfo_TokenList.py
+++ b/batch/indexer_PublicInfo_TokenList.py
@@ -28,6 +28,7 @@ from sqlalchemy import delete
 from sqlalchemy.engine.create import create_engine
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm.session import Session
+from urllib3 import Retry
 
 from app.config import (
     DATABASE_URL,
@@ -56,7 +57,11 @@ class Processor:
 
         # Get from TOKEN_LIST_URL
         try:
-            _resp = requests.get(TOKEN_LIST_URL, timeout=REQUEST_TIMEOUT)
+            _resp = requests.get(
+                TOKEN_LIST_URL,
+                timeout=REQUEST_TIMEOUT,
+                retry=Retry(total=3, allowed_methods=["GET"]),
+            )
             if _resp.status_code != 200:
                 raise Exception(f"status code={_resp.status_code}")
             token_list_json = _resp.json()

--- a/batch/indexer_PublicInfo_TokenList.py
+++ b/batch/indexer_PublicInfo_TokenList.py
@@ -24,6 +24,7 @@ import time
 
 import requests
 from eth_utils import to_checksum_address
+from requests.adapters import HTTPAdapter
 from sqlalchemy import delete
 from sqlalchemy.engine.create import create_engine
 from sqlalchemy.exc import SQLAlchemyError
@@ -57,14 +58,17 @@ class Processor:
 
         # Get from TOKEN_LIST_URL
         try:
-            _resp = requests.get(
-                TOKEN_LIST_URL,
-                timeout=REQUEST_TIMEOUT,
-                retry=Retry(total=3, allowed_methods=["GET"]),
-            )
-            if _resp.status_code != 200:
-                raise Exception(f"status code={_resp.status_code}")
-            token_list_json = _resp.json()
+            with requests.Session() as session:
+                adapter = HTTPAdapter(max_retries=Retry(3, allowed_methods=["GET"]))
+                session.mount("http://", adapter)
+                session.mount("https://", adapter)
+                _resp = session.get(
+                    url=TOKEN_LIST_URL,
+                    timeout=REQUEST_TIMEOUT,
+                )
+                if _resp.status_code != 200:
+                    raise Exception(f"status code={_resp.status_code}")
+                token_list_json = _resp.json()
         except Exception:
             LOG.exception("Failed to get token list")
             return

--- a/tests/batch/indexer_Company_List_test.py
+++ b/tests/batch/indexer_Company_List_test.py
@@ -64,7 +64,7 @@ class TestProcessor:
 
     # <Normal_1>
     # 0 record
-    @mock.patch("requests.get")
+    @mock.patch("requests.Session.get")
     async def test_normal_1(self, mock_get, processor, session):
         # Prepare data
         _company = Company()
@@ -102,7 +102,7 @@ class TestProcessor:
 
     # <Normal_2>
     # 1 record
-    @mock.patch("requests.get")
+    @mock.patch("requests.Session.get")
     async def test_normal_2(self, mock_get, processor, session):
         # Prepare data
         _company = Company()
@@ -157,7 +157,7 @@ class TestProcessor:
 
     # <Normal_3>
     # 2 record
-    @mock.patch("requests.get")
+    @mock.patch("requests.Session.get")
     async def test_normal_3(self, mock_get, processor, session):
         # Prepare data
         _company = Company()
@@ -226,7 +226,7 @@ class TestProcessor:
     # Insert SKIP
     # type error
     # address
-    @mock.patch("requests.get")
+    @mock.patch("requests.Session.get")
     async def test_normal_4_1_1(self, mock_get, processor, session):
         # Prepare data
         _company = Company()
@@ -289,7 +289,7 @@ class TestProcessor:
     # Insert SKIP
     # type error
     # corporate_name
-    @mock.patch("requests.get")
+    @mock.patch("requests.Session.get")
     async def test_normal_4_1_2(self, mock_get, processor, session):
         # Prepare data
         _company = Company()
@@ -352,7 +352,7 @@ class TestProcessor:
     # Insert SKIP
     # type error
     # rsa_publickey
-    @mock.patch("requests.get")
+    @mock.patch("requests.Session.get")
     async def test_normal_4_1_3(self, mock_get, processor, session):
         # Prepare data
         _company = Company()
@@ -415,7 +415,7 @@ class TestProcessor:
     # Insert SKIP
     # type error
     # homepage
-    @mock.patch("requests.get")
+    @mock.patch("requests.Session.get")
     async def test_normal_4_1_4(self, mock_get, processor, session):
         # Prepare data
         _company = Company()
@@ -478,7 +478,7 @@ class TestProcessor:
     # Insert SKIP
     # required error
     # address
-    @mock.patch("requests.get")
+    @mock.patch("requests.Session.get")
     async def test_normal_4_2_1(self, mock_get, processor, session):
         # Prepare data
         _company = Company()
@@ -540,7 +540,7 @@ class TestProcessor:
     # Insert SKIP
     # required error
     # corporate_name
-    @mock.patch("requests.get")
+    @mock.patch("requests.Session.get")
     async def test_normal_4_2_2(self, mock_get, processor, session):
         # Prepare data
         _company = Company()
@@ -602,7 +602,7 @@ class TestProcessor:
     # Insert SKIP
     # required error
     # address
-    @mock.patch("requests.get")
+    @mock.patch("requests.Session.get")
     async def test_normal_4_2_3(self, mock_get, processor, session):
         # Prepare data
         _company = Company()
@@ -663,7 +663,7 @@ class TestProcessor:
     # <Normal_4_3>
     # Insert SKIP
     # invalid address error
-    @mock.patch("requests.get")
+    @mock.patch("requests.Session.get")
     async def test_normal_4_3(self, mock_get, processor, session):
         # Prepare data
         _company = Company()
@@ -725,7 +725,7 @@ class TestProcessor:
     # <Normal_5_1>
     # There are no differences from last time
     # -> Skip this cycle
-    @mock.patch("requests.get")
+    @mock.patch("requests.Session.get")
     async def test_normal_5_1(self, mock_get, processor, session, caplog):
         # Run target process: 1st time
         mock_get.side_effect = [
@@ -801,7 +801,7 @@ class TestProcessor:
 
     # <Normal_5_2>
     # There are differences from the previous cycle
-    @mock.patch("requests.get")
+    @mock.patch("requests.Session.get")
     async def test_normal_5_2(self, mock_get, processor, session, caplog):
         # Run target process: 1st time
         mock_get.side_effect = [
@@ -869,7 +869,7 @@ class TestProcessor:
     # API error
     # Connection error
     @mock.patch(
-        "requests.get",
+        "requests.Session.get",
         MagicMock(side_effect=requests.exceptions.ConnectionError),
     )
     async def test_error_1_1(self, processor, session):
@@ -906,7 +906,7 @@ class TestProcessor:
     # <Error_1_2>
     # API error
     # not succeed api
-    @mock.patch("requests.get")
+    @mock.patch("requests.Session.get")
     async def test_error_1_2(self, mock_get, processor, session):
         # Prepare data
         _company = Company()
@@ -944,7 +944,7 @@ class TestProcessor:
     # <Error_2>
     # not decode response
     @mock.patch(
-        "requests.get",
+        "requests.Session.get",
         MagicMock(side_effect=json.decoder.JSONDecodeError),
     )
     async def test_error_2(self, processor, session):
@@ -980,7 +980,7 @@ class TestProcessor:
 
     # <Error_3>
     # other error
-    @mock.patch("requests.get")
+    @mock.patch("requests.Session.get")
     async def test_error_3(self, mock_get, processor, session):
         # Prepare data
         _company = Company()

--- a/tests/batch/indexer_PublicInfo_PublicAccountList_test.py
+++ b/tests/batch/indexer_PublicInfo_PublicAccountList_test.py
@@ -72,7 +72,7 @@ class TestProcessor:
 
     # <Normal_1>
     # 0 record
-    @mock.patch("requests.get")
+    @mock.patch("requests.Session.get")
     async def test_normal_1(self, mock_get, processor, async_session):
         # Prepare data
         _account_list = PublicAccountList()
@@ -99,7 +99,7 @@ class TestProcessor:
 
     # <Normal_2>
     # Multiple records
-    @mock.patch("requests.get")
+    @mock.patch("requests.Session.get")
     async def test_normal_2(self, mock_get, processor, async_session):
         # Prepare data
         _account_list = PublicAccountList()
@@ -163,7 +163,7 @@ class TestProcessor:
     # <Normal_3_1>
     # There are no differences from last time
     # -> Skip this cycle
-    @mock.patch("requests.get")
+    @mock.patch("requests.Session.get")
     async def test_normal_3_1(self, mock_get, processor, async_session, caplog):
         # Run target process: 1st time
         mock_get.side_effect = [
@@ -244,7 +244,7 @@ class TestProcessor:
 
     # <Normal_3_2>
     # There are differences from last time
-    @mock.patch("requests.get")
+    @mock.patch("requests.Session.get")
     async def test_normal_3_2(self, mock_get, processor, async_session, caplog):
         # Run target process: 1st time
         mock_get.side_effect = [
@@ -317,7 +317,7 @@ class TestProcessor:
     # <Error_1_1>
     # API error: ConnectionError
     @mock.patch(
-        "requests.get",
+        "requests.Session.get",
         MagicMock(side_effect=requests.exceptions.ConnectionError),
     )
     async def test_error_1_1(self, processor, async_session):
@@ -356,7 +356,7 @@ class TestProcessor:
 
     # <Error_1_2>
     # API error: Not succeed request
-    @mock.patch("requests.get")
+    @mock.patch("requests.Session.get")
     async def test_error_1_2(self, mock_get, processor, async_session):
         # Prepare data
         _account_list = PublicAccountList()
@@ -397,7 +397,7 @@ class TestProcessor:
     # <Error_1_3>
     # API error: JSONDecodeError
     @mock.patch(
-        "requests.get",
+        "requests.Session.get",
         MagicMock(side_effect=json.decoder.JSONDecodeError),
     )
     async def test_error_1_3(self, processor, async_session):
@@ -437,7 +437,7 @@ class TestProcessor:
     # <Error_2>
     # Invalid type error
     # -> Skip processing
-    @mock.patch("requests.get")
+    @mock.patch("requests.Session.get")
     @pytest.mark.parametrize(
         "invalid_record",
         [
@@ -522,7 +522,7 @@ class TestProcessor:
 
     # <Error_3>
     # Other error
-    @mock.patch("requests.get")
+    @mock.patch("requests.Session.get")
     async def test_error_3(self, mock_get, processor, async_session):
         # Mock
         mock_get.side_effect = [

--- a/tests/batch/indexer_PublicInfo_TokenList_test.py
+++ b/tests/batch/indexer_PublicInfo_TokenList_test.py
@@ -70,7 +70,7 @@ class TestProcessor:
 
     # <Normal_1>
     # 0 record
-    @mock.patch("requests.get")
+    @mock.patch("requests.Session.get")
     async def test_normal_1(self, mock_get, processor, async_session):
         # Prepare data
         _token_list_item = TokenList()
@@ -110,7 +110,7 @@ class TestProcessor:
 
     # <Normal_2>
     # 1 record
-    @mock.patch("requests.get")
+    @mock.patch("requests.Session.get")
     async def test_normal_2(self, mock_get, processor, async_session):
         # Prepare data
         _token_list_item = TokenList()
@@ -165,7 +165,7 @@ class TestProcessor:
 
     # <Normal_3>
     # 2 record
-    @mock.patch("requests.get")
+    @mock.patch("requests.Session.get")
     async def test_normal_3(self, mock_get, processor, async_session):
         # Prepare data
         _token_list_item = TokenList()
@@ -231,7 +231,7 @@ class TestProcessor:
     # <Normal_4_1>
     # There are no differences from last time
     # -> Skip this cycle
-    @mock.patch("requests.get")
+    @mock.patch("requests.Session.get")
     async def test_normal_4_1(self, mock_get, processor, async_session, caplog):
         # Run target process: 1st time
         mock_get.side_effect = [
@@ -302,7 +302,7 @@ class TestProcessor:
 
     # <Normal_4_2>
     # There are differences from the previous cycle
-    @mock.patch("requests.get")
+    @mock.patch("requests.Session.get")
     async def test_normal_4_2(self, mock_get, processor, async_session, caplog):
         # Run target process: 1st time
         mock_get.side_effect = [
@@ -368,7 +368,7 @@ class TestProcessor:
     # <Error_1_1>
     # API error: ConnectionError
     @mock.patch(
-        "requests.get",
+        "requests.Session.get",
         MagicMock(side_effect=requests.exceptions.ConnectionError),
     )
     async def test_error_1_1(self, processor, async_session):
@@ -394,7 +394,7 @@ class TestProcessor:
 
     # <Error_1_2>
     # API error: Not succeed request
-    @mock.patch("requests.get")
+    @mock.patch("requests.Session.get")
     async def test_error_1_2(self, mock_get, processor, async_session):
         # Prepare data
         _token_list_item = TokenList()
@@ -422,7 +422,7 @@ class TestProcessor:
     # <Error_1_3>
     # API error: JSONDecodeError
     @mock.patch(
-        "requests.get",
+        "requests.Session.get",
         MagicMock(side_effect=json.decoder.JSONDecodeError),
     )
     async def test_error_1_3(self, processor, async_session):
@@ -449,7 +449,7 @@ class TestProcessor:
     # <Error_2>
     # Invalid type error
     # -> Skip processing
-    @mock.patch("requests.get")
+    @mock.patch("requests.Session.get")
     @pytest.mark.parametrize(
         "invalid_record",
         [
@@ -554,7 +554,7 @@ class TestProcessor:
 
     # <Error_3>
     # Other error
-    @mock.patch("requests.get")
+    @mock.patch("requests.Session.get")
     async def test_error_3(self, mock_get, processor, async_session):
         # Prepare data
         _token_list_item = TokenList()


### PR DESCRIPTION
## 📌 Description

This pull request refactors the way HTTP requests are made in the batch indexer modules to improve reliability and error handling. The main change is switching from direct `requests.get` calls to using a `requests.Session` with a configured `HTTPAdapter` and retry logic. Corresponding updates have been made to the test files to mock `requests.Session.get` instead of `requests.get`.


## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
- Close #1674 

## 🔄 Changes

**HTTP request reliability improvements:**

* Updated `batch/indexer_Company_List.py`, `batch/indexer_PublicInfo_PublicAccountList.py`, and `batch/indexer_PublicInfo_TokenList.py` to use `requests.Session` with an `HTTPAdapter` and `Retry` for GET requests, enabling automatic retries on failure. [[1]](diffhunk://#diff-2359c2c901c0bf63f535536230a813892d80f729b49e09f624146375f560efccR27-R32) [[2]](diffhunk://#diff-2359c2c901c0bf63f535536230a813892d80f729b49e09f624146375f560efccL59-R68) [[3]](diffhunk://#diff-048a0c2d5f84b4f4010d4f6c7975b0ced289c942ca3cca76aa6af4e11eb3b5c5R27-R32) [[4]](diffhunk://#diff-048a0c2d5f84b4f4010d4f6c7975b0ced289c942ca3cca76aa6af4e11eb3b5c5L59-R68) [[5]](diffhunk://#diff-a7a131314605411c18f6ff01bcfed2c6a9e586af183a697f77cad0bf8fb0bb04R27-R32) [[6]](diffhunk://#diff-a7a131314605411c18f6ff01bcfed2c6a9e586af183a697f77cad0bf8fb0bb04L59-R68)

**Test updates for new request pattern:**

* Changed all relevant tests in `tests/batch/indexer_Company_List_test.py`, `tests/batch/indexer_PublicInfo_PublicAccountList_test.py`, and `tests/batch/indexer_PublicInfo_TokenList_test.py` to mock `requests.Session.get` instead of `requests.get`, ensuring tests align with the new request implementation. [[1]](diffhunk://#diff-35d97a18d655dae98d38cc4cdc3ea5d7c43a531d91dea3bef6543adafab9de46L67-R67) [[2]](diffhunk://#diff-35d97a18d655dae98d38cc4cdc3ea5d7c43a531d91dea3bef6543adafab9de46L105-R105) [[3]](diffhunk://#diff-35d97a18d655dae98d38cc4cdc3ea5d7c43a531d91dea3bef6543adafab9de46L160-R160) [[4]](diffhunk://#diff-35d97a18d655dae98d38cc4cdc3ea5d7c43a531d91dea3bef6543adafab9de46L229-R229) [[5]](diffhunk://#diff-35d97a18d655dae98d38cc4cdc3ea5d7c43a531d91dea3bef6543adafab9de46L292-R292) [[6]](diffhunk://#diff-35d97a18d655dae98d38cc4cdc3ea5d7c43a531d91dea3bef6543adafab9de46L355-R355) [[7]](diffhunk://#diff-35d97a18d655dae98d38cc4cdc3ea5d7c43a531d91dea3bef6543adafab9de46L418-R418) [[8]](diffhunk://#diff-35d97a18d655dae98d38cc4cdc3ea5d7c43a531d91dea3bef6543adafab9de46L481-R481) [[9]](diffhunk://#diff-35d97a18d655dae98d38cc4cdc3ea5d7c43a531d91dea3bef6543adafab9de46L543-R543) [[10]](diffhunk://#diff-35d97a18d655dae98d38cc4cdc3ea5d7c43a531d91dea3bef6543adafab9de46L605-R605) [[11]](diffhunk://#diff-35d97a18d655dae98d38cc4cdc3ea5d7c43a531d91dea3bef6543adafab9de46L666-R666) [[12]](diffhunk://#diff-35d97a18d655dae98d38cc4cdc3ea5d7c43a531d91dea3bef6543adafab9de46L728-R728) [[13]](diffhunk://#diff-35d97a18d655dae98d38cc4cdc3ea5d7c43a531d91dea3bef6543adafab9de46L804-R804) [[14]](diffhunk://#diff-35d97a18d655dae98d38cc4cdc3ea5d7c43a531d91dea3bef6543adafab9de46L872-R872) [[15]](diffhunk://#diff-35d97a18d655dae98d38cc4cdc3ea5d7c43a531d91dea3bef6543adafab9de46L909-R909) [[16]](diffhunk://#diff-35d97a18d655dae98d38cc4cdc3ea5d7c43a531d91dea3bef6543adafab9de46L947-R947) [[17]](diffhunk://#diff-35d97a18d655dae98d38cc4cdc3ea5d7c43a531d91dea3bef6543adafab9de46L983-R983) [[18]](diffhunk://#diff-d3686b59ddf1f55f1f840d62344f0ac19c9f4b01620f515326e4d8e382c508ccL75-R75) [[19]](diffhunk://#diff-d3686b59ddf1f55f1f840d62344f0ac19c9f4b01620f515326e4d8e382c508ccL102-R102) [[20]](diffhunk://#diff-d3686b59ddf1f55f1f840d62344f0ac19c9f4b01620f515326e4d8e382c508ccL166-R166) [[21]](diffhunk://#diff-d3686b59ddf1f55f1f840d62344f0ac19c9f4b01620f515326e4d8e382c508ccL247-R247) [[22]](diffhunk://#diff-d3686b59ddf1f55f1f840d62344f0ac19c9f4b01620f515326e4d8e382c508ccL320-R320) [[23]](diffhunk://#diff-d3686b59ddf1f55f1f840d62344f0ac19c9f4b01620f515326e4d8e382c508ccL359-R359) [[24]](diffhunk://#diff-d3686b59ddf1f55f1f840d62344f0ac19c9f4b01620f515326e4d8e382c508ccL400-R400) [[25]](diffhunk://#diff-d3686b59ddf1f55f1f840d62344f0ac19c9f4b01620f515326e4d8e382c508ccL440-R440) [[26]](diffhunk://#diff-d3686b59ddf1f55f1f840d62344f0ac19c9f4b01620f515326e4d8e382c508ccL525-R525) [[27]](diffhunk://#diff-8902d87446e2f39d2137548e110baf81fa2e440e9861a8273e70e79a4b70eac9L73-R73) [[28]](diffhunk://#diff-8902d87446e2f39d2137548e110baf81fa2e440e9861a8273e70e79a4b70eac9L113-R113)

## 📌 Checklist

- [x] I have added tests where necessary.
- [-] I have updated the documentation where necessary.
