### PR TITLE
feat: Add CacheControlMiddleware to manage caching headers in responses

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -66,7 +66,11 @@ from app.errors import (
     ServiceUnavailable,
     SuspendedTokenError,
 )
-from app.middleware import ResponseLoggerMiddleware, StripTrailingSlashMiddleware
+from app.middleware import (
+    CacheControlMiddleware,
+    ResponseLoggerMiddleware,
+    StripTrailingSlashMiddleware,
+)
 from app.utils import o11y
 from app.utils.docs_utils import custom_openapi
 
@@ -180,6 +184,7 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+app.add_middleware(CacheControlMiddleware)
 app.add_middleware(ResponseLoggerMiddleware)
 app.add_middleware(StripTrailingSlashMiddleware)
 

--- a/app/middleware/__init__.py
+++ b/app/middleware/__init__.py
@@ -17,5 +17,6 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
+from .cache_control import CacheControlMiddleware
 from .response_logger import ResponseLoggerMiddleware
 from .strip_trailing_slash import StripTrailingSlashMiddleware

--- a/app/middleware/cache_control.py
+++ b/app/middleware/cache_control.py
@@ -62,16 +62,6 @@ class CacheControlMiddleware(BaseHTTPMiddleware):
                 req_cache_control = request.headers.get("Cache-Control")
                 if req_cache_control is not None:
                     response.headers["Cache-Control"] = req_cache_control
-                # Mirror other related headers if present
-                req_pragma = request.headers.get("Pragma")
-                if req_pragma is not None:
-                    response.headers["Pragma"] = req_pragma
-                req_etag = request.headers.get("ETag")
-                if req_etag is not None:
-                    response.headers["ETag"] = req_etag
-                req_expires = request.headers.get("Expires")
-                if req_expires is not None:
-                    response.headers["Expires"] = req_expires
         except Exception:
             # Do not break the response flow even if header manipulation fails
             pass

--- a/app/middleware/cache_control.py
+++ b/app/middleware/cache_control.py
@@ -27,7 +27,7 @@ class CacheControlMiddleware(BaseHTTPMiddleware):
     """
     Middleware to control caching headers.
     - For 4xx and 5xx responses: enforce no-store/no-cache headers and remove validators.
-    - For other responses: mirror incoming request's Cache-Control/Pragma/ETag/Expires if present.
+    - For other responses: mirror incoming request's Cache-Control if present.
     """
 
     def __init__(self, app: ASGIApp, statuses: tuple[int, ...] | None = None) -> None:

--- a/app/middleware/cache_control.py
+++ b/app/middleware/cache_control.py
@@ -25,15 +25,41 @@ from starlette.types import ASGIApp
 
 class CacheControlMiddleware(BaseHTTPMiddleware):
     """
-    Middleware to control caching headers.
-    - For 4xx and 5xx responses: enforce no-store/no-cache headers and remove validators.
-    - For other responses: mirror incoming request's Cache-Control if present.
+    Middleware to control caching headers by whitelist policy.
+    - Cache is enabled only for specific status codes.
+    - For other status codes, caching is strongly disabled.
+
+    The whitelist of status codes is selected based on RFC7231 semantics
+    for cacheable responses in typical scenarios:
+      200, 203, 204, 206, 300, 301, 404, 405, 410, 414, 501.
     """
 
-    def __init__(self, app: ASGIApp, statuses: tuple[int, ...] | None = None) -> None:
+    # Default whitelist: enable cache only for these status codes
+    DEFAULT_CACHE_ENABLED_STATUSES: tuple[int, ...] = (
+        200,
+        203,
+        204,
+        206,
+        300,
+        301,
+        404,
+        405,
+        410,
+        414,
+        501,
+    )
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        cache_enabled_statuses: tuple[int, ...] | None = None,
+    ) -> None:
         super().__init__(app)
-        # Optional: if specific statuses are provided, they can override the default behavior
-        self.statuses = statuses
+        self.cache_enabled_statuses = (
+            cache_enabled_statuses
+            if cache_enabled_statuses is not None
+            else self.DEFAULT_CACHE_ENABLED_STATUSES
+        )
 
     async def dispatch(
         self, request: Request, call_next: RequestResponseEndpoint
@@ -41,27 +67,23 @@ class CacheControlMiddleware(BaseHTTPMiddleware):
         response = await call_next(request)
         try:
             status_code = response.status_code
-            is_error = (self.statuses is None and 400 <= status_code < 600) or (
-                self.statuses is not None and status_code in self.statuses
-            )
+            cache_enabled = status_code in self.cache_enabled_statuses
 
-            if is_error:
-                # Strongly disable caching on clients/proxies for error responses
+            if cache_enabled:
+                # Mirror only Cache-Control from request if provided
+                req_cache_control = request.headers.get("Cache-Control")
+                if req_cache_control is not None:
+                    response.headers["Cache-Control"] = req_cache_control
+            else:
+                # Strongly disable caching for non-whitelisted status codes
                 response.headers["Cache-Control"] = (
                     "no-store, no-cache, must-revalidate, max-age=0"
                 )
-                # Legacy proxies hint
                 response.headers["Pragma"] = "no-cache"
-                # Remove validators/expiry if present
                 if "ETag" in response.headers:
                     del response.headers["ETag"]
                 if "Expires" in response.headers:
                     del response.headers["Expires"]
-            else:
-                # Mirror request Cache-Control if provided, otherwise keep existing response behavior
-                req_cache_control = request.headers.get("Cache-Control")
-                if req_cache_control is not None:
-                    response.headers["Cache-Control"] = req_cache_control
         except Exception:
             # Do not break the response flow even if header manipulation fails
             pass

--- a/app/middleware/cache_control.py
+++ b/app/middleware/cache_control.py
@@ -1,0 +1,78 @@
+"""
+Copyright BOOSTRY Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.requests import Request
+from starlette.responses import Response
+from starlette.types import ASGIApp
+
+
+class CacheControlMiddleware(BaseHTTPMiddleware):
+    """
+    Middleware to control caching headers.
+    - For 4xx and 5xx responses: enforce no-store/no-cache headers and remove validators.
+    - For other responses: mirror incoming request's Cache-Control/Pragma/ETag/Expires if present.
+    """
+
+    def __init__(self, app: ASGIApp, statuses: tuple[int, ...] | None = None) -> None:
+        super().__init__(app)
+        # Optional: if specific statuses are provided, they can override the default behavior
+        self.statuses = statuses
+
+    async def dispatch(
+        self, request: Request, call_next: RequestResponseEndpoint
+    ) -> Response:
+        response = await call_next(request)
+        try:
+            status_code = response.status_code
+            is_error = (self.statuses is None and 400 <= status_code < 600) or (
+                self.statuses is not None and status_code in self.statuses
+            )
+
+            if is_error:
+                # Strongly disable caching on clients/proxies for error responses
+                response.headers["Cache-Control"] = (
+                    "no-store, no-cache, must-revalidate, max-age=0"
+                )
+                # Legacy proxies hint
+                response.headers["Pragma"] = "no-cache"
+                # Remove validators/expiry if present
+                if "ETag" in response.headers:
+                    del response.headers["ETag"]
+                if "Expires" in response.headers:
+                    del response.headers["Expires"]
+            else:
+                # Mirror request Cache-Control if provided, otherwise keep existing response behavior
+                req_cache_control = request.headers.get("Cache-Control")
+                if req_cache_control is not None:
+                    response.headers["Cache-Control"] = req_cache_control
+                # Mirror other related headers if present
+                req_pragma = request.headers.get("Pragma")
+                if req_pragma is not None:
+                    response.headers["Pragma"] = req_pragma
+                req_etag = request.headers.get("ETag")
+                if req_etag is not None:
+                    response.headers["ETag"] = req_etag
+                req_expires = request.headers.get("Expires")
+                if req_expires is not None:
+                    response.headers["Expires"] = req_expires
+        except Exception:
+            # Do not break the response flow even if header manipulation fails
+            pass
+        return response


### PR DESCRIPTION
## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->

This pull request introduces a new middleware to manage HTTP caching headers based on response status codes, improving cache control and compliance with RFC9111/RFC7231.

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
None

## 🔄 Changes

<!-- List the major changes in this PR. -->

**Middleware Addition and Integration**

* Added `CacheControlMiddleware` to the codebase, which enforces cache header policies by status code, allowing cache only for specific whitelisted statuses (e.g., 200, 301, 404) and disabling cache for others. (`app/middleware/cache_control.py`)
* Registered `CacheControlMiddleware` in the middleware initialization and main application setup, ensuring it is applied to all incoming requests. (`app/middleware/__init__.py`, `app/main.py`) [[1]](diffhunk://#diff-4db911b05254f60d1dd42131be4e0a9072f90d50b5c2d5ca5de89a576ae8bb86R20) [[2]](diffhunk://#diff-990f7e4140fab1ad82afc787505090b64d4024e63a891405cd9085e7e6b249ddL69-R73) [[3]](diffhunk://#diff-990f7e4140fab1ad82afc787505090b64d4024e63a891405cd9085e7e6b249ddR187)

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
