### PR TITLE
Refactor block range calculations for token and exchange events in Transfer/TransferApproval indexers

### DIFF
--- a/batch/sub_indexers/indexer_Transfer.py
+++ b/batch/sub_indexers/indexer_Transfer.py
@@ -20,17 +20,15 @@ SPDX-License-Identifier: Apache-2.0
 import json
 import sys
 from datetime import datetime, timedelta, timezone
-from typing import Any, List, Optional, Sequence, cast
+from typing import Any, List, Optional, Sequence
 
 from eth_utils.address import to_checksum_address
 from hexbytes import HexBytes
 from pydantic import ValidationError
 from sqlalchemy import desc, select
 from sqlalchemy.ext.asyncio import AsyncSession
-from web3 import Web3
-from web3.contract.async_contract import AsyncContractEvent
 from web3.exceptions import ABIEventNotFound
-from web3.types import EventData, FilterParams
+from web3.types import EventData
 
 from app.config import TOKEN_LIST_CONTRACT_ADDRESS, ZERO_ADDRESS
 from app.contracts import AsyncContract
@@ -56,10 +54,6 @@ async_web3 = AsyncWeb3Wrapper()
 
 class Processor:
     """Processor for indexing Token transfer events"""
-
-    # Maximum number of contract addresses in one eth_getLogs request.
-    # This is a trade-off between request count and payload size.
-    ADDRESS_CHUNK_SIZE = 200
 
     class TargetTokenList:
         class TargetToken:
@@ -347,105 +341,6 @@ class Processor:
             if target.skip_block is None or block_to > target.skip_block
         ]
 
-    @staticmethod
-    def __chunked(values: list[str], chunk_size: int) -> list[list[str]]:
-        """Split a list into fixed-size chunks."""
-        return [values[i : i + chunk_size] for i in range(0, len(values), chunk_size)]
-
-    @staticmethod
-    def __build_topic0(event_name: str, event_abi: Any) -> str:
-        """Build topic0 (= event signature hash) from event ABI."""
-        input_types = ",".join(
-            [input_param["type"] for input_param in event_abi.get("inputs", [])]
-        )
-        signature = f"{event_name}({input_types})"
-        return Web3.keccak(text=signature).to_0x_hex()
-
-    async def __get_logs_by_event(
-        self,
-        event_name: str,
-        block_from: int,
-        block_to: int,
-        targets: Sequence[TargetTokenList.TargetToken],
-    ) -> list[tuple[TargetTokenList.TargetToken, EventData]]:
-        """Fetch logs once per event type, then decode and map to each target token.
-
-        Flow:
-        1) Build target token/decoder maps
-        2) Query logs in address chunks with shared topic0 filter
-        3) Filter out already synchronized logs by per-token skip_block
-        4) Decode and return logs sorted by (blockNumber, logIndex)
-        """
-        target_by_address: dict[str, Processor.TargetTokenList.TargetToken] = {}
-        event_decoder_by_address: dict[str, AsyncContractEvent] = {}
-        topic0: str | None = None
-
-        for target in targets:
-            token = target.token_contract
-
-            event_class: Any = getattr(token.events, event_name, None)
-            if event_class is None:
-                continue
-            event_decoder = event_class()
-            if not isinstance(event_decoder, AsyncContractEvent):
-                continue
-
-            token_address = to_checksum_address(token.address)
-            target_by_address[token_address] = target
-            event_decoder_by_address[token_address] = event_decoder
-            if topic0 is None:
-                topic0 = self.__build_topic0(event_name, event_decoder.abi)
-
-        if len(target_by_address) == 0 or topic0 is None:
-            return []
-
-        logs: list[tuple[Processor.TargetTokenList.TargetToken, EventData]] = []
-        target_addresses = list(target_by_address.keys())
-        topics = [[topic0]]
-
-        for address_chunk in self.__chunked(target_addresses, self.ADDRESS_CHUNK_SIZE):
-            # One eth_getLogs request per event type + address chunk.
-            filter_params = cast(
-                FilterParams,
-                {
-                    "fromBlock": block_from,
-                    "toBlock": block_to,
-                    "address": address_chunk,
-                    "topics": topics,
-                },
-            )
-            raw_logs = await async_web3.eth.get_logs(filter_params)
-            for raw_log in raw_logs:
-                # Map log to target token by address.
-                token_address = to_checksum_address(raw_log["address"])
-                target = target_by_address.get(token_address)
-                if target is None:
-                    continue
-
-                # Skip logs that are already synchronized based on per-token skip_block.
-                if (
-                    target.skip_block is not None
-                    and raw_log["blockNumber"] <= target.skip_block
-                ):
-                    continue
-
-                # Decode log with corresponding event decoder.
-                event_decoder = event_decoder_by_address.get(token_address)
-                if event_decoder is None:
-                    continue
-
-                try:
-                    event = event_decoder.process_log(raw_log)
-                    logs.append((target, event))
-                except Exception:
-                    continue
-
-        # Sort logs by (blockNumber, logIndex) to ensure correct processing order.
-        logs.sort(
-            key=lambda log_data: (log_data[1]["blockNumber"], log_data[1]["logIndex"])
-        )
-        return logs
-
     async def __sync_transfer(
         self,
         db_session: AsyncSession,
@@ -460,66 +355,89 @@ class Processor:
         :param block_to: To block
         :return:
         """
-        # Fetch once by event type and process per-token with skip guards.
-        try:
-            events = await self.__get_logs_by_event(
-                "Transfer", block_from, block_to, targets
-            )
-        except ABIEventNotFound:
-            events = []
+        for target in targets:
+            token = target.token_contract
+            skip_timestamp = target.skip_timestamp
+            skip_block = target.skip_block
+            events_view: Any = token.events
 
-        try:
-            for target, event in events:
-                token = target.token_contract
-                skip_timestamp = target.skip_timestamp
-                args = event["args"]
-                value = args.get("value", 0)
-                if value > sys.maxsize:
+            # Get "Transfer" logs
+            try:
+                if skip_block is not None and block_to <= skip_block:
+                    # Skip if the token has already been synchronized to block_to.
+                    LOG.debug(f"{token.address}: block_to <= skip_block")
                     continue
-
-                event_created = await self.__gen_block_timestamp(event=event)
-                if event_created is None:
-                    continue
-                if skip_timestamp is not None and event_created <= skip_timestamp:
-                    LOG.debug(
-                        f"Skip Registry Transfer data in DB: blockNumber={event['blockNumber']}"
+                elif skip_block is not None and block_from <= skip_block < block_to:
+                    # block_from <= skip_block < block_to
+                    LOG.debug(f"{token.address}: block_from <= skip_block < block_to")
+                    events: list[EventData] = await events_view.Transfer.get_logs(
+                        from_block=skip_block + 1, to_block=block_to
                     )
-                    continue
+                else:
+                    # No logs or
+                    # skip_block < block_from < block_to
+                    LOG.debug(f"{token.address}: skip_block < block_from < block_to")
+                    events = await events_view.Transfer.get_logs(
+                        from_block=block_from, to_block=block_to
+                    )
+            except ABIEventNotFound:
+                events = []
 
-                # Judge whether the transfer is a reallocation
-                transaction_hash = event["transactionHash"].to_0x_hex()
-                is_reallocation = False
-                tx = await AsyncContract.get_transaction(
-                    event["transactionHash"], event["blockNumber"]
-                )
-                if tx is not None:
-                    tx_data: HexBytes | None = tx.get("input")
-                    # Check if the transaction data contains the reallocation marker("c0ffee00")
-                    if tx_data is not None and "c0ffee00" in tx_data.hex():
-                        try:
-                            raw_call_data = tx_data.hex().split("c0ffee00", 1)[1]
-                            call_data = json.loads(bytes.fromhex(raw_call_data))
-                            if call_data.get("purpose") == "Reallocation":
-                                is_reallocation = True
-                        except (ValueError, json.JSONDecodeError):
-                            # If decoding fails, treat it as a normal transfer
-                            pass
+            # Index logs
+            try:
+                for event in events:
+                    args = event["args"]
+                    value = args.get("value", 0)
+                    if value > sys.maxsize:
+                        pass
+                    else:
+                        event_created = await self.__gen_block_timestamp(event=event)
+                        if event_created is None:
+                            continue
+                        if (
+                            skip_timestamp is not None
+                            and event_created <= skip_timestamp
+                        ):
+                            LOG.debug(
+                                f"Skip Registry Transfer data in DB: blockNumber={event['blockNumber']}"
+                            )
+                            continue
 
-                self.__insert_idx(
-                    db_session=db_session,
-                    transaction_hash=transaction_hash,
-                    token_address=to_checksum_address(token.address),
-                    from_account_address=args.get("from", ZERO_ADDRESS),
-                    to_account_address=args.get("to", ZERO_ADDRESS),
-                    value=value,
-                    source_event=IDXTransferSourceEventType.REALLOCATION
-                    if is_reallocation is True
-                    else IDXTransferSourceEventType.TRANSFER,
-                    data_str=None,
-                    event_created=event_created,
-                )
-        except Exception as e:
-            raise e
+                        # Judge whether the transfer is a reallocation
+                        transaction_hash = event["transactionHash"].to_0x_hex()
+                        is_reallocation = False
+                        tx = await AsyncContract.get_transaction(
+                            event["transactionHash"], event["blockNumber"]
+                        )
+                        if tx is not None:
+                            tx_data: HexBytes | None = tx.get("input")
+                            # Check if the transaction data contains the reallocation marker("c0ffee00")
+                            if tx_data is not None and "c0ffee00" in tx_data.hex():
+                                try:
+                                    raw_call_data = tx_data.hex().split("c0ffee00", 1)[
+                                        1
+                                    ]
+                                    call_data = json.loads(bytes.fromhex(raw_call_data))
+                                    if call_data.get("purpose") == "Reallocation":
+                                        is_reallocation = True
+                                except (ValueError, json.JSONDecodeError):
+                                    # If decoding fails, treat it as a normal transfer
+                                    pass
+                        self.__insert_idx(
+                            db_session=db_session,
+                            transaction_hash=transaction_hash,
+                            token_address=to_checksum_address(token.address),
+                            from_account_address=args.get("from", ZERO_ADDRESS),
+                            to_account_address=args.get("to", ZERO_ADDRESS),
+                            value=value,
+                            source_event=IDXTransferSourceEventType.REALLOCATION
+                            if is_reallocation is True
+                            else IDXTransferSourceEventType.TRANSFER,
+                            data_str=None,
+                            event_created=event_created,
+                        )
+            except Exception as e:
+                raise e
 
     async def __sync_unlock(
         self,
@@ -535,45 +453,64 @@ class Processor:
         :param block_to: to block number
         :return: None
         """
-        # Fetch once by event type and process per-token with skip guards.
-        try:
-            events = await self.__get_logs_by_event(
-                "Unlock", block_from, block_to, targets
-            )
-        except ABIEventNotFound:
-            events = []
+        for target in targets:
+            token = target.token_contract
+            skip_block = target.skip_block
+            events_view: Any = token.events
 
-        try:
-            for target, event in events:
-                token = target.token_contract
-                args = event["args"]
-                transaction_hash = event["transactionHash"].to_0x_hex()
-                block_data = await async_web3.eth.get_block(event["blockNumber"])
-                assert "timestamp" in block_data
-                block_timestamp = datetime.fromtimestamp(
-                    block_data["timestamp"],
-                    UTC,
-                ).replace(tzinfo=None)
-                if args.get("value", 0) > sys.maxsize:
+            # Get "Unlock" logs
+            try:
+                if skip_block is not None and block_to <= skip_block:
+                    # Skip if the token has already been synchronized to block_to.
+                    LOG.debug(f"{token.address}: block_to <= skip_block")
                     continue
-
-                from_address = args.get("accountAddress", ZERO_ADDRESS)
-                to_address = args.get("recipientAddress", ZERO_ADDRESS)
-                data_str = args.get("data", "")
-                if from_address != to_address:
-                    self.__insert_idx(
-                        db_session=db_session,
-                        transaction_hash=transaction_hash,
-                        token_address=to_checksum_address(token.address),
-                        from_account_address=from_address,
-                        to_account_address=to_address,
-                        value=args.get("value", 0),
-                        source_event=IDXTransferSourceEventType.UNLOCK,
-                        data_str=data_str,
-                        event_created=block_timestamp,
+                elif skip_block is not None and block_from <= skip_block < block_to:
+                    # block_from <= skip_block < block_to
+                    LOG.debug(f"{token.address}: block_from <= skip_block < block_to")
+                    events: list[EventData] = await events_view.Unlock.get_logs(
+                        from_block=skip_block + 1, to_block=block_to
                     )
-        except Exception:
-            raise
+                else:
+                    # No logs or
+                    # skip_block < block_from < block_to
+                    LOG.debug(f"{token.address}: skip_block < block_from < block_to")
+                    events = await events_view.Unlock.get_logs(
+                        from_block=block_from, to_block=block_to
+                    )
+            except ABIEventNotFound:
+                events = []
+
+            # Index logs
+            try:
+                for event in events:
+                    args = event["args"]
+                    transaction_hash = event["transactionHash"].to_0x_hex()
+                    block_data = await async_web3.eth.get_block(event["blockNumber"])
+                    assert "timestamp" in block_data
+                    block_timestamp = datetime.fromtimestamp(
+                        block_data["timestamp"],
+                        UTC,
+                    ).replace(tzinfo=None)
+                    if args.get("value", 0) > sys.maxsize:
+                        pass
+                    else:
+                        from_address = args.get("accountAddress", ZERO_ADDRESS)
+                        to_address = args.get("recipientAddress", ZERO_ADDRESS)
+                        data_str = args.get("data", "")
+                        if from_address != to_address:
+                            self.__insert_idx(
+                                db_session=db_session,
+                                transaction_hash=transaction_hash,
+                                token_address=to_checksum_address(token.address),
+                                from_account_address=from_address,
+                                to_account_address=to_address,
+                                value=args.get("value", 0),
+                                source_event=IDXTransferSourceEventType.UNLOCK,
+                                data_str=data_str,
+                                event_created=block_timestamp,
+                            )
+            except Exception:
+                raise
 
     async def __sync_force_unlock(
         self,
@@ -589,46 +526,64 @@ class Processor:
         :param block_to: to block number
         :return: None
         """
-        # Fetch once by event type and process per-token with skip guards.
-        try:
-            events = await self.__get_logs_by_event(
-                "ForceUnlock", block_from, block_to, targets
-            )
-        except ABIEventNotFound:
-            events = []
+        for target in targets:
+            token = target.token_contract
+            skip_block = target.skip_block
+            events_view: Any = token.events
 
-        try:
-            for target, event in events:
-                token = target.token_contract
-                args = event["args"]
-                transaction_hash = event["transactionHash"].to_0x_hex()
-                block_data = await async_web3.eth.get_block(event["blockNumber"])
-                assert "timestamp" in block_data
-                block_timestamp = datetime.fromtimestamp(
-                    block_data["timestamp"],
-                    UTC,
-                ).replace(tzinfo=None)
-                if args.get("value", 0) > sys.maxsize:
+            # Get "ForceUnlock" logs
+            try:
+                if skip_block is not None and block_to <= skip_block:
+                    # Skip if the token has already been synchronized to block_to.
+                    LOG.debug(f"{token.address}: block_to <= skip_block")
                     continue
-
-                # Only insert if from and to addresses are different.
-                from_address = args.get("accountAddress", ZERO_ADDRESS)
-                to_address = args.get("recipientAddress", ZERO_ADDRESS)
-                data_str = args.get("data", "")
-                if from_address != to_address:
-                    self.__insert_idx(
-                        db_session=db_session,
-                        transaction_hash=transaction_hash,
-                        token_address=to_checksum_address(token.address),
-                        from_account_address=from_address,
-                        to_account_address=to_address,
-                        value=args.get("value", 0),
-                        source_event=IDXTransferSourceEventType.FORCE_UNLOCK,
-                        data_str=data_str,
-                        event_created=block_timestamp,
+                elif skip_block is not None and block_from <= skip_block < block_to:
+                    # block_from <= skip_block < block_to
+                    LOG.debug(f"{token.address}: block_from <= skip_block < block_to")
+                    events: list[EventData] = await events_view.ForceUnlock.get_logs(
+                        from_block=skip_block + 1, to_block=block_to
                     )
-        except Exception:
-            raise
+                else:
+                    # No logs or
+                    # skip_block < block_from < block_to
+                    LOG.debug(f"{token.address}: skip_block < block_from < block_to")
+                    events = await events_view.ForceUnlock.get_logs(
+                        from_block=block_from, to_block=block_to
+                    )
+            except ABIEventNotFound:
+                events = []
+
+            # Index logs
+            try:
+                for event in events:
+                    args = event["args"]
+                    transaction_hash = event["transactionHash"].to_0x_hex()
+                    block_data = await async_web3.eth.get_block(event["blockNumber"])
+                    assert "timestamp" in block_data
+                    block_timestamp = datetime.fromtimestamp(
+                        block_data["timestamp"],
+                        UTC,
+                    ).replace(tzinfo=None)
+                    if args.get("value", 0) > sys.maxsize:
+                        pass
+                    else:
+                        from_address = args.get("accountAddress", ZERO_ADDRESS)
+                        to_address = args.get("recipientAddress", ZERO_ADDRESS)
+                        data_str = args.get("data", "")
+                        if from_address != to_address:
+                            self.__insert_idx(
+                                db_session=db_session,
+                                transaction_hash=transaction_hash,
+                                token_address=to_checksum_address(token.address),
+                                from_account_address=from_address,
+                                to_account_address=to_address,
+                                value=args.get("value", 0),
+                                source_event=IDXTransferSourceEventType.FORCE_UNLOCK,
+                                data_str=data_str,
+                                event_created=block_timestamp,
+                            )
+            except Exception:
+                raise
 
     async def __sync_force_change_locked_account(
         self,
@@ -644,46 +599,66 @@ class Processor:
         :param block_to: to block number
         :return: None
         """
-        # Fetch once by event type and process per-token with skip guards.
-        try:
-            events = await self.__get_logs_by_event(
-                "ForceChangeLockedAccount", block_from, block_to, targets
-            )
-        except ABIEventNotFound:
-            events = []
+        for target in targets:
+            token = target.token_contract
+            skip_block = target.skip_block
+            events_view: Any = token.events
 
-        try:
-            for target, event in events:
-                token = target.token_contract
-                args = event["args"]
-                transaction_hash = event["transactionHash"].to_0x_hex()
-                block_data = await async_web3.eth.get_block(event["blockNumber"])
-                assert "timestamp" in block_data
-                block_timestamp = datetime.fromtimestamp(
-                    block_data["timestamp"],
-                    UTC,
-                ).replace(tzinfo=None)
-                if args.get("value", 0) > sys.maxsize:
+            # Get "ForceChangeLockedAccount" logs
+            try:
+                if skip_block is not None and block_to <= skip_block:
+                    # Skip if the token has already been synchronized to block_to.
+                    LOG.debug(f"{token.address}: block_to <= skip_block")
                     continue
-
-                # Only insert if from and to addresses are different.
-                from_address = args.get("beforeAccountAddress", ZERO_ADDRESS)
-                to_address = args.get("afterAccountAddress", ZERO_ADDRESS)
-                data_str = args.get("data", "")
-                if from_address != to_address:
-                    self.__insert_idx(
-                        db_session=db_session,
-                        transaction_hash=transaction_hash,
-                        token_address=to_checksum_address(token.address),
-                        from_account_address=from_address,
-                        to_account_address=to_address,
-                        value=args.get("value", 0),
-                        source_event=IDXTransferSourceEventType.FORCE_CHANGE_LOCKED_ACCOUNT,
-                        data_str=data_str,
-                        event_created=block_timestamp,
+                elif skip_block is not None and block_from <= skip_block < block_to:
+                    # block_from <= skip_block < block_to
+                    LOG.debug(f"{token.address}: block_from <= skip_block < block_to")
+                    events: list[
+                        EventData
+                    ] = await events_view.ForceChangeLockedAccount.get_logs(
+                        from_block=skip_block + 1, to_block=block_to
                     )
-        except Exception:
-            raise
+                else:
+                    # No logs or
+                    # skip_block < block_from < block_to
+                    LOG.debug(f"{token.address}: skip_block < block_from < block_to")
+                    events = await events_view.ForceChangeLockedAccount.get_logs(
+                        from_block=block_from, to_block=block_to
+                    )
+            except ABIEventNotFound:
+                events = []
+
+            # Index logs
+            try:
+                for event in events:
+                    args = event["args"]
+                    transaction_hash = event["transactionHash"].to_0x_hex()
+                    block_data = await async_web3.eth.get_block(event["blockNumber"])
+                    assert "timestamp" in block_data
+                    block_timestamp = datetime.fromtimestamp(
+                        block_data["timestamp"],
+                        UTC,
+                    ).replace(tzinfo=None)
+                    if args.get("value", 0) > sys.maxsize:
+                        pass
+                    else:
+                        from_address = args.get("beforeAccountAddress", ZERO_ADDRESS)
+                        to_address = args.get("afterAccountAddress", ZERO_ADDRESS)
+                        data_str = args.get("data", "")
+                        if from_address != to_address:
+                            self.__insert_idx(
+                                db_session=db_session,
+                                transaction_hash=transaction_hash,
+                                token_address=to_checksum_address(token.address),
+                                from_account_address=from_address,
+                                to_account_address=to_address,
+                                value=args.get("value", 0),
+                                source_event=IDXTransferSourceEventType.FORCE_CHANGE_LOCKED_ACCOUNT,
+                                data_str=data_str,
+                                event_created=block_timestamp,
+                            )
+            except Exception:
+                raise
 
     async def __update_skip_block(self, db_session: AsyncSession):
         """Memorize the block number where next processing should start from

--- a/batch/sub_indexers/indexer_TransferApproval.py
+++ b/batch/sub_indexers/indexer_TransferApproval.py
@@ -19,15 +19,12 @@ SPDX-License-Identifier: Apache-2.0
 
 import sys
 from datetime import datetime, timezone
-from typing import Any, List, Mapping, Optional, Sequence, cast
+from typing import Any, List, Mapping, Optional, Sequence
 
-from eth_utils.address import to_checksum_address
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
-from web3 import Web3
-from web3.contract.async_contract import AsyncContractEvent
 from web3.exceptions import ABIEventNotFound
-from web3.types import EventData, FilterParams
+from web3.types import EventData
 
 from app.config import TOKEN_LIST_CONTRACT_ADDRESS, ZERO_ADDRESS
 from app.contracts import AsyncContract
@@ -63,10 +60,6 @@ ibetSecurityTokenEscrow
 
 class Processor:
     """Processor for indexing Token transfer approval events"""
-
-    # Maximum number of contract addresses in one eth_getLogs request.
-    # This is a trade-off between request count and payload size.
-    ADDRESS_CHUNK_SIZE = 200
 
     class TargetTokenList:
         class TargetToken:
@@ -341,196 +334,6 @@ class Processor:
 
         self.__update_cursor(block_to + 1)
 
-    @staticmethod
-    def __chunked(values: list[str], chunk_size: int) -> list[list[str]]:
-        """Split a list into fixed-size chunks."""
-        return [values[i : i + chunk_size] for i in range(0, len(values), chunk_size)]
-
-    @staticmethod
-    def __build_topic0(event_name: str, event_abi: Any) -> str:
-        """Build topic0 (= event signature hash) from event ABI."""
-        input_types = ",".join(
-            [input_param["type"] for input_param in event_abi.get("inputs", [])]
-        )
-        signature = f"{event_name}({input_types})"
-        return Web3.keccak(text=signature).to_0x_hex()
-
-    async def __get_logs_for_token_event(
-        self, event_name: str, block_to: int
-    ) -> list[tuple[TargetTokenList.TargetToken, EventData]]:
-        """Fetch logs once per event type, then decode and map to each target token.
-
-        Flow:
-        1) Build target token/decoder maps
-        2) Query logs in address chunks with shared topic0 filter
-        3) Filter out already synchronized logs by per-token cursor
-        4) Decode and return logs sorted by (blockNumber, logIndex)
-        """
-        target_by_address: dict[str, Processor.TargetTokenList.TargetToken] = {}
-        event_decoder_by_address: dict[str, AsyncContractEvent] = {}
-        topic0: str | None = None
-        oldest_block_from: int | None = None
-
-        for target in self.token_list:
-            token = target.token_contract
-            block_from = target.cursor
-            if block_from > block_to:
-                # Already synchronized up to block_to. Skip RPC call and processing.
-                LOG.debug(
-                    f"Skip {event_name}(token): {token.address} block_from({block_from}) > block_to({block_to})"
-                )
-                continue
-
-            if oldest_block_from is None or block_from < oldest_block_from:
-                oldest_block_from = block_from
-
-            event_class: Any = getattr(token.events, event_name, None)
-            if event_class is None:
-                continue
-            event_decoder = event_class()
-            if not isinstance(event_decoder, AsyncContractEvent):
-                continue
-            token_address = to_checksum_address(token.address)
-            target_by_address[token_address] = target
-            event_decoder_by_address[token_address] = event_decoder
-            if topic0 is None:
-                topic0 = self.__build_topic0(event_name, event_decoder.abi)
-
-        if oldest_block_from is None or len(target_by_address) == 0 or topic0 is None:
-            return []
-
-        logs: list[tuple[Processor.TargetTokenList.TargetToken, EventData]] = []
-        target_addresses = list(target_by_address.keys())
-        topics = [[topic0]]
-
-        for address_chunk in self.__chunked(target_addresses, self.ADDRESS_CHUNK_SIZE):
-            # One eth_getLogs request per event type + address chunk.
-            filter_params = cast(
-                FilterParams,
-                {
-                    "fromBlock": oldest_block_from,
-                    "toBlock": block_to,
-                    "address": address_chunk,
-                    "topics": topics,
-                },
-            )
-            raw_logs = await async_web3.eth.get_logs(filter_params)
-            for raw_log in raw_logs:
-                # Map log to target token by address.
-                token_address = to_checksum_address(raw_log["address"])
-                target = target_by_address.get(token_address)
-                if target is None:
-                    continue
-
-                # Guard: skip logs that are already synchronized, based on per-token cursor.
-                if raw_log["blockNumber"] < target.cursor:
-                    continue
-
-                # Decode log with corresponding event decoder.
-                event_decoder = event_decoder_by_address.get(token_address)
-                if event_decoder is None:
-                    continue
-                try:
-                    event = event_decoder.process_log(raw_log)
-                    logs.append((target, event))
-                except Exception:
-                    # Keep indexing robust: skip logs that cannot be decoded.
-                    continue
-
-        # Sort logs by (blockNumber, logIndex) to ensure correct processing order.
-        logs.sort(
-            key=lambda log_data: (log_data[1]["blockNumber"], log_data[1]["logIndex"])
-        )
-        return logs
-
-    async def __get_logs_for_exchange_event(
-        self, event_name: str, block_to: int
-    ) -> list[tuple[TargetExchangeList.TargetExchange, EventData]]:
-        """Fetch logs once per event type, then decode and map to each exchange.
-
-        Flow:
-        1) Build target exchange/decoder maps
-        2) Query logs in address chunks with shared topic0 filter
-        3) Filter out already synchronized logs by per-exchange cursor
-        4) Decode and return logs sorted by (blockNumber, logIndex)
-        """
-        target_by_address: dict[str, Processor.TargetExchangeList.TargetExchange] = {}
-        event_decoder_by_address: dict[str, AsyncContractEvent] = {}
-        topic0: str | None = None
-        oldest_block_from: int | None = None
-
-        for target in self.exchange_list:
-            block_from = target.cursor
-            if block_from > block_to:
-                # Already synchronized up to block_to. Skip RPC call and processing.
-                LOG.debug(
-                    f"Skip {event_name}(exchange): {target.exchange_address} block_from({block_from}) > block_to({block_to})"
-                )
-                continue
-
-            if oldest_block_from is None or block_from < oldest_block_from:
-                oldest_block_from = block_from
-
-            event_class: Any = getattr(
-                target.exchange_contract.events, event_name, None
-            )
-            if event_class is None:
-                continue
-            event_decoder = event_class()
-            if not isinstance(event_decoder, AsyncContractEvent):
-                continue
-            exchange_address = to_checksum_address(target.exchange_address)
-            target_by_address[exchange_address] = target
-            event_decoder_by_address[exchange_address] = event_decoder
-            if topic0 is None:
-                topic0 = self.__build_topic0(event_name, event_decoder.abi)
-
-        if oldest_block_from is None or len(target_by_address) == 0 or topic0 is None:
-            return []
-
-        logs: list[tuple[Processor.TargetExchangeList.TargetExchange, EventData]] = []
-        target_addresses = list(target_by_address.keys())
-        topics = [[topic0]]
-
-        for address_chunk in self.__chunked(target_addresses, self.ADDRESS_CHUNK_SIZE):
-            # One eth_getLogs request per event type + address chunk.
-            filter_params = cast(
-                FilterParams,
-                {
-                    "fromBlock": oldest_block_from,
-                    "toBlock": block_to,
-                    "address": address_chunk,
-                    "topics": topics,
-                },
-            )
-            raw_logs = await async_web3.eth.get_logs(filter_params)
-            for raw_log in raw_logs:
-                # Map log to target exchange by address.
-                exchange_address = to_checksum_address(raw_log["address"])
-                target = target_by_address.get(exchange_address)
-                if target is None:
-                    continue
-
-                # Skip logs that are already synchronized, based on per-exchange cursor.
-                if raw_log["blockNumber"] < target.cursor:
-                    continue
-
-                # Decode log with corresponding event decoder.
-                event_decoder = event_decoder_by_address.get(exchange_address)
-                if event_decoder is None:
-                    continue
-                try:
-                    event = event_decoder.process_log(raw_log)
-                    logs.append((target, event))
-                except Exception:
-                    continue
-
-        # Sort logs by (blockNumber, logIndex) to ensure correct processing order.
-        logs.sort(
-            key=lambda log_data: (log_data[1]["blockNumber"], log_data[1]["logIndex"])
-        )
-        return logs
-
     def __update_cursor(self, block_number: int):
         """Memorize the block number where next processing should start from
         :param block_number: block number to be set
@@ -551,33 +354,41 @@ class Processor:
         :param block_to: To Block
         :return: None
         """
-        # Fetch once by event type and process per-token with cursor guards.
-        try:
-            events = await self.__get_logs_for_token_event("ApplyForTransfer", block_to)
-        except ABIEventNotFound:
-            events = []
-        try:
-            for target, event in events:
-                token = target.token_contract
-                args = event["args"]
-                value = args.get("value", 0)
-                if value > sys.maxsize:
-                    continue
-                block_timestamp = await self.get_block_timestamp(event=event)
-                await self.__sink_on_transfer_approval(
-                    db_session=db_session,
-                    event_type="ApplyFor",
-                    token_address=token.address,
-                    exchange_address=None,
-                    application_id=args.get("index"),
-                    from_address=args.get("from", ZERO_ADDRESS),
-                    to_address=args.get("to", ZERO_ADDRESS),
-                    value=value,
-                    optional_data_applicant=args.get("data"),
-                    block_timestamp=block_timestamp,
+        for target in self.token_list:
+            token = target.token_contract
+            block_from = target.cursor
+            if block_from > block_to:
+                LOG.debug(
+                    f"Skip ApplyForTransfer(token): {token.address} block_from({block_from}) > block_to({block_to})"
                 )
-        except Exception as e:
-            raise e
+                continue
+            try:
+                events: list[EventData] = await token.events.ApplyForTransfer.get_logs(
+                    from_block=block_from, to_block=block_to
+                )
+            except ABIEventNotFound:
+                events = []
+            try:
+                for event in events:
+                    args = event["args"]
+                    value = args.get("value", 0)
+                    if value > sys.maxsize:
+                        continue
+                    block_timestamp = await self.get_block_timestamp(event=event)
+                    await self.__sink_on_transfer_approval(
+                        db_session=db_session,
+                        event_type="ApplyFor",
+                        token_address=token.address,
+                        exchange_address=None,
+                        application_id=args.get("index"),
+                        from_address=args.get("from", ZERO_ADDRESS),
+                        to_address=args.get("to", ZERO_ADDRESS),
+                        value=value,
+                        optional_data_applicant=args.get("data"),
+                        block_timestamp=block_timestamp,
+                    )
+            except Exception as e:
+                raise e
 
     async def __sync_token_cancel_transfer(
         self, db_session: AsyncSession, block_to: int
@@ -587,26 +398,34 @@ class Processor:
         :param block_to: To Block
         :return: None
         """
-        # Fetch once by event type and process per-token with cursor guards.
-        try:
-            events = await self.__get_logs_for_token_event("CancelTransfer", block_to)
-        except ABIEventNotFound:
-            events = []
-        try:
-            for target, event in events:
-                token = target.token_contract
-                args = event["args"]
-                await self.__sink_on_transfer_approval(
-                    db_session=db_session,
-                    event_type="Cancel",
-                    token_address=token.address,
-                    exchange_address=None,
-                    application_id=args.get("index"),
-                    from_address=args.get("from", ZERO_ADDRESS),
-                    to_address=args.get("to", ZERO_ADDRESS),
+        for target in self.token_list:
+            token = target.token_contract
+            block_from = target.cursor
+            if block_from > block_to:
+                LOG.debug(
+                    f"Skip CancelTransfer(token): {token.address} block_from({block_from}) > block_to({block_to})"
                 )
-        except Exception as e:
-            raise e
+                continue
+            try:
+                events: list[EventData] = await token.events.CancelTransfer.get_logs(
+                    from_block=block_from, to_block=block_to
+                )
+            except ABIEventNotFound:
+                events = []
+            try:
+                for event in events:
+                    args = event["args"]
+                    await self.__sink_on_transfer_approval(
+                        db_session=db_session,
+                        event_type="Cancel",
+                        token_address=token.address,
+                        exchange_address=None,
+                        application_id=args.get("index"),
+                        from_address=args.get("from", ZERO_ADDRESS),
+                        to_address=args.get("to", ZERO_ADDRESS),
+                    )
+            except Exception as e:
+                raise e
 
     async def __sync_token_approve_transfer(
         self, db_session: AsyncSession, block_to: int
@@ -616,29 +435,37 @@ class Processor:
         :param block_to: To Block
         :return: None
         """
-        # Fetch once by event type and process per-token with cursor guards.
-        try:
-            events = await self.__get_logs_for_token_event("ApproveTransfer", block_to)
-        except ABIEventNotFound:
-            events = []
-        try:
-            for target, event in events:
-                token = target.token_contract
-                args = event["args"]
-                block_timestamp = await self.get_block_timestamp(event=event)
-                await self.__sink_on_transfer_approval(
-                    db_session=db_session,
-                    event_type="Approve",
-                    token_address=token.address,
-                    exchange_address=None,
-                    application_id=args.get("index"),
-                    from_address=args.get("from", ZERO_ADDRESS),
-                    to_address=args.get("to", ZERO_ADDRESS),
-                    optional_data_approver=args.get("data"),
-                    block_timestamp=block_timestamp,
+        for target in self.token_list:
+            token = target.token_contract
+            block_from = target.cursor
+            if block_from > block_to:
+                LOG.debug(
+                    f"Skip ApproveTransfer(token): {token.address} block_from({block_from}) > block_to({block_to})"
                 )
-        except Exception as e:
-            raise e
+                continue
+            try:
+                events: list[EventData] = await token.events.ApproveTransfer.get_logs(
+                    from_block=block_from, to_block=block_to
+                )
+            except ABIEventNotFound:
+                events = []
+            try:
+                for event in events:
+                    args = event["args"]
+                    block_timestamp = await self.get_block_timestamp(event=event)
+                    await self.__sink_on_transfer_approval(
+                        db_session=db_session,
+                        event_type="Approve",
+                        token_address=token.address,
+                        exchange_address=None,
+                        application_id=args.get("index"),
+                        from_address=args.get("from", ZERO_ADDRESS),
+                        to_address=args.get("to", ZERO_ADDRESS),
+                        optional_data_approver=args.get("data"),
+                        block_timestamp=block_timestamp,
+                    )
+            except Exception as e:
+                raise e
 
     async def __sync_exchange_apply_for_transfer(
         self, db_session: AsyncSession, block_to: int
@@ -648,38 +475,50 @@ class Processor:
         :param block_to: To Block
         :return: None
         """
-        # Fetch once by event type and process per-exchange with cursor guards.
-        try:
-            events = await self.__get_logs_for_exchange_event(
-                "ApplyForTransfer", block_to
-            )
-        except ABIEventNotFound:
-            events = []
-        try:
-            token_address_list = [t.token_contract.address for t in self.token_list]
-            for target, event in events:
-                exchange = target.exchange_contract
-                args = event["args"]
-                if args.get("token", ZERO_ADDRESS) not in token_address_list:
-                    continue
-                value = args.get("value", 0)
-                if value > sys.maxsize:
-                    continue
-                block_timestamp = await self.get_block_timestamp(event=event)
-                await self.__sink_on_transfer_approval(
-                    db_session=db_session,
-                    event_type="ApplyFor",
-                    token_address=args.get("token", ZERO_ADDRESS),
-                    exchange_address=exchange.address,
-                    application_id=args.get("escrowId"),
-                    from_address=args.get("from", ZERO_ADDRESS),
-                    to_address=args.get("to", ZERO_ADDRESS),
-                    value=args.get("value"),
-                    optional_data_applicant=args.get("data"),
-                    block_timestamp=block_timestamp,
+        for target in self.exchange_list:
+            block_from = target.cursor
+            if block_from > block_to:
+                LOG.debug(
+                    f"Skip ApplyForTransfer(exchange): {target.exchange_address} block_from({block_from}) > block_to({block_to})"
                 )
-        except Exception as e:
-            raise e
+                continue
+            exchange = target.exchange_contract
+            try:
+                events: list[
+                    EventData
+                ] = await exchange.events.ApplyForTransfer.get_logs(
+                    from_block=block_from, to_block=block_to
+                )
+            except ABIEventNotFound:
+                events = []
+            try:
+                # Filter events by listed token
+                events_filtered: list[EventData] = []
+                token_address_list = [t.token_contract.address for t in self.token_list]
+                for event in events:
+                    args = event["args"]
+                    if args.get("token", ZERO_ADDRESS) in token_address_list:
+                        events_filtered.append(event)
+                for event in events_filtered:
+                    args = event["args"]
+                    value = args.get("value", 0)
+                    if value > sys.maxsize:
+                        continue
+                    block_timestamp = await self.get_block_timestamp(event=event)
+                    await self.__sink_on_transfer_approval(
+                        db_session=db_session,
+                        event_type="ApplyFor",
+                        token_address=args.get("token", ZERO_ADDRESS),
+                        exchange_address=exchange.address,
+                        application_id=args.get("escrowId"),
+                        from_address=args.get("from", ZERO_ADDRESS),
+                        to_address=args.get("to", ZERO_ADDRESS),
+                        value=args.get("value"),
+                        optional_data_applicant=args.get("data"),
+                        block_timestamp=block_timestamp,
+                    )
+            except Exception as e:
+                raise e
 
     async def __sync_exchange_cancel_transfer(
         self, db_session: AsyncSession, block_to: int
@@ -689,31 +528,41 @@ class Processor:
         :param block_to: To Block
         :return: None
         """
-        # Fetch once by event type and process per-exchange with cursor guards.
-        try:
-            events = await self.__get_logs_for_exchange_event(
-                "CancelTransfer", block_to
-            )
-        except ABIEventNotFound:
-            events = []
-        try:
-            token_address_list = [t.token_contract.address for t in self.token_list]
-            for target, event in events:
-                exchange = target.exchange_contract
-                args = event["args"]
-                if args.get("token", ZERO_ADDRESS) not in token_address_list:
-                    continue
-                await self.__sink_on_transfer_approval(
-                    db_session=db_session,
-                    event_type="Cancel",
-                    token_address=args.get("token", ZERO_ADDRESS),
-                    exchange_address=exchange.address,
-                    application_id=args.get("escrowId"),
-                    from_address=args.get("from", ZERO_ADDRESS),
-                    to_address=args.get("to", ZERO_ADDRESS),
+        for target in self.exchange_list:
+            block_from = target.cursor
+            if block_from > block_to:
+                LOG.debug(
+                    f"Skip CancelTransfer(exchange): {target.exchange_address} block_from({block_from}) > block_to({block_to})"
                 )
-        except Exception as e:
-            raise e
+                continue
+            exchange = target.exchange_contract
+            try:
+                events: list[EventData] = await exchange.events.CancelTransfer.get_logs(
+                    from_block=block_from, to_block=block_to
+                )
+            except ABIEventNotFound:
+                events = []
+            try:
+                # Filter events by listed token
+                events_filtered: list[EventData] = []
+                token_address_list = [t.token_contract.address for t in self.token_list]
+                for event in events:
+                    args = event["args"]
+                    if args.get("token", ZERO_ADDRESS) in token_address_list:
+                        events_filtered.append(event)
+                for event in events_filtered:
+                    args = event["args"]
+                    await self.__sink_on_transfer_approval(
+                        db_session=db_session,
+                        event_type="Cancel",
+                        token_address=args.get("token", ZERO_ADDRESS),
+                        exchange_address=exchange.address,
+                        application_id=args.get("escrowId"),
+                        from_address=args.get("from", ZERO_ADDRESS),
+                        to_address=args.get("to", ZERO_ADDRESS),
+                    )
+            except Exception as e:
+                raise e
 
     async def __sync_exchange_escrow_finished(
         self, db_session: AsyncSession, block_to: int
@@ -723,33 +572,43 @@ class Processor:
         :param block_to: To Block
         :return: None
         """
-        # Fetch once by event type and process per-exchange with cursor guards.
-        try:
-            events = await self.__get_logs_for_exchange_event(
-                "EscrowFinished", block_to
-            )
-        except ABIEventNotFound:
-            events = []
-        try:
-            token_address_list = [t.token_contract.address for t in self.token_list]
-            for target, event in events:
-                exchange = target.exchange_contract
-                args = event["args"]
-                if args.get("transferApprovalRequired") is not True:
-                    continue
-                if args.get("token", ZERO_ADDRESS) not in token_address_list:
-                    continue
-                await self.__sink_on_transfer_approval(
-                    db_session=db_session,
-                    event_type="EscrowFinish",
-                    token_address=args.get("token", ZERO_ADDRESS),
-                    exchange_address=exchange.address,
-                    application_id=args.get("escrowId"),
-                    from_address=args.get("sender", ZERO_ADDRESS),
-                    to_address=args.get("recipient", ZERO_ADDRESS),
+        for target in self.exchange_list:
+            block_from = target.cursor
+            if block_from > block_to:
+                LOG.debug(
+                    f"Skip EscrowFinished(exchange): {target.exchange_address} block_from({block_from}) > block_to({block_to})"
                 )
-        except Exception as e:
-            raise e
+                continue
+            exchange = target.exchange_contract
+            try:
+                events: list[EventData] = await exchange.events.EscrowFinished.get_logs(
+                    from_block=block_from,
+                    to_block=block_to,
+                    argument_filters={"transferApprovalRequired": True},
+                )
+            except ABIEventNotFound:
+                events = []
+            try:
+                # Filter events by listed token
+                events_filtered: list[EventData] = []
+                token_address_list = [t.token_contract.address for t in self.token_list]
+                for event in events:
+                    args = event["args"]
+                    if args.get("token", ZERO_ADDRESS) in token_address_list:
+                        events_filtered.append(event)
+                for event in events_filtered:
+                    args = event["args"]
+                    await self.__sink_on_transfer_approval(
+                        db_session=db_session,
+                        event_type="EscrowFinish",
+                        token_address=args.get("token", ZERO_ADDRESS),
+                        exchange_address=exchange.address,
+                        application_id=args.get("escrowId"),
+                        from_address=args.get("sender", ZERO_ADDRESS),
+                        to_address=args.get("recipient", ZERO_ADDRESS),
+                    )
+            except Exception as e:
+                raise e
 
     async def __sync_exchange_approve_transfer(
         self, db_session: AsyncSession, block_to: int
@@ -759,32 +618,44 @@ class Processor:
         :param block_to: To Block
         :return: None
         """
-        # Fetch once by event type and process per-exchange with cursor guards.
-        try:
-            events = await self.__get_logs_for_exchange_event(
-                "ApproveTransfer", block_to
-            )
-        except ABIEventNotFound:
-            events = []
-        try:
-            token_address_list = [t.token_contract.address for t in self.token_list]
-            for target, event in events:
-                exchange = target.exchange_contract
-                args = event["args"]
-                if args.get("token", ZERO_ADDRESS) not in token_address_list:
-                    continue
-                block_timestamp = await self.get_block_timestamp(event=event)
-                await self.__sink_on_transfer_approval(
-                    db_session=db_session,
-                    event_type="Approve",
-                    token_address=args.get("token", ZERO_ADDRESS),
-                    exchange_address=exchange.address,
-                    application_id=args.get("escrowId"),
-                    optional_data_approver=args.get("data"),
-                    block_timestamp=block_timestamp,
+        for target in self.exchange_list:
+            block_from = target.cursor
+            if block_from > block_to:
+                LOG.debug(
+                    f"Skip ApproveTransfer(exchange): {target.exchange_address} block_from({block_from}) > block_to({block_to})"
                 )
-        except Exception as e:
-            raise e
+                continue
+            exchange = target.exchange_contract
+            try:
+                events: list[
+                    EventData
+                ] = await exchange.events.ApproveTransfer.get_logs(
+                    from_block=block_from, to_block=block_to
+                )
+            except ABIEventNotFound:
+                events = []
+            try:
+                # Filter events by listed token
+                events_filtered: list[EventData] = []
+                token_address_list = [t.token_contract.address for t in self.token_list]
+                for event in events:
+                    args = event["args"]
+                    if args.get("token", ZERO_ADDRESS) in token_address_list:
+                        events_filtered.append(event)
+                for event in events_filtered:
+                    args = event["args"]
+                    block_timestamp = await self.get_block_timestamp(event=event)
+                    await self.__sink_on_transfer_approval(
+                        db_session=db_session,
+                        event_type="Approve",
+                        token_address=args.get("token", ZERO_ADDRESS),
+                        exchange_address=exchange.address,
+                        application_id=args.get("escrowId"),
+                        optional_data_approver=args.get("data"),
+                        block_timestamp=block_timestamp,
+                    )
+            except Exception as e:
+                raise e
 
     @staticmethod
     def __get_oldest_cursor(target_token_list: TargetTokenList, block_to: int) -> int:

--- a/tests/batch/sub_indexers/indexer_Transfer_test.py
+++ b/tests/batch/sub_indexers/indexer_Transfer_test.py
@@ -1123,6 +1123,13 @@ class TestProcessor:
         assert idx_block_number is not None
         assert idx_block_number.latest_block_number == block_number_2
 
+        assert 4 == caplog.record_tuples.count(
+            (
+                LOG.name,
+                logging.DEBUG,
+                f"{share_token.address}: block_from <= skip_block < block_to",
+            )
+        )
         caplog.clear()
 
     # <Normal_4_3>
@@ -1353,69 +1360,14 @@ class TestProcessor:
         assert idx_block_number is not None
         assert idx_block_number.latest_block_number == block_number
 
+        assert 4 == caplog.record_tuples.count(
+            (
+                LOG.name,
+                logging.DEBUG,
+                f"{share_token.address}: skip_block < block_from < block_to",
+            )
+        )
         caplog.clear()
-
-    # <Normal_4_6>
-    # get_logs is called once per event type in a single sync run
-    async def test_normal_4_6(
-        self,
-        processor: Processor,
-        shared_contract: SharedContract,
-        async_session: AsyncSession,
-    ):
-        # Issue Token
-        token_list_contract = shared_contract["TokenList"]
-        personal_info_contract_address = shared_contract["PersonalInfo"]["address"]
-        share_token = self.issue_token_share(
-            self.issuer,
-            config.ZERO_ADDRESS,
-            personal_info_contract_address,
-            token_list_contract,
-        )
-        await self.listing_token(share_token.address, async_session)
-
-        # Execute batch processing with spying get_logs
-        with mock.patch.object(
-            indexer_Transfer.async_web3.eth,
-            "get_logs",
-            wraps=indexer_Transfer.async_web3.eth.get_logs,
-        ) as mock_get_logs:
-            await processor.sync_new_logs()
-
-        # Transfer / Unlock / ForceUnlock / ForceChangeLockedAccount
-        assert mock_get_logs.await_count == 4
-
-    # <Normal_4_7>
-    # get_logs is not called when token is already synchronized to latest block
-    async def test_normal_4_7(
-        self,
-        processor: Processor,
-        shared_contract: SharedContract,
-        async_session: AsyncSession,
-    ):
-        # Issue Token
-        token_list_contract = shared_contract["TokenList"]
-        personal_info_contract_address = shared_contract["PersonalInfo"]["address"]
-        share_token = self.issue_token_share(
-            self.issuer,
-            config.ZERO_ADDRESS,
-            personal_info_contract_address,
-            token_list_contract,
-        )
-        await self.listing_token(share_token.address, async_session)
-
-        # 1st sync to initialize skip block
-        await processor.sync_new_logs()
-
-        # 2nd sync should skip all event queries
-        with mock.patch.object(
-            indexer_Transfer.async_web3.eth,
-            "get_logs",
-            wraps=indexer_Transfer.async_web3.eth.get_logs,
-        ) as mock_get_logs:
-            await processor.sync_new_logs()
-
-        assert mock_get_logs.await_count == 0
 
     # <Normal_5>
     # Not Listing Token


### PR DESCRIPTION
## 📌 Description

This pull request refactors and improves the logic for determining the starting block (`fromBlock`) when querying blockchain logs for both token and exchange events in the `indexer_Transfer.py` and `indexer_TransferApproval.py` files. The main goal is to ensure that log queries start from the correct minimum block for each target, preventing redundant or missed log retrievals, while also simplifying the code structure.

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
- Related to #1767 

## 🔄 Changes

<!-- List the major changes in this PR. -->

**1. Improved Minimum Block Calculation Logic**
- Introduced new static methods (`__calculate_minimum_from_block_for_targets`, `__calculate_minimum_from_block_for_token_targets`, and `__calculate_minimum_from_block_for_exchange_targets`) to accurately determine the minimum `fromBlock` for log queries based on per-target cursors or skip blocks, replacing the previous approach of using a single `oldest_block_from` value.

**2. Refactored Mapping of Targets and Decoders**
- Combined the mapping of targets and their event decoders into a single dictionary (`target_by_address`) that stores tuples of (target, event_decoder), eliminating the need for separate decoder dictionaries and reducing redundant lookups.


## 📌 Checklist

- [x] I have added tests where necessary.
- [ ] I have updated the documentation where necessary.
