### PR TITLE
Add combined public-info indexer

### DIFF
--- a/batch/indexer_PublicInfo_Combined.py
+++ b/batch/indexer_PublicInfo_Combined.py
@@ -1,0 +1,132 @@
+"""
+Copyright BOOSTRY Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import asyncio
+import sys
+import time
+from dataclasses import dataclass
+from typing import Protocol
+
+from sqlalchemy.exc import SQLAlchemyError
+
+from app.config import (
+    COMPANY_LIST_LOCAL_MODE,
+    COMPANY_LIST_SLEEP_INTERVAL,
+    PUBLIC_ACCOUNT_LIST_SLEEP_INTERVAL,
+    TOKEN_LIST_SLEEP_INTERVAL,
+)
+from app.errors import ServiceUnavailable
+from batch import free_malloc, log
+from batch.log import BatchLoggerAdapter
+from batch.sub_indexers import (
+    indexer_Company_List,
+    indexer_PublicInfo_PublicAccountList,
+    indexer_PublicInfo_TokenList,
+)
+
+process_name = "INDEXER-PUBLIC-INFO-COMBINED"
+LOG: BatchLoggerAdapter = log.get_logger(process_name=process_name)
+
+
+class IndexerProcessor(Protocol):
+    async def sync_new_logs(self) -> None: ...
+
+
+@dataclass
+class ScheduledProcessor:
+    processor: IndexerProcessor
+    child_logger: BatchLoggerAdapter
+    interval_sec: int
+    next_run_at: float = 0.0
+
+
+async def run_processor(processor: IndexerProcessor, child_logger: BatchLoggerAdapter):
+    try:
+        with log.parent_process(process_name):
+            await processor.sync_new_logs()
+            child_logger.debug("Processed")
+    except ServiceUnavailable:
+        with log.parent_process(process_name):
+            child_logger.notice("An external service was unavailable")
+    except SQLAlchemyError as sa_err:
+        with log.parent_process(process_name):
+            child_logger.error(
+                f"A database error has occurred: code={sa_err.code}\n{sa_err}"
+            )
+    except Exception:
+        with log.parent_process(process_name):
+            child_logger.exception("An exception occurred during processing")
+
+
+async def main():
+    LOG.info("Service started successfully")
+
+    loop_interval_sec = 5
+
+    processors: list[ScheduledProcessor] = [
+        ScheduledProcessor(
+            processor=indexer_PublicInfo_TokenList.Processor(),
+            child_logger=indexer_PublicInfo_TokenList.LOG,
+            interval_sec=TOKEN_LIST_SLEEP_INTERVAL,
+        ),
+        ScheduledProcessor(
+            processor=indexer_PublicInfo_PublicAccountList.Processor(),
+            child_logger=indexer_PublicInfo_PublicAccountList.LOG,
+            interval_sec=PUBLIC_ACCOUNT_LIST_SLEEP_INTERVAL,
+        ),
+    ]
+
+    if COMPANY_LIST_LOCAL_MODE:
+        LOG.info("CompanyList processor is disabled by COMPANY_LIST_LOCAL_MODE")
+    else:
+        processors.append(
+            ScheduledProcessor(
+                processor=indexer_Company_List.Processor(),
+                child_logger=indexer_Company_List.LOG,
+                interval_sec=COMPANY_LIST_SLEEP_INTERVAL,
+            )
+        )
+        LOG.info("CompanyList processor is enabled")
+
+    now = time.time()
+    for scheduled in processors:
+        await run_processor(scheduled.processor, scheduled.child_logger)
+        scheduled.next_run_at = now + scheduled.interval_sec
+
+    while True:
+        loop_start = time.time()
+
+        for scheduled in processors:
+            if loop_start >= scheduled.next_run_at:
+                await run_processor(scheduled.processor, scheduled.child_logger)
+                scheduled.next_run_at = time.time() + scheduled.interval_sec
+
+        elapsed_time = time.time() - loop_start
+        time_to_sleep = max(loop_interval_sec - elapsed_time, 0)
+        if time_to_sleep == 0:
+            LOG.notice("Processing is delayed")
+        await asyncio.sleep(time_to_sleep)
+        free_malloc()
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        sys.exit(1)

--- a/batch/indexer_PublicInfo_Combined.py
+++ b/batch/indexer_PublicInfo_Combined.py
@@ -45,7 +45,7 @@ LOG: BatchLoggerAdapter = log.get_logger(process_name=process_name)
 
 
 class IndexerProcessor(Protocol):
-    async def sync_new_logs(self) -> None: ...
+    def process(self) -> None: ...
 
 
 @dataclass
@@ -59,7 +59,7 @@ class ScheduledProcessor:
 async def run_processor(processor: IndexerProcessor, child_logger: BatchLoggerAdapter):
     try:
         with log.parent_process(process_name):
-            await processor.sync_new_logs()
+            processor.process()
             child_logger.debug("Processed")
     except ServiceUnavailable:
         with log.parent_process(process_name):

--- a/batch/sub_indexers/indexer_Company_List.py
+++ b/batch/sub_indexers/indexer_Company_List.py
@@ -19,31 +19,23 @@ SPDX-License-Identifier: Apache-2.0
 
 import hashlib
 import json
-import sys
-import time
 
 import requests
 from pydantic import ValidationError
 from requests.adapters import HTTPAdapter
 from sqlalchemy import delete
 from sqlalchemy.engine.create import create_engine
-from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm.session import Session
 from urllib3 import Retry
 
-from app.config import (
-    COMPANY_LIST_SLEEP_INTERVAL,
-    COMPANY_LIST_URL,
-    DATABASE_URL,
-    REQUEST_TIMEOUT,
-)
-from app.errors import ServiceUnavailable
+from app.config import COMPANY_LIST_URL, DATABASE_URL, REQUEST_TIMEOUT
 from app.model.db import Company
 from app.model.type import CompanyListItem
-from batch import free_malloc, log
+from batch import log
+from batch.log import BatchLoggerAdapter
 
-process_name = "INDEXER-COMPANY-LIST"
-LOG = log.get_logger(process_name=process_name)
+process_name = "SUB:COMPANY-LIST"
+LOG: BatchLoggerAdapter = log.get_logger(process_name=process_name)
 
 db_engine = create_engine(DATABASE_URL, echo=False, pool_pre_ping=True)
 
@@ -54,10 +46,12 @@ class Processor:
     def __init__(self):
         self.company_list_digest = None
 
+    async def sync_new_logs(self) -> None:
+        self.process()
+
     def process(self):
         LOG.info("Syncing company list")
 
-        # Get from COMPANY_LIST_URL
         if COMPANY_LIST_URL is None:
             LOG.warning("COMPANY_LIST_URL is not set")
             return
@@ -77,7 +71,6 @@ class Processor:
             LOG.exception("Failed to get company list")
             return
 
-        # Check the difference from the previous cycle
         _resp_digest = hashlib.sha256(
             json.dumps(company_list_json).encode()
         ).hexdigest()
@@ -87,13 +80,10 @@ class Processor:
         else:
             self.company_list_digest = _resp_digest
 
-        # Update DB data
         db_session = Session(autocommit=False, autoflush=True, bind=db_engine)
         try:
-            # Delete all company list from DB
             db_session.execute(delete(Company))
 
-            # Insert company list
             for i, company in enumerate(company_list_json):
                 try:
                     company_list_item = CompanyListItem.model_validate(company)  # type: ignore[arg-type]
@@ -141,30 +131,3 @@ class Processor:
                 company_list_item.trustee.corporate_address
             )
         db_session.merge(_company)
-
-
-def main():
-    LOG.info("Service started successfully")
-    processor = Processor()
-    while True:
-        start_time = time.time()
-
-        try:
-            processor.process()
-        except ServiceUnavailable:
-            LOG.notice("An external service was unavailable")
-        except SQLAlchemyError as sa_err:
-            LOG.error(f"A database error has occurred: code={sa_err.code}\n{sa_err}")
-        except Exception:  # Unexpected errors
-            LOG.exception("An exception occurred during processing")
-
-        elapsed_time = time.time() - start_time
-        time.sleep(max(COMPANY_LIST_SLEEP_INTERVAL - elapsed_time, 0))
-        free_malloc()
-
-
-if __name__ == "__main__":
-    try:
-        main()
-    except KeyboardInterrupt:
-        sys.exit(1)

--- a/batch/sub_indexers/indexer_Company_List.py
+++ b/batch/sub_indexers/indexer_Company_List.py
@@ -52,6 +52,7 @@ class Processor:
     def process(self):
         LOG.info("Syncing company list")
 
+        # Get from COMPANY_LIST_URL
         if COMPANY_LIST_URL is None:
             LOG.warning("COMPANY_LIST_URL is not set")
             return
@@ -71,6 +72,7 @@ class Processor:
             LOG.exception("Failed to get company list")
             return
 
+        # Check the difference from the previous cycle
         _resp_digest = hashlib.sha256(
             json.dumps(company_list_json).encode()
         ).hexdigest()
@@ -80,10 +82,13 @@ class Processor:
         else:
             self.company_list_digest = _resp_digest
 
+        # Update DB data
         db_session = Session(autocommit=False, autoflush=True, bind=db_engine)
         try:
+            # Delete all company list from DB
             db_session.execute(delete(Company))
 
+            # Insert company list
             for i, company in enumerate(company_list_json):
                 try:
                     company_list_item = CompanyListItem.model_validate(company)  # type: ignore[arg-type]

--- a/batch/sub_indexers/indexer_Company_List.py
+++ b/batch/sub_indexers/indexer_Company_List.py
@@ -46,9 +46,6 @@ class Processor:
     def __init__(self):
         self.company_list_digest = None
 
-    async def sync_new_logs(self) -> None:
-        self.process()
-
     def process(self):
         LOG.info("Syncing company list")
 

--- a/batch/sub_indexers/indexer_PublicInfo_PublicAccountList.py
+++ b/batch/sub_indexers/indexer_PublicInfo_PublicAccountList.py
@@ -52,6 +52,7 @@ class Processor:
     def process(self):
         LOG.info("Syncing public account list")
 
+        # Get data from PUBLIC_ACCOUNT_LIST_URL
         if PUBLIC_ACCOUNT_LIST_URL is None:
             LOG.warning("PUBLIC_ACCOUNT_LIST_URL is not set")
             return
@@ -71,6 +72,7 @@ class Processor:
             LOG.exception("Failed to get public account list")
             return
 
+        # Check the difference from the previous cycle
         _resp_digest = hashlib.sha256(
             json.dumps(account_list_json).encode()
         ).hexdigest()
@@ -80,10 +82,13 @@ class Processor:
         else:
             self.account_list_digest = _resp_digest
 
+        # Update DB data
         db_session = Session(autocommit=False, autoflush=True, bind=db_engine)
         try:
+            # Delete all account list from DB
             db_session.execute(delete(PublicAccountList))
 
+            # Insert account list
             for i, _account in enumerate(account_list_json):
                 key_manager = _account.get("key_manager", None)
                 key_manager_name = _account.get("key_manager_name", None)

--- a/batch/sub_indexers/indexer_PublicInfo_PublicAccountList.py
+++ b/batch/sub_indexers/indexer_PublicInfo_PublicAccountList.py
@@ -19,8 +19,6 @@ SPDX-License-Identifier: Apache-2.0
 
 import hashlib
 import json
-import sys
-import time
 from typing import Literal
 
 import requests
@@ -28,22 +26,16 @@ from eth_utils.address import to_checksum_address
 from requests.adapters import HTTPAdapter
 from sqlalchemy import delete
 from sqlalchemy.engine.create import create_engine
-from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm.session import Session
 from urllib3 import Retry
 
-from app.config import (
-    DATABASE_URL,
-    PUBLIC_ACCOUNT_LIST_SLEEP_INTERVAL,
-    PUBLIC_ACCOUNT_LIST_URL,
-    REQUEST_TIMEOUT,
-)
-from app.errors import ServiceUnavailable
+from app.config import DATABASE_URL, PUBLIC_ACCOUNT_LIST_URL, REQUEST_TIMEOUT
 from app.model.db import PublicAccountList
-from batch import free_malloc, log
+from batch import log
+from batch.log import BatchLoggerAdapter
 
-process_name = "INDEXER-PUBLIC-INFO-PUBLIC-ACCOUNT"
-LOG = log.get_logger(process_name=process_name)
+process_name = "SUB:PUBLIC-ACCOUNT-LIST"
+LOG: BatchLoggerAdapter = log.get_logger(process_name=process_name)
 
 db_engine = create_engine(DATABASE_URL, echo=False, pool_pre_ping=True)
 
@@ -54,10 +46,12 @@ class Processor:
     def __init__(self):
         self.account_list_digest = None
 
+    async def sync_new_logs(self) -> None:
+        self.process()
+
     def process(self):
         LOG.info("Syncing public account list")
 
-        # Get data from PUBLIC_ACCOUNT_LIST_URL
         if PUBLIC_ACCOUNT_LIST_URL is None:
             LOG.warning("PUBLIC_ACCOUNT_LIST_URL is not set")
             return
@@ -77,7 +71,6 @@ class Processor:
             LOG.exception("Failed to get public account list")
             return
 
-        # Check the difference from the previous cycle
         _resp_digest = hashlib.sha256(
             json.dumps(account_list_json).encode()
         ).hexdigest()
@@ -87,13 +80,10 @@ class Processor:
         else:
             self.account_list_digest = _resp_digest
 
-        # Update DB data
         db_session = Session(autocommit=False, autoflush=True, bind=db_engine)
         try:
-            # Delete all account list from DB
             db_session.execute(delete(PublicAccountList))
 
-            # Insert account list
             for i, _account in enumerate(account_list_json):
                 key_manager = _account.get("key_manager", None)
                 key_manager_name = _account.get("key_manager_name", None)
@@ -153,30 +143,3 @@ class Processor:
         _account_list.account_type = account_type
         _account_list.account_address = account_address
         db_session.merge(_account_list)
-
-
-def main():
-    LOG.info("Service started successfully")
-    processor = Processor()
-    while True:
-        start_time = time.time()
-
-        try:
-            processor.process()
-        except ServiceUnavailable:
-            LOG.notice("An external service was unavailable")
-        except SQLAlchemyError as sa_err:
-            LOG.error(f"A database error has occurred: code={sa_err.code}\n{sa_err}")
-        except Exception:  # Unexpected errors
-            LOG.exception("An exception occurred during processing")
-
-        elapsed_time = time.time() - start_time
-        time.sleep(max(PUBLIC_ACCOUNT_LIST_SLEEP_INTERVAL - elapsed_time, 0))
-        free_malloc()
-
-
-if __name__ == "__main__":
-    try:
-        main()
-    except KeyboardInterrupt:
-        sys.exit(1)

--- a/batch/sub_indexers/indexer_PublicInfo_PublicAccountList.py
+++ b/batch/sub_indexers/indexer_PublicInfo_PublicAccountList.py
@@ -46,9 +46,6 @@ class Processor:
     def __init__(self):
         self.account_list_digest = None
 
-    async def sync_new_logs(self) -> None:
-        self.process()
-
     def process(self):
         LOG.info("Syncing public account list")
 

--- a/batch/sub_indexers/indexer_PublicInfo_TokenList.py
+++ b/batch/sub_indexers/indexer_PublicInfo_TokenList.py
@@ -19,31 +19,23 @@ SPDX-License-Identifier: Apache-2.0
 
 import hashlib
 import json
-import sys
-import time
 
 import requests
 from pydantic import ValidationError
 from requests.adapters import HTTPAdapter
 from sqlalchemy import delete
 from sqlalchemy.engine.create import create_engine
-from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm.session import Session
 from urllib3 import Retry
 
-from app.config import (
-    DATABASE_URL,
-    REQUEST_TIMEOUT,
-    TOKEN_LIST_SLEEP_INTERVAL,
-    TOKEN_LIST_URL,
-)
-from app.errors import ServiceUnavailable
+from app.config import DATABASE_URL, REQUEST_TIMEOUT, TOKEN_LIST_URL
 from app.model.db import TokenList
 from app.model.type.token_list import TokenListItem
-from batch import free_malloc, log
+from batch import log
+from batch.log import BatchLoggerAdapter
 
-process_name = "INDEXER-PUBLIC-INFO-TOKEN-LIST"
-LOG = log.get_logger(process_name=process_name)
+process_name = "SUB:TOKEN-LIST"
+LOG: BatchLoggerAdapter = log.get_logger(process_name=process_name)
 
 db_engine = create_engine(DATABASE_URL, echo=False, pool_pre_ping=True)
 
@@ -54,10 +46,12 @@ class Processor:
     def __init__(self):
         self.token_list_digest = None
 
+    async def sync_new_logs(self) -> None:
+        self.process()
+
     def process(self):
         LOG.info("Syncing token list")
 
-        # Get from TOKEN_LIST_URL
         try:
             if TOKEN_LIST_URL is None:
                 LOG.warning("TOKEN_LIST_URL is not set")
@@ -77,7 +71,6 @@ class Processor:
             LOG.exception("Failed to get token list")
             return
 
-        # Check the difference from the previous cycle
         _resp_digest = hashlib.sha256(json.dumps(token_list_json).encode()).hexdigest()
         if _resp_digest == self.token_list_digest:
             LOG.info("Skip: There are no differences from the previous cycle")
@@ -85,13 +78,10 @@ class Processor:
         else:
             self.token_list_digest = _resp_digest
 
-        # Update DB data
         db_session = Session(autocommit=False, autoflush=True, bind=db_engine)
         try:
-            # Delete all token list from DB
             db_session.execute(delete(TokenList))
 
-            # Insert token list
             for i, token in enumerate(token_list_json):
                 try:
                     token_list_item = TokenListItem.model_validate(token)
@@ -125,30 +115,3 @@ class Processor:
         _token_list.product_type = token_list_item.product_type
         _token_list.issuer_address = token_list_item.issuer_address
         db_session.merge(_token_list)
-
-
-def main():
-    LOG.info("Service started successfully")
-    processor = Processor()
-    while True:
-        start_time = time.time()
-
-        try:
-            processor.process()
-        except ServiceUnavailable:
-            LOG.notice("An external service was unavailable")
-        except SQLAlchemyError as sa_err:
-            LOG.error(f"A database error has occurred: code={sa_err.code}\n{sa_err}")
-        except Exception:  # Unexpected errors
-            LOG.exception("An exception occurred during processing")
-
-        elapsed_time = time.time() - start_time
-        time.sleep(max(TOKEN_LIST_SLEEP_INTERVAL - elapsed_time, 0))
-        free_malloc()
-
-
-if __name__ == "__main__":
-    try:
-        main()
-    except KeyboardInterrupt:
-        sys.exit(1)

--- a/batch/sub_indexers/indexer_PublicInfo_TokenList.py
+++ b/batch/sub_indexers/indexer_PublicInfo_TokenList.py
@@ -46,9 +46,6 @@ class Processor:
     def __init__(self):
         self.token_list_digest = None
 
-    async def sync_new_logs(self) -> None:
-        self.process()
-
     def process(self):
         LOG.info("Syncing token list")
 

--- a/batch/sub_indexers/indexer_PublicInfo_TokenList.py
+++ b/batch/sub_indexers/indexer_PublicInfo_TokenList.py
@@ -52,6 +52,7 @@ class Processor:
     def process(self):
         LOG.info("Syncing token list")
 
+        # Get from TOKEN_LIST_URL
         try:
             if TOKEN_LIST_URL is None:
                 LOG.warning("TOKEN_LIST_URL is not set")
@@ -71,6 +72,7 @@ class Processor:
             LOG.exception("Failed to get token list")
             return
 
+        # Check the difference from the previous cycle
         _resp_digest = hashlib.sha256(json.dumps(token_list_json).encode()).hexdigest()
         if _resp_digest == self.token_list_digest:
             LOG.info("Skip: There are no differences from the previous cycle")
@@ -78,10 +80,13 @@ class Processor:
         else:
             self.token_list_digest = _resp_digest
 
+        # Update DB data
         db_session = Session(autocommit=False, autoflush=True, bind=db_engine)
         try:
+            # Delete all token list from DB
             db_session.execute(delete(TokenList))
 
+            # Insert token list
             for i, token in enumerate(token_list_json):
                 try:
                     token_list_item = TokenListItem.model_validate(token)

--- a/bin/healthcheck_indexer.sh
+++ b/bin/healthcheck_indexer.sh
@@ -17,11 +17,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-if [[ "${APP_ENV:-}" != "local" && "${COMPANY_LIST_LOCAL_MODE:-}" -ne 1 ]]; then
-  PROC_LIST="${PROC_LIST} batch/indexer_Company_List.py"
-fi
-PROC_LIST="${PROC_LIST} batch/indexer_PublicInfo_TokenList.py"
-PROC_LIST="${PROC_LIST} batch/indexer_PublicInfo_PublicAccountList.py"
+PROC_LIST="${PROC_LIST} batch/indexer_PublicInfo_Combined.py"
 PROC_LIST="${PROC_LIST} batch/indexer_Transfer_Combined.py"
 PROC_LIST="${PROC_LIST} batch/indexer_Token_Holders.py"
 PROC_LIST="${PROC_LIST} batch/indexer_Token_List_Event.py"

--- a/bin/run_indexer.sh
+++ b/bin/run_indexer.sh
@@ -36,7 +36,6 @@ if [[ "${APP_ENV:-}" != "local" && "${COMPANY_LIST_LOCAL_MODE:-}" -ne 1 ]]; then
     echo -n "[WARNING] Could not access to COMPANY_LIST_URL, " >&2
     echo "please confirm COMPANY_LIST_URL, which response code is ${resp}" >&2
   fi
-  python batch/indexer_Company_List.py &
 else
   # check company_list.json is default one
   content_length="$(wc -c data/company_list.json | awk '{print $1}')"
@@ -44,7 +43,6 @@ else
     echo '[WARNING] company_list.json is empty. Please mount company_list.json if you use company list local mode.' >&2
   fi
 fi
-
 
 # check TOKEN_LIST_URL
 if [ -z "${TOKEN_LIST_URL:-}" ]; then
@@ -57,8 +55,6 @@ if [ "${resp}" -ne 200 ]; then
   echo -n "[WARNING] Could not access to TOKEN_LIST_URL, " >&2
   echo "please confirm TOKEN_LIST_URL, which response code is ${resp}" >&2
 fi
-python batch/indexer_PublicInfo_TokenList.py &
-
 
 # check PUBLIC_ACCOUNT_LIST_URL
 if [ -z "${PUBLIC_ACCOUNT_LIST_URL:-}" ]; then
@@ -71,8 +67,8 @@ if [ "${resp}" -ne 200 ]; then
   echo -n "[WARNING] Could not access to PUBLIC_ACCOUNT_LIST_URL, " >&2
   echo "please confirm PUBLIC_ACCOUNT_LIST_URL, which response code is ${resp}" >&2
 fi
-python batch/indexer_PublicInfo_PublicAccountList.py &
 
+python batch/indexer_PublicInfo_Combined.py &
 
 python batch/indexer_Transfer_Combined.py &
 python batch/indexer_Token_Holders.py &

--- a/tests/batch/indexer_Company_List_test.py
+++ b/tests/batch/indexer_Company_List_test.py
@@ -29,7 +29,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.model.db import Company
-from batch.indexer_Company_List import LOG, Processor
+from batch.sub_indexers.indexer_Company_List import LOG, Processor
 
 
 @pytest.fixture(scope="function")
@@ -57,7 +57,9 @@ class MockResponse:
         return self.data
 
 
-@mock.patch("batch.indexer_Company_List.COMPANY_LIST_URL", "https://localhost")
+@mock.patch(
+    "batch.sub_indexers.indexer_Company_List.COMPANY_LIST_URL", "https://localhost"
+)
 @pytest.mark.asyncio
 class TestProcessor:
     ###########################################################################

--- a/tests/batch/indexer_PublicInfo_PublicAccountList_test.py
+++ b/tests/batch/indexer_PublicInfo_PublicAccountList_test.py
@@ -29,7 +29,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.model.db import PublicAccountList
-from batch.indexer_PublicInfo_PublicAccountList import LOG, Processor
+from batch.sub_indexers.indexer_PublicInfo_PublicAccountList import LOG, Processor
 
 
 @pytest.fixture(scope="function")
@@ -58,7 +58,7 @@ class MockResponse:
 
 
 @mock.patch(
-    "batch.indexer_PublicInfo_PublicAccountList.PUBLIC_ACCOUNT_LIST_URL",
+    "batch.sub_indexers.indexer_PublicInfo_PublicAccountList.PUBLIC_ACCOUNT_LIST_URL",
     "http://test/public_account_list.json",
 )
 @pytest.mark.asyncio

--- a/tests/batch/indexer_PublicInfo_TokenList_test.py
+++ b/tests/batch/indexer_PublicInfo_TokenList_test.py
@@ -30,7 +30,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.model.db import TokenList
-from batch.indexer_PublicInfo_TokenList import LOG, Processor
+from batch.sub_indexers.indexer_PublicInfo_TokenList import LOG, Processor
 
 
 @pytest.fixture(scope="function")
@@ -58,7 +58,10 @@ class MockResponse:
         return self.data
 
 
-@mock.patch("batch.indexer_PublicInfo_TokenList.TOKEN_LIST_URL", "https://localhost")
+@mock.patch(
+    "batch.sub_indexers.indexer_PublicInfo_TokenList.TOKEN_LIST_URL",
+    "https://localhost",
+)
 @pytest.mark.asyncio
 class TestProcessor:
     ###########################################################################


### PR DESCRIPTION
This pull request refactors the batch indexer processes for company, public account, and token lists by modularizing them into sub-indexers and introducing a new combined orchestrator.

## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
None

## 🔄 Changes

<!-- List the major changes in this PR. -->

**Major refactoring and architecture changes:**

* Introduced a new orchestrator script `indexer_PublicInfo_Combined.py` that asynchronously schedules and runs the company, public account, and token list sub-indexers, centralizing process management and error handling.
* Moved the company, public account, and token list indexers into the `batch/sub_indexers/` directory, renaming the files for clarity and modularity.

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
