### PR TITLE
fix: Add type annotations to fix pyright type errors in `tests/batch/`

### DIFF
--- a/app/model/db/idx_block_data.py
+++ b/app/model/db/idx_block_data.py
@@ -50,7 +50,7 @@ class IDXBlockData(Base):
     # Other data
     hash: Mapped[str] = mapped_column(String(66), nullable=False, index=True)
     size: Mapped[int | None] = mapped_column(Integer)
-    transactions: Mapped[dict | None] = mapped_column(JSON)
+    transactions: Mapped[list[str] | None] = mapped_column(JSON)
 
     FIELDS = {
         "number": int,

--- a/app/model/db/idx_lock_unlock.py
+++ b/app/model/db/idx_lock_unlock.py
@@ -78,7 +78,7 @@ class IDXLock(Base):
     # Locked Amount
     value: Mapped[int] = mapped_column(BigInteger, index=True, nullable=False)
     # Data(LockDataMessage)
-    data: Mapped[dict] = mapped_column(JSON, nullable=False)
+    data: Mapped[dict[str, object]] = mapped_column(JSON, nullable=False)
     # Lock Datetime
     block_timestamp: Mapped[datetime] = mapped_column(
         DateTime, index=True, nullable=False
@@ -158,7 +158,7 @@ class IDXUnlock(Base):
     # Locked Amount
     value: Mapped[int] = mapped_column(BigInteger, index=True, nullable=False)
     # Data(UnlockDataMessage)
-    data: Mapped[dict] = mapped_column(JSON, nullable=False)
+    data: Mapped[dict[str, object]] = mapped_column(JSON, nullable=False)
     # Lock Datetime
     block_timestamp: Mapped[datetime] = mapped_column(
         DateTime, index=True, nullable=False

--- a/app/model/db/idx_token.py
+++ b/app/model/db/idx_token.py
@@ -242,7 +242,7 @@ class IDXShareToken(TokenBase):
     is_canceled: Mapped[int | None] = mapped_column(Boolean)
     # Dividend Information(JSON)
     # NOTE: Short-term cache required
-    dividend_information: Mapped[dict | None] = mapped_column(JSON)
+    dividend_information: Mapped[dict[str, object] | None] = mapped_column(JSON)
 
     FIELDS = {
         "personal_info_address": str,

--- a/app/model/db/idx_transfer.py
+++ b/app/model/db/idx_transfer.py
@@ -77,7 +77,7 @@ class IDXTransfer(Base):
     #     => None
     #   source_event = "Unlock", "ForceUnlock", "ForceChangeLockedAccount"
     #     =>  DataMessage
-    data: Mapped[dict | None] = mapped_column(JSON)
+    data: Mapped[dict[str, object] | None] = mapped_column(JSON)
     # Message
     #   source_event = "Transfer", "Reallocation"
     #     => None

--- a/app/model/db/notification.py
+++ b/app/model/db/notification.py
@@ -118,9 +118,9 @@ class Notification(Base):
     block_timestamp: Mapped[datetime | None] = mapped_column(DateTime)
 
     # 通知イベントの内容
-    args: Mapped[dict | None] = mapped_column(JSON)
+    args: Mapped[dict[str, object] | None] = mapped_column(JSON)
     # 通知のメタデータ（通知イベントには入っていないが、取りたい情報。トークン名など）
-    metainfo: Mapped[dict | None] = mapped_column(JSON)
+    metainfo: Mapped[dict[str, object] | None] = mapped_column(JSON)
 
     if engine.name == "mysql":
         # NOTE:MySQLではDatetime型で小数秒桁を指定しない場合、整数秒しか保存されない

--- a/batch/indexer_Position_Bond.py
+++ b/batch/indexer_Position_Bond.py
@@ -22,7 +22,7 @@ import json
 import sys
 from datetime import datetime, timedelta, timezone
 from itertools import groupby
-from typing import List, Literal, Optional, Sequence
+from typing import List, Literal, Mapping, Optional, Sequence
 
 from eth_utils import to_checksum_address
 from sqlalchemy import select
@@ -1926,8 +1926,9 @@ class Processor:
 
     @staticmethod
     def remove_duplicate_event_by_token_account_desc(
-        events: List, account_keys: List[str]
-    ) -> List[str]:
+        events: Sequence[Mapping[str, Mapping[str, str]]],
+        account_keys: Sequence[str],
+    ) -> list[str]:
         """Remove duplicate account from event list.
         Events that have same account key will be removed.
 

--- a/batch/indexer_Position_Coupon.py
+++ b/batch/indexer_Position_Coupon.py
@@ -20,7 +20,7 @@ SPDX-License-Identifier: Apache-2.0
 import asyncio
 import sys
 from itertools import groupby
-from typing import List, Optional, Sequence
+from typing import List, Mapping, Optional, Sequence
 
 from eth_utils import to_checksum_address
 from sqlalchemy import select
@@ -960,8 +960,9 @@ class Processor:
 
     @staticmethod
     def remove_duplicate_event_by_token_account_desc(
-        events: List, account_keys: List[str]
-    ) -> List[str]:
+        events: Sequence[Mapping[str, Mapping[str, str]]],
+        account_keys: Sequence[str],
+    ) -> list[str]:
         """Remove duplicate account from event list.
         Events that have same account key will be removed.
 

--- a/batch/indexer_Position_Membership.py
+++ b/batch/indexer_Position_Membership.py
@@ -20,7 +20,7 @@ SPDX-License-Identifier: Apache-2.0
 import asyncio
 import sys
 from itertools import groupby
-from typing import List, Optional, Sequence
+from typing import List, Mapping, Optional, Sequence
 
 from eth_utils import to_checksum_address
 from sqlalchemy import select
@@ -924,8 +924,9 @@ class Processor:
 
     @staticmethod
     def remove_duplicate_event_by_token_account_desc(
-        events: List, account_keys: List[str]
-    ) -> List[str]:
+        events: Sequence[Mapping[str, Mapping[str, str]]],
+        account_keys: Sequence[str],
+    ) -> list[str]:
         """Remove duplicate account from event list.
         Events that have same account key will be removed.
 

--- a/batch/indexer_Position_Share.py
+++ b/batch/indexer_Position_Share.py
@@ -22,7 +22,7 @@ import json
 import sys
 from datetime import datetime, timedelta, timezone
 from itertools import groupby
-from typing import List, Literal, Optional, Sequence
+from typing import List, Literal, Mapping, Optional, Sequence
 
 from eth_utils import to_checksum_address
 from sqlalchemy import select
@@ -1926,8 +1926,9 @@ class Processor:
 
     @staticmethod
     def remove_duplicate_event_by_token_account_desc(
-        events: List, account_keys: List[str]
-    ) -> List[str]:
+        events: Sequence[Mapping[str, Mapping[str, str]]],
+        account_keys: Sequence[str],
+    ) -> list[str]:
         """Remove duplicate account from event list.
         Events that have same account key will be removed.
 

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -2,9 +2,7 @@
     "include": [
         "logger.py",
         "server.py",
-        "tests/app/",
-        "tests/utils/",
-        "tests/*.py",
+        "tests/",
     ],
     "exclude": [],
     "typeCheckingMode": "strict"

--- a/tests/app/token_TokenHoldersCollectionId_test.py
+++ b/tests/app/token_TokenHoldersCollectionId_test.py
@@ -47,14 +47,9 @@ from tests.contract_modules import (
 from tests.types import DeployedContract, SharedContract, UnitTestAccount
 
 
-@pytest.fixture(scope="session")
-def test_module(shared_contract: SharedContract) -> type[Processor]:
-    return Processor
-
-
 @pytest.fixture(scope="function")
-def processor(test_module: type[Processor], session: Session) -> Processor:
-    return test_module()
+def processor() -> Processor:
+    return Processor()
 
 
 class TestTokenTokenHoldersCollectionId:

--- a/tests/app/token_TokenHoldersCollection_test.py
+++ b/tests/app/token_TokenHoldersCollection_test.py
@@ -46,14 +46,9 @@ from tests.contract_modules import (
 from tests.types import DeployedContract, SharedContract, UnitTestAccount
 
 
-@pytest.fixture(scope="session")
-def test_module(shared_contract: SharedContract) -> type[Processor]:
-    return Processor
-
-
 @pytest.fixture(scope="function")
-def processor(test_module: type[Processor], session: Session) -> Processor:
-    return test_module()
+def processor() -> Processor:
+    return Processor()
 
 
 class TestTokenTokenHoldersCollection:

--- a/tests/batch/indexer_Company_List_test.py
+++ b/tests/batch/indexer_Company_List_test.py
@@ -26,13 +26,14 @@ from unittest.mock import MagicMock
 import pytest
 import requests
 from sqlalchemy import select
+from sqlalchemy.orm import Session
 
 from app.model.db import Company
 from batch.indexer_Company_List import LOG, Processor
 
 
 @pytest.fixture(scope="function")
-def processor(session):
+def processor():
     return Processor()
 
 
@@ -66,7 +67,9 @@ class TestProcessor:
     # <Normal_1>
     # 0 record
     @mock.patch("requests.Session.get")
-    async def test_normal_1(self, mock_get, processor, session):
+    async def test_normal_1(
+        self, mock_get: mock.MagicMock, processor: Processor, session: Session
+    ):
         # Prepare data
         _company = Company()
         _company.address = "0x01"
@@ -104,7 +107,9 @@ class TestProcessor:
     # <Normal_2>
     # 1 record
     @mock.patch("requests.Session.get")
-    async def test_normal_2(self, mock_get, processor, session):
+    async def test_normal_2(
+        self, mock_get: mock.MagicMock, processor: Processor, session: Session
+    ):
         # Prepare data
         _company = Company()
         _company.address = "0x01"
@@ -159,7 +164,9 @@ class TestProcessor:
     # <Normal_3>
     # 2 record
     @mock.patch("requests.Session.get")
-    async def test_normal_3(self, mock_get, processor, session):
+    async def test_normal_3(
+        self, mock_get: mock.MagicMock, processor: Processor, session: Session
+    ):
         # Prepare data
         _company = Company()
         _company.address = "0x01"
@@ -228,7 +235,9 @@ class TestProcessor:
     # type error
     # address
     @mock.patch("requests.Session.get")
-    async def test_normal_4_1_1(self, mock_get, processor, session):
+    async def test_normal_4_1_1(
+        self, mock_get: mock.MagicMock, processor: Processor, session: Session
+    ):
         # Prepare data
         _company = Company()
         _company.address = "0x01"
@@ -291,7 +300,9 @@ class TestProcessor:
     # type error
     # corporate_name
     @mock.patch("requests.Session.get")
-    async def test_normal_4_1_2(self, mock_get, processor, session):
+    async def test_normal_4_1_2(
+        self, mock_get: mock.MagicMock, processor: Processor, session: Session
+    ):
         # Prepare data
         _company = Company()
         _company.address = "0x01"
@@ -354,7 +365,9 @@ class TestProcessor:
     # type error
     # rsa_publickey
     @mock.patch("requests.Session.get")
-    async def test_normal_4_1_3(self, mock_get, processor, session):
+    async def test_normal_4_1_3(
+        self, mock_get: mock.MagicMock, processor: Processor, session: Session
+    ):
         # Prepare data
         _company = Company()
         _company.address = "0x01"
@@ -417,7 +430,9 @@ class TestProcessor:
     # type error
     # homepage
     @mock.patch("requests.Session.get")
-    async def test_normal_4_1_4(self, mock_get, processor, session):
+    async def test_normal_4_1_4(
+        self, mock_get: mock.MagicMock, processor: Processor, session: Session
+    ):
         # Prepare data
         _company = Company()
         _company.address = "0x01"
@@ -480,7 +495,9 @@ class TestProcessor:
     # required error
     # address
     @mock.patch("requests.Session.get")
-    async def test_normal_4_2_1(self, mock_get, processor, session):
+    async def test_normal_4_2_1(
+        self, mock_get: mock.MagicMock, processor: Processor, session: Session
+    ):
         # Prepare data
         _company = Company()
         _company.address = "0x01"
@@ -542,7 +559,9 @@ class TestProcessor:
     # required error
     # corporate_name
     @mock.patch("requests.Session.get")
-    async def test_normal_4_2_2(self, mock_get, processor, session):
+    async def test_normal_4_2_2(
+        self, mock_get: mock.MagicMock, processor: Processor, session: Session
+    ):
         # Prepare data
         _company = Company()
         _company.address = "0x01"
@@ -604,7 +623,9 @@ class TestProcessor:
     # required error
     # address
     @mock.patch("requests.Session.get")
-    async def test_normal_4_2_3(self, mock_get, processor, session):
+    async def test_normal_4_2_3(
+        self, mock_get: mock.MagicMock, processor: Processor, session: Session
+    ):
         # Prepare data
         _company = Company()
         _company.address = "0x01"
@@ -665,7 +686,9 @@ class TestProcessor:
     # Insert SKIP
     # invalid address error
     @mock.patch("requests.Session.get")
-    async def test_normal_4_3(self, mock_get, processor, session):
+    async def test_normal_4_3(
+        self, mock_get: mock.MagicMock, processor: Processor, session: Session
+    ):
         # Prepare data
         _company = Company()
         _company.address = "0x01"
@@ -727,7 +750,13 @@ class TestProcessor:
     # There are no differences from last time
     # -> Skip this cycle
     @mock.patch("requests.Session.get")
-    async def test_normal_5_1(self, mock_get, processor, session, caplog):
+    async def test_normal_5_1(
+        self,
+        mock_get: mock.MagicMock,
+        processor: Processor,
+        session: Session,
+        caplog: pytest.LogCaptureFixture,
+    ):
         # Run target process: 1st time
         mock_get.side_effect = [
             MockResponse(
@@ -803,7 +832,13 @@ class TestProcessor:
     # <Normal_5_2>
     # There are differences from the previous cycle
     @mock.patch("requests.Session.get")
-    async def test_normal_5_2(self, mock_get, processor, session, caplog):
+    async def test_normal_5_2(
+        self,
+        mock_get: mock.MagicMock,
+        processor: Processor,
+        session: Session,
+        caplog: pytest.LogCaptureFixture,
+    ):
         # Run target process: 1st time
         mock_get.side_effect = [
             MockResponse(
@@ -865,7 +900,9 @@ class TestProcessor:
     # <Normal_6_1>
     # trustee情報あり
     @mock.patch("requests.Session.get")
-    async def test_normal_6_1(self, mock_get, processor, session):
+    async def test_normal_6_1(
+        self, mock_get: mock.MagicMock, processor: Processor, session: Session
+    ):
         # Prepare data
         _company = Company()
         _company.address = "0x01"
@@ -928,7 +965,9 @@ class TestProcessor:
     # <Normal_6_2>
     # trustee情報不正 -> Insert SKIP
     @mock.patch("requests.Session.get")
-    async def test_normal_6_2(self, mock_get, processor, session):
+    async def test_normal_6_2(
+        self, mock_get: mock.MagicMock, processor: Processor, session: Session
+    ):
         # Prepare data
         _company = Company()
         _company.address = "0x01"
@@ -1006,7 +1045,7 @@ class TestProcessor:
         "requests.Session.get",
         MagicMock(side_effect=requests.exceptions.ConnectionError),
     )
-    async def test_error_1_1(self, processor, session):
+    async def test_error_1_1(self, processor: Processor, session: Session):
         # Prepare data
         _company = Company()
         _company.address = "0x01"
@@ -1041,7 +1080,9 @@ class TestProcessor:
     # API error
     # not succeed api
     @mock.patch("requests.Session.get")
-    async def test_error_1_2(self, mock_get, processor, session):
+    async def test_error_1_2(
+        self, mock_get: mock.MagicMock, processor: Processor, session: Session
+    ):
         # Prepare data
         _company = Company()
         _company.address = "0x01"
@@ -1081,7 +1122,7 @@ class TestProcessor:
         "requests.Session.get",
         MagicMock(side_effect=json.decoder.JSONDecodeError),
     )
-    async def test_error_2(self, processor, session):
+    async def test_error_2(self, processor: Processor, session: Session):
         # Prepare data
         _company = Company()
         _company.address = "0x01"
@@ -1115,7 +1156,9 @@ class TestProcessor:
     # <Error_3>
     # other error
     @mock.patch("requests.Session.get")
-    async def test_error_3(self, mock_get, processor, session):
+    async def test_error_3(
+        self, mock_get: mock.MagicMock, processor: Processor, session: Session
+    ):
         # Prepare data
         _company = Company()
         _company.address = "0x01"

--- a/tests/batch/indexer_PublicInfo_PublicAccountList_test.py
+++ b/tests/batch/indexer_PublicInfo_PublicAccountList_test.py
@@ -26,13 +26,14 @@ from unittest.mock import MagicMock
 import pytest
 import requests
 from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.model.db import PublicAccountList
 from batch.indexer_PublicInfo_PublicAccountList import LOG, Processor
 
 
 @pytest.fixture(scope="function")
-def processor(session):
+def processor():
     return Processor()
 
 
@@ -73,7 +74,12 @@ class TestProcessor:
     # <Normal_1>
     # 0 record
     @mock.patch("requests.Session.get")
-    async def test_normal_1(self, mock_get, processor, async_session):
+    async def test_normal_1(
+        self,
+        mock_get: mock.MagicMock,
+        processor: Processor,
+        async_session: AsyncSession,
+    ):
         # Prepare data
         _account_list = PublicAccountList()
         _account_list.key_manager = self.test_key_manager_1
@@ -100,7 +106,12 @@ class TestProcessor:
     # <Normal_2>
     # Multiple records
     @mock.patch("requests.Session.get")
-    async def test_normal_2(self, mock_get, processor, async_session):
+    async def test_normal_2(
+        self,
+        mock_get: mock.MagicMock,
+        processor: Processor,
+        async_session: AsyncSession,
+    ):
         # Prepare data
         _account_list = PublicAccountList()
         _account_list.key_manager = self.test_key_manager_1
@@ -164,7 +175,13 @@ class TestProcessor:
     # There are no differences from last time
     # -> Skip this cycle
     @mock.patch("requests.Session.get")
-    async def test_normal_3_1(self, mock_get, processor, async_session, caplog):
+    async def test_normal_3_1(
+        self,
+        mock_get: mock.MagicMock,
+        processor: Processor,
+        async_session: AsyncSession,
+        caplog: pytest.LogCaptureFixture,
+    ):
         # Run target process: 1st time
         mock_get.side_effect = [
             MockResponse(
@@ -245,7 +262,13 @@ class TestProcessor:
     # <Normal_3_2>
     # There are differences from last time
     @mock.patch("requests.Session.get")
-    async def test_normal_3_2(self, mock_get, processor, async_session, caplog):
+    async def test_normal_3_2(
+        self,
+        mock_get: mock.MagicMock,
+        processor: Processor,
+        async_session: AsyncSession,
+        caplog: pytest.LogCaptureFixture,
+    ):
         # Run target process: 1st time
         mock_get.side_effect = [
             MockResponse(
@@ -320,7 +343,7 @@ class TestProcessor:
         "requests.Session.get",
         MagicMock(side_effect=requests.exceptions.ConnectionError),
     )
-    async def test_error_1_1(self, processor, async_session):
+    async def test_error_1_1(self, processor: Processor, async_session: AsyncSession):
         # Prepare data
         _account_list = PublicAccountList()
         _account_list.key_manager = self.test_key_manager_1
@@ -357,7 +380,12 @@ class TestProcessor:
     # <Error_1_2>
     # API error: Not succeed request
     @mock.patch("requests.Session.get")
-    async def test_error_1_2(self, mock_get, processor, async_session):
+    async def test_error_1_2(
+        self,
+        mock_get: mock.MagicMock,
+        processor: Processor,
+        async_session: AsyncSession,
+    ):
         # Prepare data
         _account_list = PublicAccountList()
         _account_list.key_manager = self.test_key_manager_1
@@ -400,7 +428,7 @@ class TestProcessor:
         "requests.Session.get",
         MagicMock(side_effect=json.decoder.JSONDecodeError),
     )
-    async def test_error_1_3(self, processor, async_session):
+    async def test_error_1_3(self, processor: Processor, async_session: AsyncSession):
         # Prepare data
         _account_list = PublicAccountList()
         _account_list.key_manager = self.test_key_manager_1
@@ -493,7 +521,13 @@ class TestProcessor:
             },  # Missing required fields
         ],
     )
-    async def test_error_2(self, mock_get, processor, async_session, invalid_record):
+    async def test_error_2(
+        self,
+        mock_get: mock.MagicMock,
+        processor: Processor,
+        async_session: AsyncSession,
+        invalid_record: dict[str, object],
+    ):
         # Prepare data
         _account_list = PublicAccountList()
         _account_list.key_manager = self.test_key_manager_1
@@ -523,7 +557,12 @@ class TestProcessor:
     # <Error_3>
     # Other error
     @mock.patch("requests.Session.get")
-    async def test_error_3(self, mock_get, processor, async_session):
+    async def test_error_3(
+        self,
+        mock_get: mock.MagicMock,
+        processor: Processor,
+        async_session: AsyncSession,
+    ):
         # Mock
         mock_get.side_effect = [
             MockResponse(

--- a/tests/batch/indexer_PublicInfo_TokenList_test.py
+++ b/tests/batch/indexer_PublicInfo_TokenList_test.py
@@ -27,13 +27,14 @@ import pytest
 import requests
 from eth_utils.address import to_checksum_address
 from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.model.db import TokenList
 from batch.indexer_PublicInfo_TokenList import LOG, Processor
 
 
 @pytest.fixture(scope="function")
-def processor(session):
+def processor():
     return Processor()
 
 
@@ -74,7 +75,12 @@ class TestProcessor:
     # <Normal_1>
     # 0 record
     @mock.patch("requests.Session.get")
-    async def test_normal_1(self, mock_get, processor, async_session):
+    async def test_normal_1(
+        self,
+        mock_get: mock.MagicMock,
+        processor: Processor,
+        async_session: AsyncSession,
+    ):
         # Prepare data
         _token_list_item = TokenList()
         _token_list_item.token_address = self.token_address_1
@@ -114,7 +120,12 @@ class TestProcessor:
     # <Normal_2>
     # 1 record
     @mock.patch("requests.Session.get")
-    async def test_normal_2(self, mock_get, processor, async_session):
+    async def test_normal_2(
+        self,
+        mock_get: mock.MagicMock,
+        processor: Processor,
+        async_session: AsyncSession,
+    ):
         # Prepare data
         _token_list_item = TokenList()
         _token_list_item.token_address = self.token_address_1
@@ -169,7 +180,12 @@ class TestProcessor:
     # <Normal_3>
     # 2 record
     @mock.patch("requests.Session.get")
-    async def test_normal_3(self, mock_get, processor, async_session):
+    async def test_normal_3(
+        self,
+        mock_get: mock.MagicMock,
+        processor: Processor,
+        async_session: AsyncSession,
+    ):
         # Prepare data
         _token_list_item = TokenList()
         _token_list_item.token_address = self.token_address_1
@@ -234,7 +250,12 @@ class TestProcessor:
     # <Normal_issuer_address>
     # issuer_address is stored as checksum address
     @mock.patch("requests.Session.get")
-    async def test_normal_issuer_address(self, mock_get, processor, async_session):
+    async def test_normal_issuer_address(
+        self,
+        mock_get: mock.MagicMock,
+        processor: Processor,
+        async_session: AsyncSession,
+    ):
         # Prepare data
         _token_list_item = TokenList()
         _token_list_item.token_address = self.token_address_1
@@ -288,7 +309,13 @@ class TestProcessor:
     # There are no differences from last time
     # -> Skip this cycle
     @mock.patch("requests.Session.get")
-    async def test_normal_4_1(self, mock_get, processor, async_session, caplog):
+    async def test_normal_4_1(
+        self,
+        mock_get: mock.MagicMock,
+        processor: Processor,
+        async_session: AsyncSession,
+        caplog: pytest.LogCaptureFixture,
+    ):
         # Run target process: 1st time
         mock_get.side_effect = [
             MockResponse(
@@ -359,7 +386,13 @@ class TestProcessor:
     # <Normal_4_2>
     # There are differences from the previous cycle
     @mock.patch("requests.Session.get")
-    async def test_normal_4_2(self, mock_get, processor, async_session, caplog):
+    async def test_normal_4_2(
+        self,
+        mock_get: mock.MagicMock,
+        processor: Processor,
+        async_session: AsyncSession,
+        caplog: pytest.LogCaptureFixture,
+    ):
         # Run target process: 1st time
         mock_get.side_effect = [
             MockResponse(
@@ -427,7 +460,7 @@ class TestProcessor:
         "requests.Session.get",
         MagicMock(side_effect=requests.exceptions.ConnectionError),
     )
-    async def test_error_1_1(self, processor, async_session):
+    async def test_error_1_1(self, processor: Processor, async_session: AsyncSession):
         # Prepare data
         _token_list_item = TokenList()
         _token_list_item.token_address = self.token_address_1
@@ -451,7 +484,12 @@ class TestProcessor:
     # <Error_1_2>
     # API error: Not succeed request
     @mock.patch("requests.Session.get")
-    async def test_error_1_2(self, mock_get, processor, async_session):
+    async def test_error_1_2(
+        self,
+        mock_get: mock.MagicMock,
+        processor: Processor,
+        async_session: AsyncSession,
+    ):
         # Prepare data
         _token_list_item = TokenList()
         _token_list_item.token_address = self.token_address_1
@@ -481,7 +519,7 @@ class TestProcessor:
         "requests.Session.get",
         MagicMock(side_effect=json.decoder.JSONDecodeError),
     )
-    async def test_error_1_3(self, processor, async_session):
+    async def test_error_1_3(self, processor: Processor, async_session: AsyncSession):
         # Prepare data
         _token_list_item = TokenList()
         _token_list_item.token_address = self.token_address_1
@@ -555,7 +593,13 @@ class TestProcessor:
             },  # product_type missing
         ],
     )
-    async def test_error_2(self, mock_get, processor, async_session, invalid_record):
+    async def test_error_2(
+        self,
+        mock_get: mock.MagicMock,
+        processor: Processor,
+        async_session: AsyncSession,
+        invalid_record: dict[str, object],
+    ):
         # Prepare data
         _token_list_item = TokenList()
         _token_list_item.token_address = self.token_address_1
@@ -611,7 +655,12 @@ class TestProcessor:
     # <Error_3>
     # Other error
     @mock.patch("requests.Session.get")
-    async def test_error_3(self, mock_get, processor, async_session):
+    async def test_error_3(
+        self,
+        mock_get: mock.MagicMock,
+        processor: Processor,
+        async_session: AsyncSession,
+    ):
         # Prepare data
         _token_list_item = TokenList()
         _token_list_item.token_address = self.token_address_1

--- a/tests/batch/processor_Send_Chat_Webhook_test.py
+++ b/tests/batch/processor_Send_Chat_Webhook_test.py
@@ -25,6 +25,7 @@ from unittest.mock import MagicMock
 import pytest
 from sqlalchemy import select
 from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 
 from app.model.db import ChatWebhook
@@ -51,7 +52,12 @@ def caplog(caplog: pytest.LogCaptureFixture):
 class TestProcessorSendChatWebhook:
     # Normal_1
     # No unsent hook exists
-    async def test_normal_1(self, processor, async_session, caplog):
+    async def test_normal_1(
+        self,
+        processor: Processor,
+        async_session: AsyncSession,
+        caplog: pytest.LogCaptureFixture,
+    ):
         # Run processor
         with mock.patch("requests.post", MagicMock(side_effect=None)):
             processor.process()
@@ -62,7 +68,12 @@ class TestProcessorSendChatWebhook:
 
     # Normal_2
     # Unsent hook exists
-    async def test_normal_2(self, processor, async_session, caplog):
+    async def test_normal_2(
+        self,
+        processor: Processor,
+        async_session: AsyncSession,
+        caplog: pytest.LogCaptureFixture,
+    ):
         # Prepare data
         hook = ChatWebhook()
         hook.message = json.dumps({"title": "test_title1", "text": "test_text"})
@@ -84,7 +95,12 @@ class TestProcessorSendChatWebhook:
 
     # Normal_3
     # Fail to send message -> Skip
-    async def test_normal_3(self, processor, async_session, caplog):
+    async def test_normal_3(
+        self,
+        processor: Processor,
+        async_session: AsyncSession,
+        caplog: pytest.LogCaptureFixture,
+    ):
         # Prepare data
         hook = ChatWebhook()
         hook.message = json.dumps({"title": "test_title", "text": "test_text"})
@@ -111,7 +127,12 @@ class TestProcessorSendChatWebhook:
 
     # Error_1
     # SQLAlchemyError
-    async def test_error_1(self, processor, async_session, caplog):
+    async def test_error_1(
+        self,
+        processor: Processor,
+        async_session: AsyncSession,
+        caplog: pytest.LogCaptureFixture,
+    ):
         # Prepare data
         hook = ChatWebhook()
         hook.message = json.dumps({"title": "test_title", "text": "test_text"})

--- a/tests/batch/processor_Send_Mail_test.py
+++ b/tests/batch/processor_Send_Mail_test.py
@@ -32,7 +32,7 @@ from batch.processor_Send_Mail import LOG, Processor
 
 
 @pytest.fixture(scope="function")
-def processor(session):
+def processor():
     return Processor()
 
 
@@ -62,7 +62,9 @@ def caplog(caplog: pytest.LogCaptureFixture):
 class TestProcessorSendMail:
     # Normal_1
     # No unsent email exists
-    def test_normal_1(self, processor, session, caplog):
+    def test_normal_1(
+        self, processor: Processor, session: Session, caplog: pytest.LogCaptureFixture
+    ):
         # Run processor
         with (
             mock.patch("app.model.mail.mail.SMTP_SENDER_EMAIL", "sender@a.test"),
@@ -78,7 +80,9 @@ class TestProcessorSendMail:
 
     # Normal_2
     # Unsent email exists
-    def test_normal_2(self, processor, session, caplog):
+    def test_normal_2(
+        self, processor: Processor, session: Session, caplog: pytest.LogCaptureFixture
+    ):
         # Prepare data
         mail = Mail()
         mail.to_email = "to@example.com"
@@ -117,7 +121,9 @@ class TestProcessorSendMail:
     # ALLOWED_EMAIL_DESTINATION_DOMAIN_LIST
     # - Not send emails if the domain is not allowed
     @mock.patch("app.config.ALLOWED_EMAIL_DESTINATION_DOMAIN_LIST", ["example.net"])
-    def test_normal_3(self, processor, session, caplog):
+    def test_normal_3(
+        self, processor: Processor, session: Session, caplog: pytest.LogCaptureFixture
+    ):
         # Prepare data
         mail = Mail()
         mail.to_email = "to@example.com"
@@ -151,7 +157,9 @@ class TestProcessorSendMail:
         "app.config.DISALLOWED_DESTINATION_EMAIL_ADDRESS_REGEX",
         "^[a-zA-Z0-9_.+-]+@example.com",
     )
-    def test_normal_4(self, processor, session, caplog):
+    def test_normal_4(
+        self, processor: Processor, session: Session, caplog: pytest.LogCaptureFixture
+    ):
         # Prepare data
         mail = Mail()
         mail.to_email = "to@example.com"
@@ -180,7 +188,9 @@ class TestProcessorSendMail:
 
     # Normal_5
     # SMTPException -> skip
-    def test_normal_5(self, processor, session, caplog):
+    def test_normal_5(
+        self, processor: Processor, session: Session, caplog: pytest.LogCaptureFixture
+    ):
         # Prepare data
         mail = Mail()
         mail.to_email = "to@example.com"
@@ -216,7 +226,14 @@ class TestProcessorSendMail:
         "policy",
         ["", "SMTPUTF8", "HTTP"],
     )
-    def test_normal_6(self, policy, processor, session, caplog, monkeypatch):
+    def test_normal_6(
+        self,
+        policy: str,
+        processor: Processor,
+        session: Session,
+        caplog: pytest.LogCaptureFixture,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
         # Prepare data
         mail = Mail()
         mail.to_email = "to@example.com"
@@ -248,7 +265,9 @@ class TestProcessorSendMail:
 
     # Error_1
     # SQLAlchemyError
-    def test_error_1(self, processor, session, caplog):
+    def test_error_1(
+        self, processor: Processor, session: Session, caplog: pytest.LogCaptureFixture
+    ):
         # Prepare data
         mail = Mail()
         mail.to_email = "to@example.com"

--- a/tests/loadtest/locustfile.py
+++ b/tests/loadtest/locustfile.py
@@ -20,10 +20,13 @@ SPDX-License-Identifier: Apache-2.0
 from __future__ import absolute_import, unicode_literals
 
 import json
+from typing import Any
 
-from eth_utils import to_checksum_address
+from eth_utils.address import to_checksum_address
+from eth_utils.conversions import to_hex
 from locust import HttpLocust, TaskSet, task
-from web3.auto import w3
+from web3 import Web3
+from web3.auto import w3 as auto_w3
 
 from app import config
 
@@ -33,31 +36,33 @@ eth_address = "0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf"
 
 # コントラクト情報
 personal_info_json = json.load(open("../../app/contracts/json/PersonalInfo.json", "r"))
-personalinfo_contract_address = to_checksum_address(
-    config.PERSONAL_INFO_CONTRACT_ADDRESS
-)
+personal_info_contract_address_raw = config.PERSONAL_INFO_CONTRACT_ADDRESS
+assert personal_info_contract_address_raw is not None
+personalinfo_contract_address = to_checksum_address(personal_info_contract_address_raw)
 personalinfo_contract_abi = personal_info_json["abi"]
 
 # Basic認証
 basic_auth_user = config.BASIC_AUTH_USER
 basic_auth_pass = config.BASIC_AUTH_PASS
+w3: Web3 = auto_w3
 
 
 class LoadTestTaskSet(TaskSet):
     def on_start(self):
         self.client.get("/", auth=(basic_auth_user, basic_auth_pass), verify=False)
 
-    @staticmethod
-    def get_tx_info(self, eth_address):
+    def get_tx_info(self, eth_address: str) -> tuple[int, int]:
         response = self.client.get(
             "/Eth/TransactionCount/" + eth_address,
             auth=(basic_auth_user, basic_auth_pass),
             verify=False,
         )
-        response_json = json.loads(response.content.decode("utf8").replace("'", '"'))
+        response_json: dict[str, Any] = json.loads(
+            response.content.decode("utf8").replace("'", '"')
+        )
 
-        nonce = response_json["data"]["nonce"]
-        gas_price = response_json["data"]["gasprice"]
+        nonce = int(response_json["data"]["nonce"])
+        gas_price = int(response_json["data"]["gasprice"])
 
         return nonce, gas_price
 
@@ -79,9 +84,9 @@ class LoadTestTaskSet(TaskSet):
             }
         )
 
-        signed_txn = w3.eth.account.signTransaction(txn, private_key=private_key)
+        signed_txn = w3.eth.account.sign_transaction(txn, private_key=private_key)
 
-        raw_tx_hex_list = [str(signed_txn.raw_transaction.to_0x_hex())]
+        raw_tx_hex_list = [to_hex(signed_txn.raw_transaction)]
 
         payload = {"raw_tx_hex_list": raw_tx_hex_list}
         headers = {"content-type": "application/json"}

--- a/tests/utils/contract.py
+++ b/tests/utils/contract.py
@@ -21,6 +21,7 @@ import json
 from typing import Any, Type, TypeVar
 
 from eth_utils.address import to_checksum_address
+from hexbytes import HexBytes
 from web3 import Web3
 from web3.contract import Contract as Web3Contract
 from web3.exceptions import BadFunctionCallOutput, ContractLogicError
@@ -87,8 +88,8 @@ class Contract:
             bytecode_runtime=contract_json["deployedBytecode"],
         )
 
-        tx_hash = contract.constructor(*args).transact(
-            {"from": deployer, "gas": 6000000}
+        tx_hash = HexBytes(
+            contract.constructor(*args).transact({"from": deployer, "gas": 6000000})
         )
         tx = web3.eth.wait_for_transaction_receipt(tx_hash)
 

--- a/typings/locust/__init__.pyi
+++ b/typings/locust/__init__.pyi
@@ -17,8 +17,26 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
-from web3.middleware.formatting import FormattingMiddlewareBuilder
+from typing import Any, Callable, Protocol, TypeVar, overload
 
-# NOTE: The correct type is likely FormattingMiddlewareBuilder,
-# but `type` is used here to avoid a type error when passing it to `web3.middleware_onion.inject`.
-ExtraDataToPOAMiddleware: type[FormattingMiddlewareBuilder]
+class Response(Protocol):
+    content: bytes
+
+class HttpSession(Protocol):
+    def get(self, url: str, **kwargs: Any) -> Response: ...
+    def post(self, url: str, **kwargs: Any) -> Response: ...
+
+class TaskSet:
+    client: HttpSession
+
+class HttpLocust:
+    task_set: type[TaskSet]
+    min_wait: int
+    max_wait: int
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+@overload
+def task(weight: int = ...) -> Callable[[F], F]: ...
+@overload
+def task(func: F) -> F: ...

--- a/typings/pytest_alembic/__init__.pyi
+++ b/typings/pytest_alembic/__init__.pyi
@@ -17,8 +17,14 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
-from web3.middleware.formatting import FormattingMiddlewareBuilder
+class AlembicConfig:
+    def set_main_option(self, name: str, value: str) -> None: ...
 
-# NOTE: The correct type is likely FormattingMiddlewareBuilder,
-# but `type` is used here to avoid a type error when passing it to `web3.middleware_onion.inject`.
-ExtraDataToPOAMiddleware: type[FormattingMiddlewareBuilder]
+class Config:
+    alembic_config: AlembicConfig
+
+class MigrationContext:
+    config: Config
+
+    def migrate_up_to(self, revision: str) -> str | None: ...
+    def migrate_down_to(self, revision: str) -> str | None: ...

--- a/typings/web3/contract/__init__.pyi
+++ b/typings/web3/contract/__init__.pyi
@@ -17,8 +17,20 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
-from web3.middleware.formatting import FormattingMiddlewareBuilder
+from typing import Any
 
-# NOTE: The correct type is likely FormattingMiddlewareBuilder,
-# but `type` is used here to avoid a type error when passing it to `web3.middleware_onion.inject`.
-ExtraDataToPOAMiddleware: type[FormattingMiddlewareBuilder]
+class Contract:
+    address: str
+    functions: Any
+    events: Any
+
+    def __init__(self, address: str | None = None) -> None: ...
+    def constructor(self, *args: Any, **kwargs: Any) -> Any: ...
+
+class AsyncContract:
+    address: str
+    functions: Any
+    events: Any
+
+    def __init__(self, address: str | None = None) -> None: ...
+    def constructor(self, *args: Any, **kwargs: Any) -> Any: ...

--- a/typings/web3/middleware/__init__.pyi
+++ b/typings/web3/middleware/__init__.pyi
@@ -1,3 +1,22 @@
+"""
+Copyright BOOSTRY Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
 from .proof_of_authority import ExtraDataToPOAMiddleware
 
 __all__ = ["ExtraDataToPOAMiddleware"]

--- a/typings/web3/providers/async_base.pyi
+++ b/typings/web3/providers/async_base.pyi
@@ -17,8 +17,9 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
-from web3.middleware.formatting import FormattingMiddlewareBuilder
+from typing import Any, Coroutine
 
-# NOTE: The correct type is likely FormattingMiddlewareBuilder,
-# but `type` is used here to avoid a type error when passing it to `web3.middleware_onion.inject`.
-ExtraDataToPOAMiddleware: type[FormattingMiddlewareBuilder]
+class AsyncBaseProvider:
+    endpoint_uri: str
+
+    def make_request(self, method: str, params: Any) -> Coroutine[Any, Any, Any]: ...

--- a/typings/web3/providers/base.pyi
+++ b/typings/web3/providers/base.pyi
@@ -17,8 +17,9 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
-from web3.middleware.formatting import FormattingMiddlewareBuilder
+from typing import Any
 
-# NOTE: The correct type is likely FormattingMiddlewareBuilder,
-# but `type` is used here to avoid a type error when passing it to `web3.middleware_onion.inject`.
-ExtraDataToPOAMiddleware: type[FormattingMiddlewareBuilder]
+class BaseProvider:
+    endpoint_uri: str
+
+    def make_request(self, method: str, params: Any) -> Any: ...


### PR DESCRIPTION
## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->

This pull request introduces several type annotation improvements and refactorings across the codebase, primarily to enhance type safety, readability, and consistency. The most significant changes include stricter typing for JSON fields in database models, modernization of class methods to use `@classmethod` and `Self`, refactoring of function signatures for better type inference, and cleanup of test fixtures.

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
- Close #1717 

## 🔄 Changes

<!-- List the major changes in this PR. -->

**Type annotation improvements in database models:**

* Changed JSON fields in models such as `IDXBlockData`, `IDXLock`, `IDXUnlock`, `IDXShareToken`, `IDXTransfer`, and `Notification` to use more precise types like `dict[str, object]` or `list[str]` instead of generic `dict` or `list` types. [[1]](diffhunk://#diff-32aae5e21ccbd5b036306804599305b8f3c251739149a70fbd6bb23710a22587L53-R53) [[2]](diffhunk://#diff-c893684e2e10ad7d92558365e56075adf8329acebb9bcaec1b7bdc6a1a7f775dL81-R81) [[3]](diffhunk://#diff-c893684e2e10ad7d92558365e56075adf8329acebb9bcaec1b7bdc6a1a7f775dL161-R161) [[4]](diffhunk://#diff-2a4c32470c3eaa8693ad8ae260f3b87a212bfce1d7d9c9a7d273eb327dc49d2fL245-R245) [[5]](diffhunk://#diff-8004d43cd0ab067d85d3e2ef24ecd1ab7b07dc3d22f3766a557cbcdf105e33e8L80-R80) [[6]](diffhunk://#diff-017a256f2fe1dd1455bc319f709b8ab610981e74fae18f959eb14dcfabd868a8L121-R123)

**Refactoring and modernization of token model classes:**

* Updated the `from_model` methods in `TokenBase` and its subclasses (`BondToken`, `ShareToken`, `MembershipToken`, `CouponToken`) to use `@classmethod` and `Self` for better subclassing and type inference, and added type assertions for model arguments. [[1]](diffhunk://#diff-f7c275fdb5748601dd2a58f48a2e20863cf1e62fdcb7a3ed57394e3710ead56aL138-R141) [[2]](diffhunk://#diff-f7c275fdb5748601dd2a58f48a2e20863cf1e62fdcb7a3ed57394e3710ead56aL178-R180) [[3]](diffhunk://#diff-f7c275fdb5748601dd2a58f48a2e20863cf1e62fdcb7a3ed57394e3710ead56aL529-R532) [[4]](diffhunk://#diff-f7c275fdb5748601dd2a58f48a2e20863cf1e62fdcb7a3ed57394e3710ead56aL760-R764) [[5]](diffhunk://#diff-f7c275fdb5748601dd2a58f48a2e20863cf1e62fdcb7a3ed57394e3710ead56aL954-R959)
* Improved type annotations in the `token_db_cache` decorator and related function signatures for better clarity and type safety, introducing `TypeVar` and `Self`. [[1]](diffhunk://#diff-f7c275fdb5748601dd2a58f48a2e20863cf1e62fdcb7a3ed57394e3710ead56aL26-R26) [[2]](diffhunk://#diff-f7c275fdb5748601dd2a58f48a2e20863cf1e62fdcb7a3ed57394e3710ead56aR62-R63) [[3]](diffhunk://#diff-f7c275fdb5748601dd2a58f48a2e20863cf1e62fdcb7a3ed57394e3710ead56aL70-R81) [[4]](diffhunk://#diff-f7c275fdb5748601dd2a58f48a2e20863cf1e62fdcb7a3ed57394e3710ead56aL94-R93)

**Batch processor and utility function improvements:**

* Refactored the `remove_duplicate_event_by_token_account_desc` static method signatures in multiple batch indexer files to use `Sequence[Mapping[str, Mapping[str, str]]]` for events and `Sequence[str]` for account keys, returning `list[str]`. [[1]](diffhunk://#diff-e6aee665fd2105ec8714613c9b50a178d710490eb24c89975f79782d6c70d9a8L25-R25) [[2]](diffhunk://#diff-e6aee665fd2105ec8714613c9b50a178d710490eb24c89975f79782d6c70d9a8L1929-R1931) [[3]](diffhunk://#diff-3eb449147237d15155e609df5e7356d468f22207a8e0951f0b7936578ef90192L23-R23) [[4]](diffhunk://#diff-3eb449147237d15155e609df5e7356d468f22207a8e0951f0b7936578ef90192L963-R965) [[5]](diffhunk://#diff-f8682018d50b35d8077484e85c45e3b2f9cf7b36481f1235087c1df0b99113aaL23-R23) [[6]](diffhunk://#diff-f8682018d50b35d8077484e85c45e3b2f9cf7b36481f1235087c1df0b99113aaL927-R929) [[7]](diffhunk://#diff-7c8731c28bc19df2012ab5b9793f86eada370544630547f35c1d6e28938c5b34L25-R25) [[8]](diffhunk://#diff-7c8731c28bc19df2012ab5b9793f86eada370544630547f35c1d6e28938c5b34L1929-R1931)

**Improvements to batch processor node info structure:**

* Introduced a `TypedDict` (`NodeInfo`) for node information in `processor_Block_Sync_Status.py` and updated related logic to use this new type, improving type safety and code clarity. [[1]](diffhunk://#diff-c108a1c3e1e5e6f823d08a8a4c4cdb310cc6eb35ebacb924b3f3d8a675ee3006L23-R23) [[2]](diffhunk://#diff-c108a1c3e1e5e6f823d08a8a4c4cdb310cc6eb35ebacb924b3f3d8a675ee3006R81-R89) [[3]](diffhunk://#diff-c108a1c3e1e5e6f823d08a8a4c4cdb310cc6eb35ebacb924b3f3d8a675ee3006L134-L135) [[4]](diffhunk://#diff-c108a1c3e1e5e6f823d08a8a4c4cdb310cc6eb35ebacb924b3f3d8a675ee3006L145-R156) [[5]](diffhunk://#diff-c108a1c3e1e5e6f823d08a8a4c4cdb310cc6eb35ebacb924b3f3d8a675ee3006L165-R180)

**Test code cleanup and fixture simplification:**

* Simplified test fixtures in several test files by removing unnecessary indirection and returning processor instances directly. [[1]](diffhunk://#diff-63ae5887a7e304f18ba880afaf86ef5d7c9ea39f76a33ed07b55290d14fa87cfL50-R52) [[2]](diffhunk://#diff-1b03b3d7af52068101b44b08a1beafa97111c38b4432fc68f780ac0a91b3245fL49-R51) [[3]](diffhunk://#diff-68d81888543cae1192ef2f11023ea37d5379b5f5fcbff9a17272d25be187491dL36-R47)
* Updated `pyrightconfig.json` to include all test files in the `tests/` directory for type checking, ensuring better coverage.

## 📌 Checklist

- [ ] I have added tests where necessary.
- [ ] I have updated the documentation where necessary.
