### PR TITLE
Batch fetch logs and refactor event indexing (Transfer/TransferApproval)

### DIFF
--- a/batch/sub_indexers/indexer_Transfer.py
+++ b/batch/sub_indexers/indexer_Transfer.py
@@ -332,11 +332,27 @@ class Processor:
         self, db_session: AsyncSession, block_from: int, block_to: int
     ):
         LOG.info(f"STEP-2_{block_from}-{block_to}")
-        await self.__sync_transfer(db_session, block_from, block_to)
-        await self.__sync_unlock(db_session, block_from, block_to)
-        await self.__sync_force_unlock(db_session, block_from, block_to)
-        await self.__sync_force_change_locked_account(db_session, block_from, block_to)
+        active_targets = self.__filter_active_targets(block_to)
+        if len(active_targets) == 0:
+            return
+
+        await self.__sync_transfer(db_session, block_from, block_to, active_targets)
+        await self.__sync_unlock(db_session, block_from, block_to, active_targets)
+        await self.__sync_force_unlock(db_session, block_from, block_to, active_targets)
+        await self.__sync_force_change_locked_account(
+            db_session, block_from, block_to, active_targets
+        )
         await self.__update_skip_block(db_session)
+
+    def __filter_active_targets(
+        self, block_to: int
+    ) -> list[TargetTokenList.TargetToken]:
+        """Return tokens that may still have unsynchronized logs up to block_to."""
+        return [
+            target
+            for target in self.token_list
+            if target.skip_block is None or block_to > target.skip_block
+        ]
 
     @staticmethod
     def __chunked(values: list[str], chunk_size: int) -> list[list[str]]:
@@ -353,7 +369,11 @@ class Processor:
         return Web3.keccak(text=signature).to_0x_hex()
 
     async def __get_logs_by_event(
-        self, event_name: str, block_from: int, block_to: int
+        self,
+        event_name: str,
+        block_from: int,
+        block_to: int,
+        targets: Sequence[TargetTokenList.TargetToken],
     ) -> list[tuple[TargetTokenList.TargetToken, EventData]]:
         """Fetch logs once per event type, then decode and map to each target token.
 
@@ -365,46 +385,30 @@ class Processor:
         """
         target_by_address: dict[str, Processor.TargetTokenList.TargetToken] = {}
         event_decoder_by_address: dict[str, AsyncContractEvent] = {}
-        topic0_set: set[str] = set()
+        topic0: str | None = None
 
-        for target in self.token_list:
-            if target.skip_block is not None and block_to <= target.skip_block:
-                # Already synchronized up to block_to. Skip RPC call and processing.
-                LOG.debug(f"{target.token_contract.address}: block_to <= skip_block")
-                continue
-            elif (
-                target.skip_block is not None
-                and block_from <= target.skip_block < block_to
-            ):
-                # Request range partially overlaps with already synchronized range.
-                LOG.debug(
-                    f"{target.token_contract.address}: block_from <= skip_block < block_to"
-                )
-            else:
-                # Full request range is potentially unsynchronized for this token.
-                LOG.debug(
-                    f"{target.token_contract.address}: skip_block < block_from < block_to"
-                )
+        for target in targets:
+            token = target.token_contract
 
-            token_address = to_checksum_address(target.token_contract.address)
-            target_by_address[token_address] = target
-
-            event_class: Any = getattr(target.token_contract.events, event_name, None)
+            event_class: Any = getattr(token.events, event_name, None)
             if event_class is None:
                 continue
             event_decoder = event_class()
             if not isinstance(event_decoder, AsyncContractEvent):
                 continue
 
+            token_address = to_checksum_address(token.address)
+            target_by_address[token_address] = target
             event_decoder_by_address[token_address] = event_decoder
-            topic0_set.add(self.__build_topic0(event_name, event_decoder.abi))
+            if topic0 is None:
+                topic0 = self.__build_topic0(event_name, event_decoder.abi)
 
-        if len(target_by_address) == 0:
+        if len(target_by_address) == 0 or topic0 is None:
             return []
 
         logs: list[tuple[Processor.TargetTokenList.TargetToken, EventData]] = []
         target_addresses = list(target_by_address.keys())
-        topics = [list(topic0_set)]
+        topics = [[topic0]]
 
         for address_chunk in self.__chunked(target_addresses, self.ADDRESS_CHUNK_SIZE):
             # One eth_getLogs request per event type + address chunk.
@@ -450,7 +454,11 @@ class Processor:
         return logs
 
     async def __sync_transfer(
-        self, db_session: AsyncSession, block_from: int, block_to: int
+        self,
+        db_session: AsyncSession,
+        block_from: int,
+        block_to: int,
+        targets: Sequence[TargetTokenList.TargetToken],
     ):
         """Sync Transfer events
 
@@ -461,7 +469,9 @@ class Processor:
         """
         # Fetch once by event type and process per-token with skip guards.
         try:
-            events = await self.__get_logs_by_event("Transfer", block_from, block_to)
+            events = await self.__get_logs_by_event(
+                "Transfer", block_from, block_to, targets
+            )
         except ABIEventNotFound:
             events = []
 
@@ -519,7 +529,11 @@ class Processor:
             raise e
 
     async def __sync_unlock(
-        self, db_session: AsyncSession, block_from: int, block_to: int
+        self,
+        db_session: AsyncSession,
+        block_from: int,
+        block_to: int,
+        targets: Sequence[TargetTokenList.TargetToken],
     ):
         """Synchronize Unlock events
 
@@ -530,7 +544,9 @@ class Processor:
         """
         # Fetch once by event type and process per-token with skip guards.
         try:
-            events = await self.__get_logs_by_event("Unlock", block_from, block_to)
+            events = await self.__get_logs_by_event(
+                "Unlock", block_from, block_to, targets
+            )
         except ABIEventNotFound:
             events = []
 
@@ -567,7 +583,11 @@ class Processor:
             raise
 
     async def __sync_force_unlock(
-        self, db_session: AsyncSession, block_from: int, block_to: int
+        self,
+        db_session: AsyncSession,
+        block_from: int,
+        block_to: int,
+        targets: Sequence[TargetTokenList.TargetToken],
     ):
         """Synchronize ForceUnlock events
 
@@ -578,7 +598,9 @@ class Processor:
         """
         # Fetch once by event type and process per-token with skip guards.
         try:
-            events = await self.__get_logs_by_event("ForceUnlock", block_from, block_to)
+            events = await self.__get_logs_by_event(
+                "ForceUnlock", block_from, block_to, targets
+            )
         except ABIEventNotFound:
             events = []
 
@@ -616,7 +638,11 @@ class Processor:
             raise
 
     async def __sync_force_change_locked_account(
-        self, db_session: AsyncSession, block_from: int, block_to: int
+        self,
+        db_session: AsyncSession,
+        block_from: int,
+        block_to: int,
+        targets: Sequence[TargetTokenList.TargetToken],
     ):
         """Synchronize ForceChangeLockedAccount events
 
@@ -628,7 +654,7 @@ class Processor:
         # Fetch once by event type and process per-token with skip guards.
         try:
             events = await self.__get_logs_by_event(
-                "ForceChangeLockedAccount", block_from, block_to
+                "ForceChangeLockedAccount", block_from, block_to, targets
             )
         except ABIEventNotFound:
             events = []

--- a/batch/sub_indexers/indexer_Transfer.py
+++ b/batch/sub_indexers/indexer_Transfer.py
@@ -243,8 +243,12 @@ class Processor:
         try:
             LOG.info("Syncing to={}".format(latest_block))
 
+            LOG.info("STEP-1")
+
             # Refresh listed tokens
             await self.__get_token_list(local_session)
+
+            LOG.info("STEP-2")
 
             # Synchronize 1,000,000 blocks each
             _to_block = 999_999
@@ -258,6 +262,8 @@ class Processor:
             else:
                 await self.__sync_all(local_session, _from_block, latest_block)
 
+            LOG.info("STEP-3")
+
             # Update latest synchronized block numbers
             await self.__update_idx_latest_block(
                 db_session=local_session,
@@ -265,6 +271,9 @@ class Processor:
                 block_number=latest_block,
             )
             await local_session.commit()
+
+            LOG.info("STEP-4")
+
         except Exception as e:
             await local_session.rollback()
             raise e

--- a/batch/sub_indexers/indexer_Transfer.py
+++ b/batch/sub_indexers/indexer_Transfer.py
@@ -331,6 +331,7 @@ class Processor:
     async def __sync_all(
         self, db_session: AsyncSession, block_from: int, block_to: int
     ):
+        LOG.info(f"STEP-2_{block_from}-{block_to}")
         await self.__sync_transfer(db_session, block_from, block_to)
         await self.__sync_unlock(db_session, block_from, block_to)
         await self.__sync_force_unlock(db_session, block_from, block_to)

--- a/batch/sub_indexers/indexer_Transfer.py
+++ b/batch/sub_indexers/indexer_Transfer.py
@@ -368,23 +368,28 @@ class Processor:
         topic0_set: set[str] = set()
 
         for target in self.token_list:
-            token = target.token_contract
-            skip_block = target.skip_block
-            if skip_block is not None and block_to <= skip_block:
+            if target.skip_block is not None and block_to <= target.skip_block:
                 # Already synchronized up to block_to. Skip RPC call and processing.
-                LOG.debug(f"{token.address}: block_to <= skip_block")
+                LOG.debug(f"{target.token_contract.address}: block_to <= skip_block")
                 continue
-            elif skip_block is not None and block_from <= skip_block < block_to:
+            elif (
+                target.skip_block is not None
+                and block_from <= target.skip_block < block_to
+            ):
                 # Request range partially overlaps with already synchronized range.
-                LOG.debug(f"{token.address}: block_from <= skip_block < block_to")
+                LOG.debug(
+                    f"{target.token_contract.address}: block_from <= skip_block < block_to"
+                )
             else:
                 # Full request range is potentially unsynchronized for this token.
-                LOG.debug(f"{token.address}: skip_block < block_from < block_to")
+                LOG.debug(
+                    f"{target.token_contract.address}: skip_block < block_from < block_to"
+                )
 
-            token_address = to_checksum_address(token.address)
+            token_address = to_checksum_address(target.token_contract.address)
             target_by_address[token_address] = target
 
-            event_class: Any = getattr(token.events, event_name, None)
+            event_class: Any = getattr(target.token_contract.events, event_name, None)
             if event_class is None:
                 continue
             event_decoder = event_class()

--- a/batch/sub_indexers/indexer_Transfer.py
+++ b/batch/sub_indexers/indexer_Transfer.py
@@ -340,7 +340,7 @@ class Processor:
             [input_param["type"] for input_param in event_abi.get("inputs", [])]
         )
         signature = f"{event_name}({input_types})"
-        return Web3.keccak(text=signature).hex()
+        return Web3.keccak(text=signature).to_0x_hex()
 
     async def __get_logs_by_event(
         self, event_name: str, block_from: int, block_to: int

--- a/batch/sub_indexers/indexer_Transfer.py
+++ b/batch/sub_indexers/indexer_Transfer.py
@@ -20,15 +20,17 @@ SPDX-License-Identifier: Apache-2.0
 import json
 import sys
 from datetime import datetime, timedelta, timezone
-from typing import Any, List, Optional, Sequence
+from typing import Any, List, Optional, Sequence, cast
 
 from eth_utils.address import to_checksum_address
 from hexbytes import HexBytes
 from pydantic import ValidationError
 from sqlalchemy import desc, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from web3 import Web3
+from web3.contract.async_contract import AsyncContractEvent
 from web3.exceptions import ABIEventNotFound
-from web3.types import EventData
+from web3.types import EventData, FilterParams
 
 from app.config import TOKEN_LIST_CONTRACT_ADDRESS, ZERO_ADDRESS
 from app.contracts import AsyncContract
@@ -54,6 +56,10 @@ async_web3 = AsyncWeb3Wrapper()
 
 class Processor:
     """Processor for indexing Token transfer events"""
+
+    # Maximum number of contract addresses in one eth_getLogs request.
+    # This is a trade-off between request count and payload size.
+    ADDRESS_CHUNK_SIZE = 200
 
     class TargetTokenList:
         class TargetToken:
@@ -322,6 +328,112 @@ class Processor:
         await self.__sync_force_change_locked_account(db_session, block_from, block_to)
         await self.__update_skip_block(db_session)
 
+    @staticmethod
+    def __chunked(values: list[str], chunk_size: int) -> list[list[str]]:
+        """Split a list into fixed-size chunks."""
+        return [values[i : i + chunk_size] for i in range(0, len(values), chunk_size)]
+
+    @staticmethod
+    def __build_topic0(event_name: str, event_abi: Any) -> str:
+        """Build topic0 (= event signature hash) from event ABI."""
+        input_types = ",".join(
+            [input_param["type"] for input_param in event_abi.get("inputs", [])]
+        )
+        signature = f"{event_name}({input_types})"
+        return Web3.keccak(text=signature).hex()
+
+    async def __get_logs_by_event(
+        self, event_name: str, block_from: int, block_to: int
+    ) -> list[tuple[TargetTokenList.TargetToken, EventData]]:
+        """Fetch logs once per event type, then decode and map to each target token.
+
+        Flow:
+        1) Build target token/decoder maps
+        2) Query logs in address chunks with shared topic0 filter
+        3) Filter out already synchronized logs by per-token skip_block
+        4) Decode and return logs sorted by (blockNumber, logIndex)
+        """
+        target_by_address: dict[str, Processor.TargetTokenList.TargetToken] = {}
+        event_decoder_by_address: dict[str, AsyncContractEvent] = {}
+        topic0_set: set[str] = set()
+
+        for target in self.token_list:
+            token = target.token_contract
+            skip_block = target.skip_block
+            if skip_block is not None and block_to <= skip_block:
+                # Already synchronized up to block_to. Skip RPC call and processing.
+                LOG.debug(f"{token.address}: block_to <= skip_block")
+                continue
+            elif skip_block is not None and block_from <= skip_block < block_to:
+                # Request range partially overlaps with already synchronized range.
+                LOG.debug(f"{token.address}: block_from <= skip_block < block_to")
+            else:
+                # Full request range is potentially unsynchronized for this token.
+                LOG.debug(f"{token.address}: skip_block < block_from < block_to")
+
+            token_address = to_checksum_address(token.address)
+            target_by_address[token_address] = target
+
+            event_class: Any = getattr(token.events, event_name, None)
+            if event_class is None:
+                continue
+            event_decoder = event_class()
+            if not isinstance(event_decoder, AsyncContractEvent):
+                continue
+
+            event_decoder_by_address[token_address] = event_decoder
+            topic0_set.add(self.__build_topic0(event_name, event_decoder.abi))
+
+        if len(target_by_address) == 0:
+            return []
+
+        logs: list[tuple[Processor.TargetTokenList.TargetToken, EventData]] = []
+        target_addresses = list(target_by_address.keys())
+        topics = [list(topic0_set)]
+
+        for address_chunk in self.__chunked(target_addresses, self.ADDRESS_CHUNK_SIZE):
+            # One eth_getLogs request per event type + address chunk.
+            filter_params = cast(
+                FilterParams,
+                {
+                    "fromBlock": block_from,
+                    "toBlock": block_to,
+                    "address": address_chunk,
+                    "topics": topics,
+                },
+            )
+            raw_logs = await async_web3.eth.get_logs(filter_params)
+            for raw_log in raw_logs:
+                # Map log to target token by address.
+                token_address = to_checksum_address(raw_log["address"])
+                target = target_by_address.get(token_address)
+                if target is None:
+                    continue
+
+                # Skip logs that are already synchronized based on per-token skip_block.
+                if (
+                    target.skip_block is not None
+                    and raw_log["blockNumber"] <= target.skip_block
+                ):
+                    continue
+
+                # Decode log with corresponding event decoder.
+                event_decoder = event_decoder_by_address.get(token_address)
+                if event_decoder is None:
+                    continue
+
+                try:
+                    event = event_decoder.process_log(raw_log)
+                    logs.append((target, event))
+                except Exception:
+                    continue
+
+        # Sort logs by (blockNumber, logIndex) to ensure correct processing order.
+        logs.sort(
+            key=lambda log_data: (log_data[1]["blockNumber"], log_data[1]["logIndex"])
+        )
+        return logs
+
     async def __sync_transfer(
         self, db_session: AsyncSession, block_from: int, block_to: int
     ):
@@ -332,89 +444,64 @@ class Processor:
         :param block_to: To block
         :return:
         """
-        for target in self.token_list:
-            token = target.token_contract
-            skip_timestamp = target.skip_timestamp
-            skip_block = target.skip_block
-            events_view: Any = token.events
+        # Fetch once by event type and process per-token with skip guards.
+        try:
+            events = await self.__get_logs_by_event("Transfer", block_from, block_to)
+        except ABIEventNotFound:
+            events = []
 
-            # Get "Transfer" logs
-            try:
-                if skip_block is not None and block_to <= skip_block:
-                    # Skip if the token has already been synchronized to block_to.
-                    LOG.debug(f"{token.address}: block_to <= skip_block")
+        try:
+            for target, event in events:
+                token = target.token_contract
+                skip_timestamp = target.skip_timestamp
+                args = event["args"]
+                value = args.get("value", 0)
+                if value > sys.maxsize:
                     continue
-                elif skip_block is not None and block_from <= skip_block < block_to:
-                    # block_from <= skip_block < block_to
-                    LOG.debug(f"{token.address}: block_from <= skip_block < block_to")
-                    events: list[EventData] = await events_view.Transfer.get_logs(
-                        from_block=skip_block + 1, to_block=block_to
-                    )
-                else:
-                    # No logs or
-                    # skip_block < block_from < block_to
-                    LOG.debug(f"{token.address}: skip_block < block_from < block_to")
-                    events = await events_view.Transfer.get_logs(
-                        from_block=block_from, to_block=block_to
-                    )
-            except ABIEventNotFound:
-                events = []
 
-            # Index logs
-            try:
-                for event in events:
-                    args = event["args"]
-                    value = args.get("value", 0)
-                    if value > sys.maxsize:
-                        pass
-                    else:
-                        event_created = await self.__gen_block_timestamp(event=event)
-                        if event_created is None:
-                            continue
-                        if (
-                            skip_timestamp is not None
-                            and event_created <= skip_timestamp
-                        ):
-                            LOG.debug(
-                                f"Skip Registry Transfer data in DB: blockNumber={event['blockNumber']}"
-                            )
-                            continue
+                event_created = await self.__gen_block_timestamp(event=event)
+                if event_created is None:
+                    continue
+                if skip_timestamp is not None and event_created <= skip_timestamp:
+                    LOG.debug(
+                        f"Skip Registry Transfer data in DB: blockNumber={event['blockNumber']}"
+                    )
+                    continue
 
-                        # Judge whether the transfer is a reallocation
-                        transaction_hash = event["transactionHash"].to_0x_hex()
-                        is_reallocation = False
-                        tx = await AsyncContract.get_transaction(
-                            event["transactionHash"], event["blockNumber"]
-                        )
-                        if tx is not None:
-                            tx_data: HexBytes | None = tx.get("input")
-                            # Check if the transaction data contains the reallocation marker("c0ffee00")
-                            if tx_data is not None and "c0ffee00" in tx_data.hex():
-                                try:
-                                    raw_call_data = tx_data.hex().split("c0ffee00", 1)[
-                                        1
-                                    ]
-                                    call_data = json.loads(bytes.fromhex(raw_call_data))
-                                    if call_data.get("purpose") == "Reallocation":
-                                        is_reallocation = True
-                                except (ValueError, json.JSONDecodeError):
-                                    # If decoding fails, treat it as a normal transfer
-                                    pass
-                        self.__insert_idx(
-                            db_session=db_session,
-                            transaction_hash=transaction_hash,
-                            token_address=to_checksum_address(token.address),
-                            from_account_address=args.get("from", ZERO_ADDRESS),
-                            to_account_address=args.get("to", ZERO_ADDRESS),
-                            value=value,
-                            source_event=IDXTransferSourceEventType.REALLOCATION
-                            if is_reallocation is True
-                            else IDXTransferSourceEventType.TRANSFER,
-                            data_str=None,
-                            event_created=event_created,
-                        )
-            except Exception as e:
-                raise e
+                # Judge whether the transfer is a reallocation
+                transaction_hash = event["transactionHash"].to_0x_hex()
+                is_reallocation = False
+                tx = await AsyncContract.get_transaction(
+                    event["transactionHash"], event["blockNumber"]
+                )
+                if tx is not None:
+                    tx_data: HexBytes | None = tx.get("input")
+                    # Check if the transaction data contains the reallocation marker("c0ffee00")
+                    if tx_data is not None and "c0ffee00" in tx_data.hex():
+                        try:
+                            raw_call_data = tx_data.hex().split("c0ffee00", 1)[1]
+                            call_data = json.loads(bytes.fromhex(raw_call_data))
+                            if call_data.get("purpose") == "Reallocation":
+                                is_reallocation = True
+                        except (ValueError, json.JSONDecodeError):
+                            # If decoding fails, treat it as a normal transfer
+                            pass
+
+                self.__insert_idx(
+                    db_session=db_session,
+                    transaction_hash=transaction_hash,
+                    token_address=to_checksum_address(token.address),
+                    from_account_address=args.get("from", ZERO_ADDRESS),
+                    to_account_address=args.get("to", ZERO_ADDRESS),
+                    value=value,
+                    source_event=IDXTransferSourceEventType.REALLOCATION
+                    if is_reallocation is True
+                    else IDXTransferSourceEventType.TRANSFER,
+                    data_str=None,
+                    event_created=event_created,
+                )
+        except Exception as e:
+            raise e
 
     async def __sync_unlock(
         self, db_session: AsyncSession, block_from: int, block_to: int
@@ -426,64 +513,43 @@ class Processor:
         :param block_to: to block number
         :return: None
         """
-        for target in self.token_list:
-            token = target.token_contract
-            skip_block = target.skip_block
-            events_view: Any = token.events
+        # Fetch once by event type and process per-token with skip guards.
+        try:
+            events = await self.__get_logs_by_event("Unlock", block_from, block_to)
+        except ABIEventNotFound:
+            events = []
 
-            # Get "Unlock" logs
-            try:
-                if skip_block is not None and block_to <= skip_block:
-                    # Skip if the token has already been synchronized to block_to.
-                    LOG.debug(f"{token.address}: block_to <= skip_block")
+        try:
+            for target, event in events:
+                token = target.token_contract
+                args = event["args"]
+                transaction_hash = event["transactionHash"].to_0x_hex()
+                block_data = await async_web3.eth.get_block(event["blockNumber"])
+                assert "timestamp" in block_data
+                block_timestamp = datetime.fromtimestamp(
+                    block_data["timestamp"],
+                    UTC,
+                ).replace(tzinfo=None)
+                if args.get("value", 0) > sys.maxsize:
                     continue
-                elif skip_block is not None and block_from <= skip_block < block_to:
-                    # block_from <= skip_block < block_to
-                    LOG.debug(f"{token.address}: block_from <= skip_block < block_to")
-                    events: list[EventData] = await events_view.Unlock.get_logs(
-                        from_block=skip_block + 1, to_block=block_to
-                    )
-                else:
-                    # No logs or
-                    # skip_block < block_from < block_to
-                    LOG.debug(f"{token.address}: skip_block < block_from < block_to")
-                    events = await events_view.Unlock.get_logs(
-                        from_block=block_from, to_block=block_to
-                    )
-            except ABIEventNotFound:
-                events = []
 
-            # Index logs
-            try:
-                for event in events:
-                    args = event["args"]
-                    transaction_hash = event["transactionHash"].to_0x_hex()
-                    block_data = await async_web3.eth.get_block(event["blockNumber"])
-                    assert "timestamp" in block_data
-                    block_timestamp = datetime.fromtimestamp(
-                        block_data["timestamp"],
-                        UTC,
-                    ).replace(tzinfo=None)
-                    if args.get("value", 0) > sys.maxsize:
-                        pass
-                    else:
-                        from_address = args.get("accountAddress", ZERO_ADDRESS)
-                        to_address = args.get("recipientAddress", ZERO_ADDRESS)
-                        data_str = args.get("data", "")
-                        if from_address != to_address:
-                            self.__insert_idx(
-                                db_session=db_session,
-                                transaction_hash=transaction_hash,
-                                token_address=to_checksum_address(token.address),
-                                from_account_address=from_address,
-                                to_account_address=to_address,
-                                value=args.get("value", 0),
-                                source_event=IDXTransferSourceEventType.UNLOCK,
-                                data_str=data_str,
-                                event_created=block_timestamp,
-                            )
-            except Exception:
-                raise
+                from_address = args.get("accountAddress", ZERO_ADDRESS)
+                to_address = args.get("recipientAddress", ZERO_ADDRESS)
+                data_str = args.get("data", "")
+                if from_address != to_address:
+                    self.__insert_idx(
+                        db_session=db_session,
+                        transaction_hash=transaction_hash,
+                        token_address=to_checksum_address(token.address),
+                        from_account_address=from_address,
+                        to_account_address=to_address,
+                        value=args.get("value", 0),
+                        source_event=IDXTransferSourceEventType.UNLOCK,
+                        data_str=data_str,
+                        event_created=block_timestamp,
+                    )
+        except Exception:
+            raise
 
     async def __sync_force_unlock(
         self, db_session: AsyncSession, block_from: int, block_to: int
@@ -495,64 +561,44 @@ class Processor:
         :param block_to: to block number
         :return: None
         """
-        for target in self.token_list:
-            token = target.token_contract
-            skip_block = target.skip_block
-            events_view: Any = token.events
+        # Fetch once by event type and process per-token with skip guards.
+        try:
+            events = await self.__get_logs_by_event("ForceUnlock", block_from, block_to)
+        except ABIEventNotFound:
+            events = []
 
-            # Get "ForceUnlock" logs
-            try:
-                if skip_block is not None and block_to <= skip_block:
-                    # Skip if the token has already been synchronized to block_to.
-                    LOG.debug(f"{token.address}: block_to <= skip_block")
+        try:
+            for target, event in events:
+                token = target.token_contract
+                args = event["args"]
+                transaction_hash = event["transactionHash"].to_0x_hex()
+                block_data = await async_web3.eth.get_block(event["blockNumber"])
+                assert "timestamp" in block_data
+                block_timestamp = datetime.fromtimestamp(
+                    block_data["timestamp"],
+                    UTC,
+                ).replace(tzinfo=None)
+                if args.get("value", 0) > sys.maxsize:
                     continue
-                elif skip_block is not None and block_from <= skip_block < block_to:
-                    # block_from <= skip_block < block_to
-                    LOG.debug(f"{token.address}: block_from <= skip_block < block_to")
-                    events: list[EventData] = await events_view.ForceUnlock.get_logs(
-                        from_block=skip_block + 1, to_block=block_to
-                    )
-                else:
-                    # No logs or
-                    # skip_block < block_from < block_to
-                    LOG.debug(f"{token.address}: skip_block < block_from < block_to")
-                    events = await events_view.ForceUnlock.get_logs(
-                        from_block=block_from, to_block=block_to
-                    )
-            except ABIEventNotFound:
-                events = []
 
-            # Index logs
-            try:
-                for event in events:
-                    args = event["args"]
-                    transaction_hash = event["transactionHash"].to_0x_hex()
-                    block_data = await async_web3.eth.get_block(event["blockNumber"])
-                    assert "timestamp" in block_data
-                    block_timestamp = datetime.fromtimestamp(
-                        block_data["timestamp"],
-                        UTC,
-                    ).replace(tzinfo=None)
-                    if args.get("value", 0) > sys.maxsize:
-                        pass
-                    else:
-                        from_address = args.get("accountAddress", ZERO_ADDRESS)
-                        to_address = args.get("recipientAddress", ZERO_ADDRESS)
-                        data_str = args.get("data", "")
-                        if from_address != to_address:
-                            self.__insert_idx(
-                                db_session=db_session,
-                                transaction_hash=transaction_hash,
-                                token_address=to_checksum_address(token.address),
-                                from_account_address=from_address,
-                                to_account_address=to_address,
-                                value=args.get("value", 0),
-                                source_event=IDXTransferSourceEventType.FORCE_UNLOCK,
-                                data_str=data_str,
-                                event_created=block_timestamp,
-                            )
-            except Exception:
-                raise
+                # Only insert if from and to addresses are different.
+                from_address = args.get("accountAddress", ZERO_ADDRESS)
+                to_address = args.get("recipientAddress", ZERO_ADDRESS)
+                data_str = args.get("data", "")
+                if from_address != to_address:
+                    self.__insert_idx(
+                        db_session=db_session,
+                        transaction_hash=transaction_hash,
+                        token_address=to_checksum_address(token.address),
+                        from_account_address=from_address,
+                        to_account_address=to_address,
+                        value=args.get("value", 0),
+                        source_event=IDXTransferSourceEventType.FORCE_UNLOCK,
+                        data_str=data_str,
+                        event_created=block_timestamp,
+                    )
+        except Exception:
+            raise
 
     async def __sync_force_change_locked_account(
         self, db_session: AsyncSession, block_from: int, block_to: int
@@ -564,66 +610,46 @@ class Processor:
         :param block_to: to block number
         :return: None
         """
-        for target in self.token_list:
-            token = target.token_contract
-            skip_block = target.skip_block
-            events_view: Any = token.events
+        # Fetch once by event type and process per-token with skip guards.
+        try:
+            events = await self.__get_logs_by_event(
+                "ForceChangeLockedAccount", block_from, block_to
+            )
+        except ABIEventNotFound:
+            events = []
 
-            # Get "ForceChangeLockedAccount" logs
-            try:
-                if skip_block is not None and block_to <= skip_block:
-                    # Skip if the token has already been synchronized to block_to.
-                    LOG.debug(f"{token.address}: block_to <= skip_block")
+        try:
+            for target, event in events:
+                token = target.token_contract
+                args = event["args"]
+                transaction_hash = event["transactionHash"].to_0x_hex()
+                block_data = await async_web3.eth.get_block(event["blockNumber"])
+                assert "timestamp" in block_data
+                block_timestamp = datetime.fromtimestamp(
+                    block_data["timestamp"],
+                    UTC,
+                ).replace(tzinfo=None)
+                if args.get("value", 0) > sys.maxsize:
                     continue
-                elif skip_block is not None and block_from <= skip_block < block_to:
-                    # block_from <= skip_block < block_to
-                    LOG.debug(f"{token.address}: block_from <= skip_block < block_to")
-                    events: list[
-                        EventData
-                    ] = await events_view.ForceChangeLockedAccount.get_logs(
-                        from_block=skip_block + 1, to_block=block_to
-                    )
-                else:
-                    # No logs or
-                    # skip_block < block_from < block_to
-                    LOG.debug(f"{token.address}: skip_block < block_from < block_to")
-                    events = await events_view.ForceChangeLockedAccount.get_logs(
-                        from_block=block_from, to_block=block_to
-                    )
-            except ABIEventNotFound:
-                events = []
 
-            # Index logs
-            try:
-                for event in events:
-                    args = event["args"]
-                    transaction_hash = event["transactionHash"].to_0x_hex()
-                    block_data = await async_web3.eth.get_block(event["blockNumber"])
-                    assert "timestamp" in block_data
-                    block_timestamp = datetime.fromtimestamp(
-                        block_data["timestamp"],
-                        UTC,
-                    ).replace(tzinfo=None)
-                    if args.get("value", 0) > sys.maxsize:
-                        pass
-                    else:
-                        from_address = args.get("beforeAccountAddress", ZERO_ADDRESS)
-                        to_address = args.get("afterAccountAddress", ZERO_ADDRESS)
-                        data_str = args.get("data", "")
-                        if from_address != to_address:
-                            self.__insert_idx(
-                                db_session=db_session,
-                                transaction_hash=transaction_hash,
-                                token_address=to_checksum_address(token.address),
-                                from_account_address=from_address,
-                                to_account_address=to_address,
-                                value=args.get("value", 0),
-                                source_event=IDXTransferSourceEventType.FORCE_CHANGE_LOCKED_ACCOUNT,
-                                data_str=data_str,
-                                event_created=block_timestamp,
-                            )
-            except Exception:
-                raise
+                # Only insert if from and to addresses are different.
+                from_address = args.get("beforeAccountAddress", ZERO_ADDRESS)
+                to_address = args.get("afterAccountAddress", ZERO_ADDRESS)
+                data_str = args.get("data", "")
+                if from_address != to_address:
+                    self.__insert_idx(
+                        db_session=db_session,
+                        transaction_hash=transaction_hash,
+                        token_address=to_checksum_address(token.address),
+                        from_account_address=from_address,
+                        to_account_address=to_address,
+                        value=args.get("value", 0),
+                        source_event=IDXTransferSourceEventType.FORCE_CHANGE_LOCKED_ACCOUNT,
+                        data_str=data_str,
+                        event_created=block_timestamp,
+                    )
+        except Exception:
+            raise
 
     async def __update_skip_block(self, db_session: AsyncSession):
         """Memorize the block number where next processing should start from

--- a/batch/sub_indexers/indexer_Transfer.py
+++ b/batch/sub_indexers/indexer_Transfer.py
@@ -243,12 +243,8 @@ class Processor:
         try:
             LOG.info("Syncing to={}".format(latest_block))
 
-            LOG.info("STEP-1")
-
             # Refresh listed tokens
             await self.__get_token_list(local_session)
-
-            LOG.info("STEP-2")
 
             # Synchronize 1,000,000 blocks each
             _to_block = 999_999
@@ -262,8 +258,6 @@ class Processor:
             else:
                 await self.__sync_all(local_session, _from_block, latest_block)
 
-            LOG.info("STEP-3")
-
             # Update latest synchronized block numbers
             await self.__update_idx_latest_block(
                 db_session=local_session,
@@ -271,8 +265,6 @@ class Processor:
                 block_number=latest_block,
             )
             await local_session.commit()
-
-            LOG.info("STEP-4")
 
         except Exception as e:
             await local_session.rollback()
@@ -331,11 +323,12 @@ class Processor:
     async def __sync_all(
         self, db_session: AsyncSession, block_from: int, block_to: int
     ):
-        LOG.info(f"STEP-2_{block_from}-{block_to}")
+        # Filter active targets that may still have unsynchronized logs up to block_to.
         active_targets = self.__filter_active_targets(block_to)
         if len(active_targets) == 0:
             return
 
+        # Sync each event type
         await self.__sync_transfer(db_session, block_from, block_to, active_targets)
         await self.__sync_unlock(db_session, block_from, block_to, active_targets)
         await self.__sync_force_unlock(db_session, block_from, block_to, active_targets)

--- a/batch/sub_indexers/indexer_TransferApproval.py
+++ b/batch/sub_indexers/indexer_TransferApproval.py
@@ -445,7 +445,11 @@ class Processor:
     ) -> list[tuple[TargetExchangeList.TargetExchange, EventData]]:
         """Fetch logs once per event type, then decode and map to each exchange.
 
-        Flow is the same as token-side batched fetch.
+        Flow:
+        1) Build target exchange/decoder maps
+        2) Query logs in address chunks with shared topic0 filter
+        3) Filter out already synchronized logs by per-exchange cursor
+        4) Decode and return logs sorted by (blockNumber, logIndex)
         """
         target_by_address: dict[str, Processor.TargetExchangeList.TargetExchange] = {}
         event_decoder_by_address: dict[str, AsyncContractEvent] = {}

--- a/batch/sub_indexers/indexer_TransferApproval.py
+++ b/batch/sub_indexers/indexer_TransferApproval.py
@@ -350,7 +350,7 @@ class Processor:
             [input_param["type"] for input_param in event_abi.get("inputs", [])]
         )
         signature = f"{event_name}({input_types})"
-        return Web3.keccak(text=signature).hex()
+        return Web3.keccak(text=signature).to_0x_hex()
 
     async def __get_logs_for_token_event(
         self, event_name: str, block_to: int

--- a/batch/sub_indexers/indexer_TransferApproval.py
+++ b/batch/sub_indexers/indexer_TransferApproval.py
@@ -301,11 +301,19 @@ class Processor:
     async def sync_new_logs(self):
         local_session = self.__get_db_session()
         try:
+            LOG.info("STEP-1")
+
             await self.__get_contract_list(local_session)
+
+            LOG.info("STEP-2")
+
             # Synchronize 1,000,000 blocks each
             latest_block = int(await async_web3.eth.block_number)
             _from_block = self.__get_oldest_cursor(self.token_list, latest_block)
             _to_block = 999999 + _from_block
+
+            LOG.info("STEP-3")
+
             if latest_block > _to_block:
                 while _to_block < latest_block:
                     await self.__sync_all(db_session=local_session, block_to=_to_block)
@@ -317,6 +325,9 @@ class Processor:
                 local_session, self.token_list, latest_block
             )
             await local_session.commit()
+
+            LOG.info("STEP-4")
+
         except Exception as e:
             await local_session.rollback()
             raise e

--- a/batch/sub_indexers/indexer_TransferApproval.py
+++ b/batch/sub_indexers/indexer_TransferApproval.py
@@ -380,22 +380,20 @@ class Processor:
         oldest_block_from: int | None = None
 
         for target in self.token_list:
-            token = target.token_contract
-            block_from = target.cursor
-            if block_from > block_to:
+            if target.cursor > block_to:
                 # Already synchronized up to block_to. Skip RPC call and processing.
                 LOG.debug(
-                    f"Skip {event_name}(token): {token.address} block_from({block_from}) > block_to({block_to})"
+                    f"Skip {event_name}(token): {target.token_contract.address} block_from({target.cursor}) > block_to({block_to})"
                 )
                 continue
 
-            if oldest_block_from is None or block_from < oldest_block_from:
-                oldest_block_from = block_from
+            if oldest_block_from is None or target.cursor < oldest_block_from:
+                oldest_block_from = target.cursor
 
-            token_address = to_checksum_address(token.address)
+            token_address = to_checksum_address(target.token_contract.address)
             target_by_address[token_address] = target
 
-            event_class: Any = getattr(token.events, event_name, None)
+            event_class: Any = getattr(target.token_contract.events, event_name, None)
             if event_class is None:
                 continue
             event_decoder = event_class()
@@ -468,16 +466,15 @@ class Processor:
         oldest_block_from: int | None = None
 
         for target in self.exchange_list:
-            block_from = target.cursor
-            if block_from > block_to:
+            if target.cursor > block_to:
                 # Already synchronized up to block_to. Skip RPC call and processing.
                 LOG.debug(
-                    f"Skip {event_name}(exchange): {target.exchange_address} block_from({block_from}) > block_to({block_to})"
+                    f"Skip {event_name}(exchange): {target.exchange_address} block_from({target.cursor}) > block_to({block_to})"
                 )
                 continue
 
-            if oldest_block_from is None or block_from < oldest_block_from:
-                oldest_block_from = block_from
+            if oldest_block_from is None or target.cursor < oldest_block_from:
+                oldest_block_from = target.cursor
 
             exchange_address = to_checksum_address(target.exchange_address)
             target_by_address[exchange_address] = target

--- a/batch/sub_indexers/indexer_TransferApproval.py
+++ b/batch/sub_indexers/indexer_TransferApproval.py
@@ -301,18 +301,12 @@ class Processor:
     async def sync_new_logs(self):
         local_session = self.__get_db_session()
         try:
-            LOG.info("STEP-1")
-
             await self.__get_contract_list(local_session)
-
-            LOG.info("STEP-2")
 
             # Synchronize 1,000,000 blocks each
             latest_block = int(await async_web3.eth.block_number)
             _from_block = self.__get_oldest_cursor(self.token_list, latest_block)
             _to_block = 999999 + _from_block
-
-            LOG.info("STEP-3")
 
             if latest_block > _to_block:
                 while _to_block < latest_block:
@@ -325,8 +319,6 @@ class Processor:
                 local_session, self.token_list, latest_block
             )
             await local_session.commit()
-
-            LOG.info("STEP-4")
 
         except Exception as e:
             await local_session.rollback()

--- a/batch/sub_indexers/indexer_TransferApproval.py
+++ b/batch/sub_indexers/indexer_TransferApproval.py
@@ -19,12 +19,15 @@ SPDX-License-Identifier: Apache-2.0
 
 import sys
 from datetime import datetime, timezone
-from typing import Any, List, Mapping, Optional, Sequence
+from typing import Any, List, Mapping, Optional, Sequence, cast
 
+from eth_utils.address import to_checksum_address
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from web3 import Web3
+from web3.contract.async_contract import AsyncContractEvent
 from web3.exceptions import ABIEventNotFound
-from web3.types import EventData
+from web3.types import EventData, FilterParams
 
 from app.config import TOKEN_LIST_CONTRACT_ADDRESS, ZERO_ADDRESS
 from app.contracts import AsyncContract
@@ -60,6 +63,10 @@ ibetSecurityTokenEscrow
 
 class Processor:
     """Processor for indexing Token transfer approval events"""
+
+    # Maximum number of contract addresses in one eth_getLogs request.
+    # This is a trade-off between request count and payload size.
+    ADDRESS_CHUNK_SIZE = 200
 
     class TargetTokenList:
         class TargetToken:
@@ -331,6 +338,192 @@ class Processor:
 
         self.__update_cursor(block_to + 1)
 
+    @staticmethod
+    def __chunked(values: list[str], chunk_size: int) -> list[list[str]]:
+        """Split a list into fixed-size chunks."""
+        return [values[i : i + chunk_size] for i in range(0, len(values), chunk_size)]
+
+    @staticmethod
+    def __build_topic0(event_name: str, event_abi: Any) -> str:
+        """Build topic0 (= event signature hash) from event ABI."""
+        input_types = ",".join(
+            [input_param["type"] for input_param in event_abi.get("inputs", [])]
+        )
+        signature = f"{event_name}({input_types})"
+        return Web3.keccak(text=signature).hex()
+
+    async def __get_logs_for_token_event(
+        self, event_name: str, block_to: int
+    ) -> list[tuple[TargetTokenList.TargetToken, EventData]]:
+        """Fetch logs once per event type, then decode and map to each target token.
+
+        Flow:
+        1) Build target token/decoder maps
+        2) Query logs in address chunks with shared topic0 filter
+        3) Filter out already synchronized logs by per-token cursor
+        4) Decode and return logs sorted by (blockNumber, logIndex)
+        """
+        target_by_address: dict[str, Processor.TargetTokenList.TargetToken] = {}
+        event_decoder_by_address: dict[str, AsyncContractEvent] = {}
+        topic0_set: set[str] = set()
+        oldest_block_from: int | None = None
+
+        for target in self.token_list:
+            token = target.token_contract
+            block_from = target.cursor
+            if block_from > block_to:
+                # Already synchronized up to block_to. Skip RPC call and processing.
+                LOG.debug(
+                    f"Skip {event_name}(token): {token.address} block_from({block_from}) > block_to({block_to})"
+                )
+                continue
+
+            if oldest_block_from is None or block_from < oldest_block_from:
+                oldest_block_from = block_from
+
+            token_address = to_checksum_address(token.address)
+            target_by_address[token_address] = target
+
+            event_class: Any = getattr(token.events, event_name, None)
+            if event_class is None:
+                continue
+            event_decoder = event_class()
+            if not isinstance(event_decoder, AsyncContractEvent):
+                continue
+            event_decoder_by_address[token_address] = event_decoder
+            topic0_set.add(self.__build_topic0(event_name, event_decoder.abi))
+
+        if oldest_block_from is None or len(target_by_address) == 0:
+            return []
+
+        logs: list[tuple[Processor.TargetTokenList.TargetToken, EventData]] = []
+        target_addresses = list(target_by_address.keys())
+        topics = [list(topic0_set)]
+
+        for address_chunk in self.__chunked(target_addresses, self.ADDRESS_CHUNK_SIZE):
+            # One eth_getLogs request per event type + address chunk.
+            filter_params = cast(
+                FilterParams,
+                {
+                    "fromBlock": oldest_block_from,
+                    "toBlock": block_to,
+                    "address": address_chunk,
+                    "topics": topics,
+                },
+            )
+            raw_logs = await async_web3.eth.get_logs(filter_params)
+            for raw_log in raw_logs:
+                # Map log to target token by address.
+                token_address = to_checksum_address(raw_log["address"])
+                target = target_by_address.get(token_address)
+                if target is None:
+                    continue
+
+                # Guard: skip logs that are already synchronized, based on per-token cursor.
+                if raw_log["blockNumber"] < target.cursor:
+                    continue
+
+                # Decode log with corresponding event decoder.
+                event_decoder = event_decoder_by_address.get(token_address)
+                if event_decoder is None:
+                    continue
+                try:
+                    event = event_decoder.process_log(raw_log)
+                    logs.append((target, event))
+                except Exception:
+                    # Keep indexing robust: skip logs that cannot be decoded.
+                    continue
+
+        # Sort logs by (blockNumber, logIndex) to ensure correct processing order.
+        logs.sort(
+            key=lambda log_data: (log_data[1]["blockNumber"], log_data[1]["logIndex"])
+        )
+        return logs
+
+    async def __get_logs_for_exchange_event(
+        self, event_name: str, block_to: int
+    ) -> list[tuple[TargetExchangeList.TargetExchange, EventData]]:
+        """Fetch logs once per event type, then decode and map to each exchange.
+
+        Flow is the same as token-side batched fetch.
+        """
+        target_by_address: dict[str, Processor.TargetExchangeList.TargetExchange] = {}
+        event_decoder_by_address: dict[str, AsyncContractEvent] = {}
+        topic0_set: set[str] = set()
+        oldest_block_from: int | None = None
+
+        for target in self.exchange_list:
+            block_from = target.cursor
+            if block_from > block_to:
+                # Already synchronized up to block_to. Skip RPC call and processing.
+                LOG.debug(
+                    f"Skip {event_name}(exchange): {target.exchange_address} block_from({block_from}) > block_to({block_to})"
+                )
+                continue
+
+            if oldest_block_from is None or block_from < oldest_block_from:
+                oldest_block_from = block_from
+
+            exchange_address = to_checksum_address(target.exchange_address)
+            target_by_address[exchange_address] = target
+
+            event_class: Any = getattr(
+                target.exchange_contract.events, event_name, None
+            )
+            if event_class is None:
+                continue
+            event_decoder = event_class()
+            if not isinstance(event_decoder, AsyncContractEvent):
+                continue
+            event_decoder_by_address[exchange_address] = event_decoder
+            topic0_set.add(self.__build_topic0(event_name, event_decoder.abi))
+
+        if oldest_block_from is None or len(target_by_address) == 0:
+            return []
+
+        logs: list[tuple[Processor.TargetExchangeList.TargetExchange, EventData]] = []
+        target_addresses = list(target_by_address.keys())
+        topics = [list(topic0_set)]
+
+        for address_chunk in self.__chunked(target_addresses, self.ADDRESS_CHUNK_SIZE):
+            # One eth_getLogs request per event type + address chunk.
+            filter_params = cast(
+                FilterParams,
+                {
+                    "fromBlock": oldest_block_from,
+                    "toBlock": block_to,
+                    "address": address_chunk,
+                    "topics": topics,
+                },
+            )
+            raw_logs = await async_web3.eth.get_logs(filter_params)
+            for raw_log in raw_logs:
+                # Map log to target exchange by address.
+                exchange_address = to_checksum_address(raw_log["address"])
+                target = target_by_address.get(exchange_address)
+                if target is None:
+                    continue
+
+                # Skip logs that are already synchronized, based on per-exchange cursor.
+                if raw_log["blockNumber"] < target.cursor:
+                    continue
+
+                # Decode log with corresponding event decoder.
+                event_decoder = event_decoder_by_address.get(exchange_address)
+                if event_decoder is None:
+                    continue
+                try:
+                    event = event_decoder.process_log(raw_log)
+                    logs.append((target, event))
+                except Exception:
+                    continue
+
+        # Sort logs by (blockNumber, logIndex) to ensure correct processing order.
+        logs.sort(
+            key=lambda log_data: (log_data[1]["blockNumber"], log_data[1]["logIndex"])
+        )
+        return logs
+
     def __update_cursor(self, block_number: int):
         """Memorize the block number where next processing should start from
         :param block_number: block number to be set
@@ -351,38 +544,33 @@ class Processor:
         :param block_to: To Block
         :return: None
         """
-        for target in self.token_list:
-            token = target.token_contract
-            block_from = target.cursor
-            if block_from > block_to:
-                continue
-            try:
-                events: list[EventData] = await token.events.ApplyForTransfer.get_logs(
-                    from_block=block_from, to_block=block_to
+        # Fetch once by event type and process per-token with cursor guards.
+        try:
+            events = await self.__get_logs_for_token_event("ApplyForTransfer", block_to)
+        except ABIEventNotFound:
+            events = []
+        try:
+            for target, event in events:
+                token = target.token_contract
+                args = event["args"]
+                value = args.get("value", 0)
+                if value > sys.maxsize:
+                    continue
+                block_timestamp = await self.get_block_timestamp(event=event)
+                await self.__sink_on_transfer_approval(
+                    db_session=db_session,
+                    event_type="ApplyFor",
+                    token_address=token.address,
+                    exchange_address=None,
+                    application_id=args.get("index"),
+                    from_address=args.get("from", ZERO_ADDRESS),
+                    to_address=args.get("to", ZERO_ADDRESS),
+                    value=value,
+                    optional_data_applicant=args.get("data"),
+                    block_timestamp=block_timestamp,
                 )
-            except ABIEventNotFound:
-                events = []
-            try:
-                for event in events:
-                    args = event["args"]
-                    value = args.get("value", 0)
-                    if value > sys.maxsize:
-                        continue
-                    block_timestamp = await self.get_block_timestamp(event=event)
-                    await self.__sink_on_transfer_approval(
-                        db_session=db_session,
-                        event_type="ApplyFor",
-                        token_address=token.address,
-                        exchange_address=None,
-                        application_id=args.get("index"),
-                        from_address=args.get("from", ZERO_ADDRESS),
-                        to_address=args.get("to", ZERO_ADDRESS),
-                        value=value,
-                        optional_data_applicant=args.get("data"),
-                        block_timestamp=block_timestamp,
-                    )
-            except Exception as e:
-                raise e
+        except Exception as e:
+            raise e
 
     async def __sync_token_cancel_transfer(
         self, db_session: AsyncSession, block_to: int
@@ -392,31 +580,26 @@ class Processor:
         :param block_to: To Block
         :return: None
         """
-        for target in self.token_list:
-            token = target.token_contract
-            block_from = target.cursor
-            if block_from > block_to:
-                continue
-            try:
-                events: list[EventData] = await token.events.CancelTransfer.get_logs(
-                    from_block=block_from, to_block=block_to
+        # Fetch once by event type and process per-token with cursor guards.
+        try:
+            events = await self.__get_logs_for_token_event("CancelTransfer", block_to)
+        except ABIEventNotFound:
+            events = []
+        try:
+            for target, event in events:
+                token = target.token_contract
+                args = event["args"]
+                await self.__sink_on_transfer_approval(
+                    db_session=db_session,
+                    event_type="Cancel",
+                    token_address=token.address,
+                    exchange_address=None,
+                    application_id=args.get("index"),
+                    from_address=args.get("from", ZERO_ADDRESS),
+                    to_address=args.get("to", ZERO_ADDRESS),
                 )
-            except ABIEventNotFound:
-                events = []
-            try:
-                for event in events:
-                    args = event["args"]
-                    await self.__sink_on_transfer_approval(
-                        db_session=db_session,
-                        event_type="Cancel",
-                        token_address=token.address,
-                        exchange_address=None,
-                        application_id=args.get("index"),
-                        from_address=args.get("from", ZERO_ADDRESS),
-                        to_address=args.get("to", ZERO_ADDRESS),
-                    )
-            except Exception as e:
-                raise e
+        except Exception as e:
+            raise e
 
     async def __sync_token_approve_transfer(
         self, db_session: AsyncSession, block_to: int
@@ -426,34 +609,29 @@ class Processor:
         :param block_to: To Block
         :return: None
         """
-        for target in self.token_list:
-            token = target.token_contract
-            block_from = target.cursor
-            if block_from > block_to:
-                continue
-            try:
-                events: list[EventData] = await token.events.ApproveTransfer.get_logs(
-                    from_block=block_from, to_block=block_to
+        # Fetch once by event type and process per-token with cursor guards.
+        try:
+            events = await self.__get_logs_for_token_event("ApproveTransfer", block_to)
+        except ABIEventNotFound:
+            events = []
+        try:
+            for target, event in events:
+                token = target.token_contract
+                args = event["args"]
+                block_timestamp = await self.get_block_timestamp(event=event)
+                await self.__sink_on_transfer_approval(
+                    db_session=db_session,
+                    event_type="Approve",
+                    token_address=token.address,
+                    exchange_address=None,
+                    application_id=args.get("index"),
+                    from_address=args.get("from", ZERO_ADDRESS),
+                    to_address=args.get("to", ZERO_ADDRESS),
+                    optional_data_approver=args.get("data"),
+                    block_timestamp=block_timestamp,
                 )
-            except ABIEventNotFound:
-                events = []
-            try:
-                for event in events:
-                    args = event["args"]
-                    block_timestamp = await self.get_block_timestamp(event=event)
-                    await self.__sink_on_transfer_approval(
-                        db_session=db_session,
-                        event_type="Approve",
-                        token_address=token.address,
-                        exchange_address=None,
-                        application_id=args.get("index"),
-                        from_address=args.get("from", ZERO_ADDRESS),
-                        to_address=args.get("to", ZERO_ADDRESS),
-                        optional_data_approver=args.get("data"),
-                        block_timestamp=block_timestamp,
-                    )
-            except Exception as e:
-                raise e
+        except Exception as e:
+            raise e
 
     async def __sync_exchange_apply_for_transfer(
         self, db_session: AsyncSession, block_to: int
@@ -463,47 +641,38 @@ class Processor:
         :param block_to: To Block
         :return: None
         """
-        for target in self.exchange_list:
-            block_from = target.cursor
-            if block_from > block_to:
-                continue
-            exchange = target.exchange_contract
-            try:
-                events: list[
-                    EventData
-                ] = await exchange.events.ApplyForTransfer.get_logs(
-                    from_block=block_from, to_block=block_to
+        # Fetch once by event type and process per-exchange with cursor guards.
+        try:
+            events = await self.__get_logs_for_exchange_event(
+                "ApplyForTransfer", block_to
+            )
+        except ABIEventNotFound:
+            events = []
+        try:
+            token_address_list = [t.token_contract.address for t in self.token_list]
+            for target, event in events:
+                exchange = target.exchange_contract
+                args = event["args"]
+                if args.get("token", ZERO_ADDRESS) not in token_address_list:
+                    continue
+                value = args.get("value", 0)
+                if value > sys.maxsize:
+                    continue
+                block_timestamp = await self.get_block_timestamp(event=event)
+                await self.__sink_on_transfer_approval(
+                    db_session=db_session,
+                    event_type="ApplyFor",
+                    token_address=args.get("token", ZERO_ADDRESS),
+                    exchange_address=exchange.address,
+                    application_id=args.get("escrowId"),
+                    from_address=args.get("from", ZERO_ADDRESS),
+                    to_address=args.get("to", ZERO_ADDRESS),
+                    value=args.get("value"),
+                    optional_data_applicant=args.get("data"),
+                    block_timestamp=block_timestamp,
                 )
-            except ABIEventNotFound:
-                events = []
-            try:
-                # Filter events by listed token
-                events_filtered: list[EventData] = []
-                token_address_list = [t.token_contract.address for t in self.token_list]
-                for event in events:
-                    args = event["args"]
-                    if args.get("token", ZERO_ADDRESS) in token_address_list:
-                        events_filtered.append(event)
-                for event in events_filtered:
-                    args = event["args"]
-                    value = args.get("value", 0)
-                    if value > sys.maxsize:
-                        continue
-                    block_timestamp = await self.get_block_timestamp(event=event)
-                    await self.__sink_on_transfer_approval(
-                        db_session=db_session,
-                        event_type="ApplyFor",
-                        token_address=args.get("token", ZERO_ADDRESS),
-                        exchange_address=exchange.address,
-                        application_id=args.get("escrowId"),
-                        from_address=args.get("from", ZERO_ADDRESS),
-                        to_address=args.get("to", ZERO_ADDRESS),
-                        value=args.get("value"),
-                        optional_data_applicant=args.get("data"),
-                        block_timestamp=block_timestamp,
-                    )
-            except Exception as e:
-                raise e
+        except Exception as e:
+            raise e
 
     async def __sync_exchange_cancel_transfer(
         self, db_session: AsyncSession, block_to: int
@@ -513,38 +682,31 @@ class Processor:
         :param block_to: To Block
         :return: None
         """
-        for target in self.exchange_list:
-            block_from = target.cursor
-            if block_from > block_to:
-                continue
-            exchange = target.exchange_contract
-            try:
-                events: list[EventData] = await exchange.events.CancelTransfer.get_logs(
-                    from_block=block_from, to_block=block_to
+        # Fetch once by event type and process per-exchange with cursor guards.
+        try:
+            events = await self.__get_logs_for_exchange_event(
+                "CancelTransfer", block_to
+            )
+        except ABIEventNotFound:
+            events = []
+        try:
+            token_address_list = [t.token_contract.address for t in self.token_list]
+            for target, event in events:
+                exchange = target.exchange_contract
+                args = event["args"]
+                if args.get("token", ZERO_ADDRESS) not in token_address_list:
+                    continue
+                await self.__sink_on_transfer_approval(
+                    db_session=db_session,
+                    event_type="Cancel",
+                    token_address=args.get("token", ZERO_ADDRESS),
+                    exchange_address=exchange.address,
+                    application_id=args.get("escrowId"),
+                    from_address=args.get("from", ZERO_ADDRESS),
+                    to_address=args.get("to", ZERO_ADDRESS),
                 )
-            except ABIEventNotFound:
-                events = []
-            try:
-                # Filter events by listed token
-                events_filtered: list[EventData] = []
-                token_address_list = [t.token_contract.address for t in self.token_list]
-                for event in events:
-                    args = event["args"]
-                    if args.get("token", ZERO_ADDRESS) in token_address_list:
-                        events_filtered.append(event)
-                for event in events_filtered:
-                    args = event["args"]
-                    await self.__sink_on_transfer_approval(
-                        db_session=db_session,
-                        event_type="Cancel",
-                        token_address=args.get("token", ZERO_ADDRESS),
-                        exchange_address=exchange.address,
-                        application_id=args.get("escrowId"),
-                        from_address=args.get("from", ZERO_ADDRESS),
-                        to_address=args.get("to", ZERO_ADDRESS),
-                    )
-            except Exception as e:
-                raise e
+        except Exception as e:
+            raise e
 
     async def __sync_exchange_escrow_finished(
         self, db_session: AsyncSession, block_to: int
@@ -554,40 +716,33 @@ class Processor:
         :param block_to: To Block
         :return: None
         """
-        for target in self.exchange_list:
-            block_from = target.cursor
-            if block_from > block_to:
-                continue
-            exchange = target.exchange_contract
-            try:
-                events: list[EventData] = await exchange.events.EscrowFinished.get_logs(
-                    from_block=block_from,
-                    to_block=block_to,
-                    argument_filters={"transferApprovalRequired": True},
+        # Fetch once by event type and process per-exchange with cursor guards.
+        try:
+            events = await self.__get_logs_for_exchange_event(
+                "EscrowFinished", block_to
+            )
+        except ABIEventNotFound:
+            events = []
+        try:
+            token_address_list = [t.token_contract.address for t in self.token_list]
+            for target, event in events:
+                exchange = target.exchange_contract
+                args = event["args"]
+                if args.get("transferApprovalRequired") is not True:
+                    continue
+                if args.get("token", ZERO_ADDRESS) not in token_address_list:
+                    continue
+                await self.__sink_on_transfer_approval(
+                    db_session=db_session,
+                    event_type="EscrowFinish",
+                    token_address=args.get("token", ZERO_ADDRESS),
+                    exchange_address=exchange.address,
+                    application_id=args.get("escrowId"),
+                    from_address=args.get("sender", ZERO_ADDRESS),
+                    to_address=args.get("recipient", ZERO_ADDRESS),
                 )
-            except ABIEventNotFound:
-                events = []
-            try:
-                # Filter events by listed token
-                events_filtered: list[EventData] = []
-                token_address_list = [t.token_contract.address for t in self.token_list]
-                for event in events:
-                    args = event["args"]
-                    if args.get("token", ZERO_ADDRESS) in token_address_list:
-                        events_filtered.append(event)
-                for event in events_filtered:
-                    args = event["args"]
-                    await self.__sink_on_transfer_approval(
-                        db_session=db_session,
-                        event_type="EscrowFinish",
-                        token_address=args.get("token", ZERO_ADDRESS),
-                        exchange_address=exchange.address,
-                        application_id=args.get("escrowId"),
-                        from_address=args.get("sender", ZERO_ADDRESS),
-                        to_address=args.get("recipient", ZERO_ADDRESS),
-                    )
-            except Exception as e:
-                raise e
+        except Exception as e:
+            raise e
 
     async def __sync_exchange_approve_transfer(
         self, db_session: AsyncSession, block_to: int
@@ -597,41 +752,32 @@ class Processor:
         :param block_to: To Block
         :return: None
         """
-        for target in self.exchange_list:
-            block_from = target.cursor
-            if block_from > block_to:
-                continue
-            exchange = target.exchange_contract
-            try:
-                events: list[
-                    EventData
-                ] = await exchange.events.ApproveTransfer.get_logs(
-                    from_block=block_from, to_block=block_to
+        # Fetch once by event type and process per-exchange with cursor guards.
+        try:
+            events = await self.__get_logs_for_exchange_event(
+                "ApproveTransfer", block_to
+            )
+        except ABIEventNotFound:
+            events = []
+        try:
+            token_address_list = [t.token_contract.address for t in self.token_list]
+            for target, event in events:
+                exchange = target.exchange_contract
+                args = event["args"]
+                if args.get("token", ZERO_ADDRESS) not in token_address_list:
+                    continue
+                block_timestamp = await self.get_block_timestamp(event=event)
+                await self.__sink_on_transfer_approval(
+                    db_session=db_session,
+                    event_type="Approve",
+                    token_address=args.get("token", ZERO_ADDRESS),
+                    exchange_address=exchange.address,
+                    application_id=args.get("escrowId"),
+                    optional_data_approver=args.get("data"),
+                    block_timestamp=block_timestamp,
                 )
-            except ABIEventNotFound:
-                events = []
-            try:
-                # Filter events by listed token
-                events_filtered: list[EventData] = []
-                token_address_list = [t.token_contract.address for t in self.token_list]
-                for event in events:
-                    args = event["args"]
-                    if args.get("token", ZERO_ADDRESS) in token_address_list:
-                        events_filtered.append(event)
-                for event in events_filtered:
-                    args = event["args"]
-                    block_timestamp = await self.get_block_timestamp(event=event)
-                    await self.__sink_on_transfer_approval(
-                        db_session=db_session,
-                        event_type="Approve",
-                        token_address=args.get("token", ZERO_ADDRESS),
-                        exchange_address=exchange.address,
-                        application_id=args.get("escrowId"),
-                        optional_data_approver=args.get("data"),
-                        block_timestamp=block_timestamp,
-                    )
-            except Exception as e:
-                raise e
+        except Exception as e:
+            raise e
 
     @staticmethod
     def __get_oldest_cursor(target_token_list: TargetTokenList, block_to: int) -> int:

--- a/batch/sub_indexers/indexer_TransferApproval.py
+++ b/batch/sub_indexers/indexer_TransferApproval.py
@@ -376,38 +376,40 @@ class Processor:
         """
         target_by_address: dict[str, Processor.TargetTokenList.TargetToken] = {}
         event_decoder_by_address: dict[str, AsyncContractEvent] = {}
-        topic0_set: set[str] = set()
+        topic0: str | None = None
         oldest_block_from: int | None = None
 
         for target in self.token_list:
-            if target.cursor > block_to:
+            token = target.token_contract
+            block_from = target.cursor
+            if block_from > block_to:
                 # Already synchronized up to block_to. Skip RPC call and processing.
                 LOG.debug(
-                    f"Skip {event_name}(token): {target.token_contract.address} block_from({target.cursor}) > block_to({block_to})"
+                    f"Skip {event_name}(token): {token.address} block_from({block_from}) > block_to({block_to})"
                 )
                 continue
 
-            if oldest_block_from is None or target.cursor < oldest_block_from:
-                oldest_block_from = target.cursor
+            if oldest_block_from is None or block_from < oldest_block_from:
+                oldest_block_from = block_from
 
-            token_address = to_checksum_address(target.token_contract.address)
-            target_by_address[token_address] = target
-
-            event_class: Any = getattr(target.token_contract.events, event_name, None)
+            event_class: Any = getattr(token.events, event_name, None)
             if event_class is None:
                 continue
             event_decoder = event_class()
             if not isinstance(event_decoder, AsyncContractEvent):
                 continue
+            token_address = to_checksum_address(token.address)
+            target_by_address[token_address] = target
             event_decoder_by_address[token_address] = event_decoder
-            topic0_set.add(self.__build_topic0(event_name, event_decoder.abi))
+            if topic0 is None:
+                topic0 = self.__build_topic0(event_name, event_decoder.abi)
 
-        if oldest_block_from is None or len(target_by_address) == 0:
+        if oldest_block_from is None or len(target_by_address) == 0 or topic0 is None:
             return []
 
         logs: list[tuple[Processor.TargetTokenList.TargetToken, EventData]] = []
         target_addresses = list(target_by_address.keys())
-        topics = [list(topic0_set)]
+        topics = [[topic0]]
 
         for address_chunk in self.__chunked(target_addresses, self.ADDRESS_CHUNK_SIZE):
             # One eth_getLogs request per event type + address chunk.
@@ -462,22 +464,20 @@ class Processor:
         """
         target_by_address: dict[str, Processor.TargetExchangeList.TargetExchange] = {}
         event_decoder_by_address: dict[str, AsyncContractEvent] = {}
-        topic0_set: set[str] = set()
+        topic0: str | None = None
         oldest_block_from: int | None = None
 
         for target in self.exchange_list:
-            if target.cursor > block_to:
+            block_from = target.cursor
+            if block_from > block_to:
                 # Already synchronized up to block_to. Skip RPC call and processing.
                 LOG.debug(
-                    f"Skip {event_name}(exchange): {target.exchange_address} block_from({target.cursor}) > block_to({block_to})"
+                    f"Skip {event_name}(exchange): {target.exchange_address} block_from({block_from}) > block_to({block_to})"
                 )
                 continue
 
-            if oldest_block_from is None or target.cursor < oldest_block_from:
-                oldest_block_from = target.cursor
-
-            exchange_address = to_checksum_address(target.exchange_address)
-            target_by_address[exchange_address] = target
+            if oldest_block_from is None or block_from < oldest_block_from:
+                oldest_block_from = block_from
 
             event_class: Any = getattr(
                 target.exchange_contract.events, event_name, None
@@ -487,15 +487,18 @@ class Processor:
             event_decoder = event_class()
             if not isinstance(event_decoder, AsyncContractEvent):
                 continue
+            exchange_address = to_checksum_address(target.exchange_address)
+            target_by_address[exchange_address] = target
             event_decoder_by_address[exchange_address] = event_decoder
-            topic0_set.add(self.__build_topic0(event_name, event_decoder.abi))
+            if topic0 is None:
+                topic0 = self.__build_topic0(event_name, event_decoder.abi)
 
-        if oldest_block_from is None or len(target_by_address) == 0:
+        if oldest_block_from is None or len(target_by_address) == 0 or topic0 is None:
             return []
 
         logs: list[tuple[Processor.TargetExchangeList.TargetExchange, EventData]] = []
         target_addresses = list(target_by_address.keys())
-        topics = [list(topic0_set)]
+        topics = [[topic0]]
 
         for address_chunk in self.__chunked(target_addresses, self.ADDRESS_CHUNK_SIZE):
             # One eth_getLogs request per event type + address chunk.

--- a/tests/batch/sub_indexers/indexer_TransferApproval_test.py
+++ b/tests/batch/sub_indexers/indexer_TransferApproval_test.py
@@ -17,6 +17,7 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
+import logging
 from datetime import datetime
 from unittest import mock
 from unittest.mock import MagicMock
@@ -35,7 +36,7 @@ from app import config
 from app.errors import ServiceUnavailable
 from app.model.db import IDXTransferApproval, IDXTransferApprovalBlockNumber, Listing
 from batch.sub_indexers import indexer_TransferApproval
-from batch.sub_indexers.indexer_TransferApproval import Processor
+from batch.sub_indexers.indexer_TransferApproval import LOG, Processor
 from tests.account_config import eth_account
 from tests.helpers import IbetShareTestHelper
 from tests.helpers.ibet_exchange_helpers import (
@@ -63,6 +64,17 @@ async def processor() -> Processor:
     processor = Processor()
     await processor.sync_new_logs()
     return processor
+
+
+@pytest.fixture(scope="function")
+def caplog(caplog: pytest.LogCaptureFixture):
+    batch_logger = logging.getLogger("ibet_wallet_batch")
+    default_log_level = batch_logger.level
+    batch_logger.setLevel(logging.DEBUG)
+    batch_logger.propagate = True
+    yield caplog
+    batch_logger.propagate = False
+    batch_logger.setLevel(default_log_level)
 
 
 @pytest.mark.asyncio
@@ -601,6 +613,59 @@ class TestProcessor:
         ).all()
         assert len(_transfer_approval_list) == 0
 
+    # <Normal_1_7>
+    # Skip processing with no new block (token events)
+    async def test_normal_1_7(
+        self,
+        processor: Processor,
+        shared_contract: SharedContract,
+        async_session: AsyncSession,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        token_list_contract = shared_contract["TokenList"]
+        personal_info_contract = shared_contract["PersonalInfo"]
+
+        # Issue token
+        token = self.issue_token_share(
+            issuer=self.issuer,
+            exchange_contract=None,
+            personal_info_contract=personal_info_contract,
+            token_list_contract=token_list_contract,
+        )
+        await self.list_token(token_address=token.address, async_session=async_session)
+
+        # Run target process first time
+        await processor.sync_new_logs()
+
+        # Run target process second time without new block
+        caplog.clear()
+        await processor.sync_new_logs()
+
+        latest_block = web3.eth.block_number
+        next_block = latest_block + 1
+
+        assert 1 == caplog.record_tuples.count(
+            (
+                LOG.name,
+                logging.DEBUG,
+                f"Skip ApplyForTransfer(token): {token.address} block_from({next_block}) > block_to({latest_block})",
+            )
+        )
+        assert 1 == caplog.record_tuples.count(
+            (
+                LOG.name,
+                logging.DEBUG,
+                f"Skip CancelTransfer(token): {token.address} block_from({next_block}) > block_to({latest_block})",
+            )
+        )
+        assert 1 == caplog.record_tuples.count(
+            (
+                LOG.name,
+                logging.DEBUG,
+                f"Skip ApproveTransfer(token): {token.address} block_from({next_block}) > block_to({latest_block})",
+            )
+        )
+
     # <Normal_2_1>
     # IbetSecurityTokenEscrow
     #  - ApplyForTransfer
@@ -989,6 +1054,91 @@ class TestProcessor:
         assert _transfer_approval.cancelled is None
         assert _transfer_approval.escrow_finished is True
         assert _transfer_approval.transfer_approved is True
+
+    # <Normal_2_5>
+    # Skip processing with no new block (exchange events)
+    async def test_normal_2_5(
+        self,
+        processor: Processor,
+        shared_contract: SharedContract,
+        async_session: AsyncSession,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        token_list_contract = shared_contract["TokenList"]
+        personal_info_contract = shared_contract["PersonalInfo"]
+        st_escrow_contract = shared_contract["IbetSecurityTokenEscrow"]
+
+        # Issue token with exchange
+        token = self.issue_token_share(
+            issuer=self.issuer,
+            exchange_contract=st_escrow_contract,
+            personal_info_contract=personal_info_contract,
+            token_list_contract=token_list_contract,
+        )
+        await self.list_token(token_address=token.address, async_session=async_session)
+
+        # Run target process first time
+        await processor.sync_new_logs()
+
+        # Run target process second time without new block
+        caplog.clear()
+        await processor.sync_new_logs()
+
+        latest_block = web3.eth.block_number
+        next_block = latest_block + 1
+
+        # token-side skips
+        assert 1 == caplog.record_tuples.count(
+            (
+                LOG.name,
+                logging.DEBUG,
+                f"Skip ApplyForTransfer(token): {token.address} block_from({next_block}) > block_to({latest_block})",
+            )
+        )
+        assert 1 == caplog.record_tuples.count(
+            (
+                LOG.name,
+                logging.DEBUG,
+                f"Skip CancelTransfer(token): {token.address} block_from({next_block}) > block_to({latest_block})",
+            )
+        )
+        assert 1 == caplog.record_tuples.count(
+            (
+                LOG.name,
+                logging.DEBUG,
+                f"Skip ApproveTransfer(token): {token.address} block_from({next_block}) > block_to({latest_block})",
+            )
+        )
+
+        # exchange-side skips
+        assert 1 == caplog.record_tuples.count(
+            (
+                LOG.name,
+                logging.DEBUG,
+                f"Skip ApplyForTransfer(exchange): {st_escrow_contract['address']} block_from({next_block}) > block_to({latest_block})",
+            )
+        )
+        assert 1 == caplog.record_tuples.count(
+            (
+                LOG.name,
+                logging.DEBUG,
+                f"Skip CancelTransfer(exchange): {st_escrow_contract['address']} block_from({next_block}) > block_to({latest_block})",
+            )
+        )
+        assert 1 == caplog.record_tuples.count(
+            (
+                LOG.name,
+                logging.DEBUG,
+                f"Skip EscrowFinished(exchange): {st_escrow_contract['address']} block_from({next_block}) > block_to({latest_block})",
+            )
+        )
+        assert 1 == caplog.record_tuples.count(
+            (
+                LOG.name,
+                logging.DEBUG,
+                f"Skip ApproveTransfer(exchange): {st_escrow_contract['address']} block_from({next_block}) > block_to({latest_block})",
+            )
+        )
 
     ###########################################################################
     # Error Case

--- a/tests/batch/sub_indexers/indexer_Transfer_test.py
+++ b/tests/batch/sub_indexers/indexer_Transfer_test.py
@@ -1374,14 +1374,69 @@ class TestProcessor:
         assert idx_block_number is not None
         assert idx_block_number.latest_block_number == block_number
 
-        assert 4 == caplog.record_tuples.count(
-            (
-                LOG.name,
-                logging.DEBUG,
-                f"{share_token.address}: skip_block < block_from < block_to",
-            )
-        )
         caplog.clear()
+
+    # <Normal_4_6>
+    # get_logs is called once per event type in a single sync run
+    async def test_normal_4_6(
+        self,
+        processor: Processor,
+        shared_contract: SharedContract,
+        async_session: AsyncSession,
+    ):
+        # Issue Token
+        token_list_contract = shared_contract["TokenList"]
+        personal_info_contract_address = shared_contract["PersonalInfo"]["address"]
+        share_token = self.issue_token_share(
+            self.issuer,
+            config.ZERO_ADDRESS,
+            personal_info_contract_address,
+            token_list_contract,
+        )
+        await self.listing_token(share_token.address, async_session)
+
+        # Execute batch processing with spying get_logs
+        with mock.patch.object(
+            indexer_Transfer.async_web3.eth,
+            "get_logs",
+            wraps=indexer_Transfer.async_web3.eth.get_logs,
+        ) as mock_get_logs:
+            await processor.sync_new_logs()
+
+        # Transfer / Unlock / ForceUnlock / ForceChangeLockedAccount
+        assert mock_get_logs.await_count == 4
+
+    # <Normal_4_7>
+    # get_logs is not called when token is already synchronized to latest block
+    async def test_normal_4_7(
+        self,
+        processor: Processor,
+        shared_contract: SharedContract,
+        async_session: AsyncSession,
+    ):
+        # Issue Token
+        token_list_contract = shared_contract["TokenList"]
+        personal_info_contract_address = shared_contract["PersonalInfo"]["address"]
+        share_token = self.issue_token_share(
+            self.issuer,
+            config.ZERO_ADDRESS,
+            personal_info_contract_address,
+            token_list_contract,
+        )
+        await self.listing_token(share_token.address, async_session)
+
+        # 1st sync to initialize skip block
+        await processor.sync_new_logs()
+
+        # 2nd sync should skip all event queries
+        with mock.patch.object(
+            indexer_Transfer.async_web3.eth,
+            "get_logs",
+            wraps=indexer_Transfer.async_web3.eth.get_logs,
+        ) as mock_get_logs:
+            await processor.sync_new_logs()
+
+        assert mock_get_logs.await_count == 0
 
     # <Normal_5>
     # Not Listing Token

--- a/tests/batch/sub_indexers/indexer_Transfer_test.py
+++ b/tests/batch/sub_indexers/indexer_Transfer_test.py
@@ -1025,13 +1025,6 @@ class TestProcessor:
         assert idx_block_number is not None
         assert idx_block_number.latest_block_number == block_number_1
 
-        assert 4 == caplog.record_tuples.count(
-            (
-                LOG.name,
-                logging.DEBUG,
-                f"{share_token.address}: block_to <= skip_block",
-            )
-        )
         caplog.clear()
 
     # <Normal_4_2>
@@ -1130,13 +1123,6 @@ class TestProcessor:
         assert idx_block_number is not None
         assert idx_block_number.latest_block_number == block_number_2
 
-        assert 4 == caplog.record_tuples.count(
-            (
-                LOG.name,
-                logging.DEBUG,
-                f"{share_token.address}: block_from <= skip_block < block_to",
-            )
-        )
         caplog.clear()
 
     # <Normal_4_3>
@@ -1243,13 +1229,6 @@ class TestProcessor:
         assert idx_block_number is not None
         assert idx_block_number.latest_block_number == block_number_2
 
-        assert 4 == caplog.record_tuples.count(
-            (
-                LOG.name,
-                logging.DEBUG,
-                f"{share_token.address}: block_to <= skip_block",
-            )
-        )
         caplog.clear()
 
     # <Normal_4_4>


### PR DESCRIPTION
This pull request refactors the event log fetching and processing logic in both `indexer_Transfer.py` and `indexer_TransferApproval.py` to improve efficiency and reduce redundant RPC calls. The main change is the introduction of a batched, chunked log retrieval mechanism that fetches logs for multiple tokens and events in a single request, instead of one-by-one per token.

## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
None

## 🔄 Changes

<!-- List the major changes in this PR. -->

**Event log fetching and processing improvements:**

- Introduced a batched log retrieval system using a new `__get_logs_by_event` method, which fetches logs for multiple contract addresses and event types in chunks, reducing the number of RPC calls and improving performance. (`batch/sub_indexers/indexer_Transfer.py`, `batch/sub_indexers/indexer_TransferApproval.py`)

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
