### PR TITLE
Bundle transfer indexers and refactor logging

### DIFF
--- a/batch/indexer_Transfer_Combined.py
+++ b/batch/indexer_Transfer_Combined.py
@@ -1,0 +1,115 @@
+"""
+Copyright BOOSTRY Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import asyncio
+import sys
+import time
+from typing import Protocol
+
+from sqlalchemy.exc import SQLAlchemyError
+
+from app.config import SHARE_TOKEN_ENABLED
+from app.errors import ServiceUnavailable
+from batch import free_malloc, log
+from batch.log import BatchLoggerAdapter
+from batch.sub_indexers import (
+    indexer_Transfer,
+    indexer_TransferApproval,
+)
+
+process_name = "INDEXER-TRANSFER-COMBINED"
+LOG: BatchLoggerAdapter = log.get_logger(process_name=process_name)
+
+
+class IndexerProcessor(Protocol):
+    async def sync_new_logs(self) -> None: ...
+
+
+async def main():
+    """Main function for the combined Transfer indexer."""
+
+    LOG.info("Service started successfully")
+
+    loop_interval_sec = 5
+
+    processors: list[tuple[IndexerProcessor, BatchLoggerAdapter]] = [
+        (indexer_Transfer.Processor(), indexer_Transfer.LOG),
+    ]
+
+    if SHARE_TOKEN_ENABLED:
+        processors.append(
+            (indexer_TransferApproval.Processor(), indexer_TransferApproval.LOG)
+        )
+        LOG.info("TransferApproval processor is enabled")
+    else:
+        LOG.info("TransferApproval processor is disabled")
+
+    # Initial sync (retry until each processor succeeds once)
+    for processor, child_logger in processors:
+        initialized = False
+        while not initialized:
+            start_time = time.time()
+            try:
+                with log.parent_process(process_name):
+                    await processor.sync_new_logs()
+                    initialized = True
+                    child_logger.info("Initial sync succeeded")
+            except Exception:
+                with log.parent_process(process_name):
+                    child_logger.exception("Initial sync failed")
+
+            elapsed_time = time.time() - start_time
+            await asyncio.sleep(max(loop_interval_sec - elapsed_time, 0))
+
+    # Main loop
+    while True:
+        start_time = time.time()
+
+        for processor, child_logger in processors:
+            try:
+                with log.parent_process(process_name):
+                    await processor.sync_new_logs()
+                    child_logger.debug("Processed")
+            except ServiceUnavailable:
+                with log.parent_process(process_name):
+                    child_logger.notice("An external service was unavailable")
+            except SQLAlchemyError as sa_err:
+                with log.parent_process(process_name):
+                    child_logger.error(
+                        f"A database error has occurred: code={sa_err.code}\n{sa_err}"
+                    )
+            except Exception:
+                with log.parent_process(process_name):
+                    child_logger.exception(
+                        "An exception occurred during event synchronization"
+                    )
+
+        elapsed_time = time.time() - start_time
+        time_to_sleep = max(loop_interval_sec - elapsed_time, 0)
+        if time_to_sleep == 0:
+            LOG.notice("Processing is delayed")
+        await asyncio.sleep(time_to_sleep)
+        free_malloc()
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        sys.exit(1)

--- a/batch/log.py
+++ b/batch/log.py
@@ -17,28 +17,91 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
+import contextlib
+import contextvars
 import logging
 import sys
-from typing import cast
+from typing import Any, Mapping, cast
 
 from app import config
-from logger import SystemLogger
+from logger import NOTICE, SystemLogger
+
+_parent_process_name: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "batch_parent_process_name", default=None
+)
 
 
-def get_logger(process_name: str):
+@contextlib.contextmanager
+def parent_process(process_name: str | None):
+    token = _parent_process_name.set(process_name)
+    try:
+        yield
+    finally:
+        _parent_process_name.reset(token)
+
+
+class _BatchContextFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        process_name = getattr(record, "process_name", None) or record.name
+        parent_name = _parent_process_name.get()
+        record.process_name = process_name
+        record.parent_process_name = parent_name
+        record.process_path = (
+            f"{parent_name} > {process_name}" if parent_name else str(process_name)
+        )
+        return True
+
+
+class BatchLoggerAdapter(logging.LoggerAdapter[SystemLogger]):
+    """Logger adapter that injects a fixed batch `process_name` per module."""
+
+    def __init__(self, logger: SystemLogger, process_name: str):
+        super().__init__(logger, {"process_name": process_name})
+
+    def process(self, msg: Any, kwargs: Mapping[str, Any]):
+        kwargs = dict(kwargs)
+        extra = kwargs.get("extra")
+        empty_extra: dict[str, object] = {}
+        base_extra: Mapping[str, object] = (
+            self.extra if self.extra is not None else empty_extra
+        )
+        if extra is None:
+            kwargs["extra"] = dict(base_extra)
+        else:
+            merged = dict(base_extra)
+            if isinstance(extra, Mapping):
+                merged.update(cast(Mapping[str, object], extra))
+            kwargs["extra"] = merged
+        return msg, kwargs
+
+    def notice(self, msg: str, *args: Any, **kwargs: Any):
+        self.log(NOTICE, msg, *args, **kwargs)
+
+
+def _configure_base_logger() -> SystemLogger:
     logging.setLoggerClass(SystemLogger)
 
     logging.getLogger("pyroscope").setLevel(logging.ERROR)
     logging.getLogger("py_spy").setLevel(logging.ERROR)
     logging.getLogger("opentelemetry").setLevel(logging.ERROR)
 
-    LOG = cast(SystemLogger, logging.getLogger("ibet_wallet_batch"))
-    LOG.propagate = False
-    stream_handler = logging.StreamHandler(sys.stdout)
-    formatter = logging.Formatter(
-        config.INFO_LOG_FORMAT.format(f"[{process_name}]"), config.LOG_TIMESTAMP_FORMAT
-    )
-    stream_handler.setFormatter(formatter)
-    LOG.addHandler(stream_handler)
+    base_logger = cast(SystemLogger, logging.getLogger("ibet_wallet_batch"))
+    base_logger.propagate = False
 
-    return LOG
+    if not getattr(base_logger, "_ibet_wallet_batch_configured", False):
+        stream_handler = logging.StreamHandler(sys.stdout)
+        stream_handler.addFilter(_BatchContextFilter())
+        formatter = logging.Formatter(
+            config.INFO_LOG_FORMAT.format("[%(process_path)s]"),
+            config.LOG_TIMESTAMP_FORMAT,
+        )
+        stream_handler.setFormatter(formatter)
+        base_logger.addHandler(stream_handler)
+        setattr(base_logger, "_ibet_wallet_batch_configured", True)
+
+    return base_logger
+
+
+def get_logger(process_name: str) -> BatchLoggerAdapter:
+    base_logger = _configure_base_logger()
+    return BatchLoggerAdapter(base_logger, process_name=process_name)

--- a/batch/log.py
+++ b/batch/log.py
@@ -21,10 +21,12 @@ import contextlib
 import contextvars
 import logging
 import sys
-from typing import Any, Mapping, cast
+from typing import Any, cast
 
 from app import config
 from logger import NOTICE, SystemLogger
+
+_BATCH_STREAM_HANDLER_NAME = "ibet_wallet_batch.stdout"
 
 _parent_process_name: contextvars.ContextVar[str | None] = contextvars.ContextVar(
     "batch_parent_process_name", default=None
@@ -58,22 +60,6 @@ class BatchLoggerAdapter(logging.LoggerAdapter[SystemLogger]):
     def __init__(self, logger: SystemLogger, process_name: str):
         super().__init__(logger, {"process_name": process_name})
 
-    def process(self, msg: Any, kwargs: Mapping[str, Any]):
-        kwargs = dict(kwargs)
-        extra = kwargs.get("extra")
-        empty_extra: dict[str, object] = {}
-        base_extra: Mapping[str, object] = (
-            self.extra if self.extra is not None else empty_extra
-        )
-        if extra is None:
-            kwargs["extra"] = dict(base_extra)
-        else:
-            merged = dict(base_extra)
-            if isinstance(extra, Mapping):
-                merged.update(cast(Mapping[str, object], extra))
-            kwargs["extra"] = merged
-        return msg, kwargs
-
     def notice(self, msg: str, *args: Any, **kwargs: Any):
         self.log(NOTICE, msg, *args, **kwargs)
 
@@ -88,8 +74,11 @@ def _configure_base_logger() -> SystemLogger:
     base_logger = cast(SystemLogger, logging.getLogger("ibet_wallet_batch"))
     base_logger.propagate = False
 
-    if not getattr(base_logger, "_ibet_wallet_batch_configured", False):
+    if not any(
+        handler.name == _BATCH_STREAM_HANDLER_NAME for handler in base_logger.handlers
+    ):
         stream_handler = logging.StreamHandler(sys.stdout)
+        stream_handler.set_name(_BATCH_STREAM_HANDLER_NAME)
         stream_handler.addFilter(_BatchContextFilter())
         formatter = logging.Formatter(
             config.INFO_LOG_FORMAT.format("[%(process_path)s]"),
@@ -97,7 +86,6 @@ def _configure_base_logger() -> SystemLogger:
         )
         stream_handler.setFormatter(formatter)
         base_logger.addHandler(stream_handler)
-        setattr(base_logger, "_ibet_wallet_batch_configured", True)
 
     return base_logger
 

--- a/batch/sub_indexers/__init__.py
+++ b/batch/sub_indexers/__init__.py
@@ -1,0 +1,5 @@
+"""Sub-indexers used by combined/bundled batch jobs.
+
+This package contains indexer implementations that are executed as child processors
+from a parent batch loop (e.g., a combined indexer).
+"""

--- a/batch/sub_indexers/indexer_Transfer.py
+++ b/batch/sub_indexers/indexer_Transfer.py
@@ -17,7 +17,6 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
-import asyncio
 import json
 import sys
 from datetime import datetime, timedelta, timezone
@@ -27,7 +26,6 @@ from eth_utils.address import to_checksum_address
 from hexbytes import HexBytes
 from pydantic import ValidationError
 from sqlalchemy import desc, select
-from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 from web3.exceptions import ABIEventNotFound
 from web3.types import EventData
@@ -36,7 +34,6 @@ from app.config import TOKEN_LIST_CONTRACT_ADDRESS, ZERO_ADDRESS
 from app.contracts import AsyncContract
 from app.contracts.contract import AsyncContractEventsView
 from app.database import BatchAsyncSessionLocal
-from app.errors import ServiceUnavailable
 from app.model.db import (
     IDXTransfer,
     IDXTransferBlockNumber,
@@ -45,11 +42,11 @@ from app.model.db import (
     TransferDataMessage,
 )
 from app.utils.web3_utils import AsyncWeb3Wrapper
-from batch import free_malloc, log
+from batch import log
 
 UTC = timezone(timedelta(hours=0), "UTC")
 
-process_name = "INDEXER-TRANSFER"
+process_name = "SUB:TRANSFER"
 LOG = log.get_logger(process_name=process_name)
 
 async_web3 = AsyncWeb3Wrapper()
@@ -267,6 +264,7 @@ class Processor:
             raise e
         finally:
             await local_session.close()
+        LOG.info("Sync job completed successfully")
 
     async def __get_token_list(self, db_session: AsyncSession):
         self.token_list = self.TargetTokenList()
@@ -640,40 +638,3 @@ class Processor:
             ) = await self.__get_latest_synchronized(
                 db_session, target.token_contract.address
             )
-
-
-async def main():
-    LOG.info("Service started successfully")
-    processor = Processor()
-
-    # Initial sync
-    initial_synced_completed = False
-    while not initial_synced_completed:
-        try:
-            await processor.sync_new_logs()
-            initial_synced_completed = True
-            LOG.info(f"<{process_name}> Initial sync has been completed")
-        except Exception:
-            LOG.exception("Initial sync failed")
-        await asyncio.sleep(5)
-
-    # Sync new logs
-    while True:
-        try:
-            await processor.sync_new_logs()
-            LOG.debug("Processed")
-        except ServiceUnavailable:
-            LOG.notice("An external service was unavailable")
-        except SQLAlchemyError as sa_err:
-            LOG.error(f"A database error has occurred: code={sa_err.code}\n{sa_err}")
-        except Exception:
-            LOG.exception("An exception occurred during event synchronization")
-        await asyncio.sleep(5)
-        free_malloc()
-
-
-if __name__ == "__main__":
-    try:
-        asyncio.run(main())
-    except KeyboardInterrupt:
-        sys.exit(1)

--- a/batch/sub_indexers/indexer_TransferApproval.py
+++ b/batch/sub_indexers/indexer_TransferApproval.py
@@ -17,13 +17,11 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
-import asyncio
 import sys
 from datetime import datetime, timezone
 from typing import Any, List, Mapping, Optional, Sequence
 
 from sqlalchemy import select
-from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 from web3.exceptions import ABIEventNotFound
 from web3.types import EventData
@@ -32,13 +30,12 @@ from app.config import TOKEN_LIST_CONTRACT_ADDRESS, ZERO_ADDRESS
 from app.contracts import AsyncContract
 from app.contracts.contract import AsyncContractEventsView
 from app.database import BatchAsyncSessionLocal
-from app.errors import ServiceUnavailable
 from app.model.db import IDXTransferApproval, IDXTransferApprovalBlockNumber, Listing
 from app.model.schema.base import TokenType
 from app.utils.web3_utils import AsyncWeb3Wrapper
-from batch import free_malloc, log
+from batch import log
 
-process_name = "INDEXER-TRANSFER-APPROVAL"
+process_name = "SUB:TRANSFER-APPROVAL"
 LOG = log.get_logger(process_name=process_name)
 
 async_web3 = AsyncWeb3Wrapper()
@@ -294,34 +291,6 @@ class Processor:
     def __get_db_session():
         return BatchAsyncSessionLocal()
 
-    async def initial_sync(self):
-        local_session = self.__get_db_session()
-        try:
-            await self.__get_contract_list(local_session)
-            # Synchronize 1,000,000 blocks each
-            latest_block = int(await async_web3.eth.block_number)
-            _from_block = self.__get_oldest_cursor(self.token_list, latest_block)
-            _to_block = 999999 + _from_block
-            if latest_block > _to_block:
-                while _to_block < latest_block:
-                    await self.__sync_all(db_session=local_session, block_to=_to_block)
-                    _to_block += 1000000
-                await self.__sync_all(db_session=local_session, block_to=latest_block)
-            else:
-                await self.__sync_all(db_session=local_session, block_to=latest_block)
-            await self.__set_idx_transfer_approval_block_number(
-                local_session, self.token_list, latest_block
-            )
-            await local_session.commit()
-        except Exception as e:
-            await local_session.rollback()
-            raise e
-        finally:
-            await local_session.close()
-            self.token_list = self.TargetTokenList()
-            self.exchange_list = self.TargetExchangeList()
-        LOG.info(f"<{process_name}> Initial sync has been completed")
-
     async def sync_new_logs(self):
         local_session = self.__get_db_session()
         try:
@@ -348,7 +317,7 @@ class Processor:
             await local_session.close()
             self.token_list = self.TargetTokenList()
             self.exchange_list = self.TargetExchangeList()
-        LOG.info("Sync job has been completed")
+        LOG.info("Sync job completed successfully")
 
     async def __sync_all(self, db_session: AsyncSession, block_to: int):
         LOG.info("Syncing to={}".format(block_to))
@@ -813,38 +782,3 @@ class Processor:
                     )
                 transfer_approval.transfer_approved = True
         await db_session.merge(transfer_approval)
-
-
-async def main():
-    LOG.info("Service started successfully")
-    processor = Processor()
-
-    initial_synced_completed = False
-    while not initial_synced_completed:
-        try:
-            await processor.initial_sync()
-            initial_synced_completed = True
-        except Exception:
-            LOG.exception("Initial sync failed")
-
-        await asyncio.sleep(5)
-
-    while True:
-        try:
-            await processor.sync_new_logs()
-        except ServiceUnavailable:
-            LOG.notice("An external service was unavailable")
-        except SQLAlchemyError as sa_err:
-            LOG.error(f"A database error has occurred: code={sa_err.code}\n{sa_err}")
-        except Exception:
-            LOG.exception("An exception occurred during event synchronization")
-
-        await asyncio.sleep(5)
-        free_malloc()
-
-
-if __name__ == "__main__":
-    try:
-        asyncio.run(main())
-    except KeyboardInterrupt:
-        sys.exit(1)

--- a/bin/healthcheck_indexer.sh
+++ b/bin/healthcheck_indexer.sh
@@ -22,13 +22,12 @@ if [[ "${APP_ENV:-}" != "local" && "${COMPANY_LIST_LOCAL_MODE:-}" -ne 1 ]]; then
 fi
 PROC_LIST="${PROC_LIST} batch/indexer_PublicInfo_TokenList.py"
 PROC_LIST="${PROC_LIST} batch/indexer_PublicInfo_PublicAccountList.py"
-PROC_LIST="${PROC_LIST} batch/indexer_Transfer.py"
+PROC_LIST="${PROC_LIST} batch/indexer_Transfer_Combined.py"
 PROC_LIST="${PROC_LIST} batch/indexer_Token_Holders.py"
 PROC_LIST="${PROC_LIST} batch/indexer_Token_List_Event.py"
 
 if [ "${SHARE_TOKEN_ENABLED}" = 1 ]; then
   PROC_LIST="${PROC_LIST} batch/indexer_Position_Share.py"
-  PROC_LIST="${PROC_LIST} batch/indexer_TransferApproval.py"
 fi
 
 if [ "${BOND_TOKEN_ENABLED}" = 1 ]; then

--- a/bin/run_indexer.sh
+++ b/bin/run_indexer.sh
@@ -74,13 +74,12 @@ fi
 python batch/indexer_PublicInfo_PublicAccountList.py &
 
 
-python batch/indexer_Transfer.py &
+python batch/indexer_Transfer_Combined.py &
 python batch/indexer_Token_Holders.py &
 python batch/indexer_Token_List_Event.py &
 
 if [[ $SHARE_TOKEN_ENABLED = 1 ]]; then
   python batch/indexer_Position_Share.py &
-  python batch/indexer_TransferApproval.py &
 fi
 
 if [[ $BOND_TOKEN_ENABLED = 1 ]]; then

--- a/tests/batch/indexer_TransferApproval_test.py
+++ b/tests/batch/indexer_TransferApproval_test.py
@@ -17,12 +17,9 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
-import asyncio
-import logging
 from datetime import datetime
-from typing import Awaitable, Callable
 from unittest import mock
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 import pytest_asyncio
@@ -37,8 +34,8 @@ from web3.middleware import ExtraDataToPOAMiddleware
 from app import config
 from app.errors import ServiceUnavailable
 from app.model.db import IDXTransferApproval, IDXTransferApprovalBlockNumber, Listing
-from batch import indexer_TransferApproval
-from batch.indexer_TransferApproval import LOG, Processor, main
+from batch.sub_indexers import indexer_TransferApproval
+from batch.sub_indexers.indexer_TransferApproval import Processor
 from tests.account_config import eth_account
 from tests.helpers import IbetShareTestHelper
 from tests.helpers.ibet_exchange_helpers import (
@@ -59,17 +56,6 @@ def test_module(shared_contract: SharedContract):
     indexer_TransferApproval.TOKEN_LIST_CONTRACT_ADDRESS = shared_contract["TokenList"][
         "address"
     ]
-
-
-@pytest.fixture(scope="function")
-def main_func():
-    LOG = logging.getLogger("ibet_wallet_batch")
-    default_log_level = LOG.level
-    LOG.setLevel(logging.DEBUG)
-    LOG.propagate = True
-    yield main
-    LOG.propagate = False
-    LOG.setLevel(default_log_level)
 
 
 @pytest_asyncio.fixture(scope="function", loop_scope="session")
@@ -1011,7 +997,6 @@ class TestProcessor:
     # <Error_1_2>: ServiceUnavailable occurs in __sync_xx method.
     # <Error_2_1>: ServiceUnavailable occurs in "initial_sync" / "sync_new_logs".
     # <Error_2_2>: SQLAlchemyError occurs in "initial_sync" / "sync_new_logs".
-    # <Error_3>: ServiceUnavailable occurs and is handled in mainloop.
 
     # <Error_1_1>: ABIEventNotFound occurs in __sync_xx method.
     @mock.patch(
@@ -1432,36 +1417,3 @@ class TestProcessor:
             )
         ).first()
         assert idx_transfer_approval_block_number is None
-
-    # <Error_3>: ServiceUnavailable occurs and is handled in mainloop.
-    async def test_error_3(
-        self,
-        main_func: Callable[[], Awaitable[None]],
-        shared_contract: SharedContract,
-        async_session: AsyncSession,
-        caplog: pytest.LogCaptureFixture,
-    ):
-        # Mocking time.sleep to break mainloop
-        asyncio_mock = AsyncMock(wraps=asyncio)
-        asyncio_mock.sleep.side_effect = [True, TypeError()]
-
-        # Run mainloop once and fail with web3 utils error
-        with (
-            mock.patch("batch.indexer_TransferApproval.asyncio", asyncio_mock),
-            mock.patch(
-                "batch.indexer_TransferApproval.Processor.initial_sync",
-                return_value=True,
-            ),
-            mock.patch(
-                "web3.AsyncWeb3.AsyncHTTPProvider.make_request",
-                MagicMock(side_effect=ServiceUnavailable()),
-            ),
-            pytest.raises(TypeError),
-        ):
-            # Expect that sync_new_logs() raises ServiceUnavailable and handled in mainloop.
-            await main_func()
-
-        assert 1 == caplog.record_tuples.count(
-            (LOG.name, 25, "An external service was unavailable")
-        )
-        caplog.clear()

--- a/tests/batch/indexer_Transfer_test.py
+++ b/tests/batch/indexer_Transfer_test.py
@@ -41,8 +41,8 @@ from app.model.db import (
     IDXTransferSourceEventType,
     Listing,
 )
-from batch import indexer_Transfer
-from batch.indexer_Transfer import LOG, UTC, Processor
+from batch.sub_indexers import indexer_Transfer
+from batch.sub_indexers.indexer_Transfer import LOG, UTC, Processor
 from tests.account_config import eth_account
 from tests.helpers import (
     IbetCouponTestHelper,


### PR DESCRIPTION
This pull request introduces a major refactor of the batch indexer architecture to enable combined and modular execution of sub-indexers, as well as a significant overhaul of the logging system for improved context and clarity. 

## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
None

## 🔄 Changes

<!-- List the major changes in this PR. -->

**Batch indexer architecture refactor:**

* Added a new combined indexer entrypoint `indexer_Transfer_Combined.py`, which orchestrates the execution of transfer-related sub-indexers and manages their initialization and main loop.

* Moved `indexer_Transfer.py` and `indexer_TransferApproval.py` into a new `batch/sub_indexers/` package, removing their standalone main loops and adapting them to be invoked as sub-processors.

**Logging improvements:**

* Refactored `batch/log.py` to add hierarchical process context using context variables and a new `BatchLoggerAdapter`, allowing logs to show process lineage (e.g., parent > child), and added a `notice` log level.

Execution sample:
```
$ python batch/indexer_Transfer_Combined.py 
[2026-02-15 22:44:12 +0900] [41302] [INFO] [INDEXER-TRANSFER-COMBINED] Service started successfully
[2026-02-15 22:44:12 +0900] [41302] [INFO] [INDEXER-TRANSFER-COMBINED] TransferApproval processor is enabled
[2026-02-15 22:44:12 +0900] [41302] [INFO] [INDEXER-TRANSFER-COMBINED > SUB:TRANSFER] Syncing to=9685
[2026-02-15 22:44:12 +0900] [41302] [INFO] [INDEXER-TRANSFER-COMBINED > SUB:TRANSFER] Sync job completed successfully
[2026-02-15 22:44:12 +0900] [41302] [INFO] [INDEXER-TRANSFER-COMBINED > SUB:TRANSFER] Initial sync succeeded
[2026-02-15 22:44:17 +0900] [41302] [INFO] [INDEXER-TRANSFER-COMBINED > SUB:TRANSFER-APPROVAL] Syncing to=9685
[2026-02-15 22:44:17 +0900] [41302] [INFO] [INDEXER-TRANSFER-COMBINED > SUB:TRANSFER-APPROVAL] Sync job completed successfully
[2026-02-15 22:44:17 +0900] [41302] [INFO] [INDEXER-TRANSFER-COMBINED > SUB:TRANSFER-APPROVAL] Initial sync succeeded
[2026-02-15 22:44:22 +0900] [41302] [INFO] [INDEXER-TRANSFER-COMBINED > SUB:TRANSFER] Syncing to=9685
[2026-02-15 22:44:22 +0900] [41302] [INFO] [INDEXER-TRANSFER-COMBINED > SUB:TRANSFER] Sync job completed successfully
[2026-02-15 22:44:22 +0900] [41302] [INFO] [INDEXER-TRANSFER-COMBINED > SUB:TRANSFER-APPROVAL] Syncing to=9685
[2026-02-15 22:44:22 +0900] [41302] [INFO] [INDEXER-TRANSFER-COMBINED > SUB:TRANSFER-APPROVAL] Sync job completed successfully
[2026-02-15 22:44:27 +0900] [41302] [INFO] [INDEXER-TRANSFER-COMBINED > SUB:TRANSFER] Syncing to=9685
[2026-02-15 22:44:27 +0900] [41302] [INFO] [INDEXER-TRANSFER-COMBINED > SUB:TRANSFER] Sync job completed successfully
[2026-02-15 22:44:27 +0900] [41302] [INFO] [INDEXER-TRANSFER-COMBINED > SUB:TRANSFER-APPROVAL] Syncing to=9685
[2026-02-15 22:44:27 +0900] [41302] [INFO] [INDEXER-TRANSFER-COMBINED > SUB:TRANSFER-APPROVAL] Sync job completed successfully
[2026-02-15 22:44:32 +0900] [41302] [INFO] [INDEXER-TRANSFER-COMBINED > SUB:TRANSFER] Syncing to=9685
[2026-02-15 22:44:32 +0900] [41302] [INFO] [INDEXER-TRANSFER-COMBINED > SUB:TRANSFER] Sync job completed successfully
[2026-02-15 22:44:32 +0900] [41302] [INFO] [INDEXER-TRANSFER-COMBINED > SUB:TRANSFER-APPROVAL] Syncing to=9685
[2026-02-15 22:44:32 +0900] [41302] [INFO] [INDEXER-TRANSFER-COMBINED > SUB:TRANSFER-APPROVAL] Sync job completed successfully
...
```

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
