### PR TITLE
Cleanup Python environment and remove unnecessary files in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,11 @@ COPY --chown=apl:apl . /app/ibet-Wallet-API
 RUN cd /app/ibet-Wallet-API \
  && uv venv $UV_PROJECT_ENVIRONMENT \
  && uv sync --frozen --no-install-project --no-dev \
+ && PYTHON_BIN="$(uv python find $PYTHON_VERSION)" \
+ && PYTHON_ROOT="$(dirname "$(dirname "$PYTHON_BIN")")" \
+ && rm -f "$PYTHON_ROOT"/bin/pip "$PYTHON_ROOT"/bin/pip3 "$PYTHON_ROOT"/bin/pip3.* \
+ && rm -rf "$PYTHON_ROOT"/lib/python*/site-packages/pip "$PYTHON_ROOT"/lib/python*/site-packages/pip-*.dist-info \
+ && rm -rf /home/apl/.cache/uv \
  && rm -f /app/ibet-Wallet-API/pyproject.toml \
  && rm -f /app/ibet-Wallet-API/uv.lock \
  && rm -rf /app/ibet-Wallet-API/tests/
@@ -91,7 +96,10 @@ RUN apt-get update -q \
 
 # copy python, dependencies and uv from builder stage
 USER apl
-COPY --from=builder --chown=apl:apl /home/apl/ /home/apl/
+COPY --from=builder --chown=apl:apl /home/apl/.bash_profile /home/apl/.bash_profile
+COPY --from=builder --chown=apl:apl /home/apl/.bashrc /home/apl/.bashrc
+COPY --from=builder --chown=apl:apl /home/apl/.local/share/uv/python/ /home/apl/.local/share/uv/python/
+COPY --from=builder --chown=apl:apl /home/apl/.venv/ /home/apl/.venv/
 COPY --from=builder --chown=apl:apl /app/ibet-Wallet-API/ /app/ibet-Wallet-API/
 COPY --from=builder --chown=apl:apl /usr/local/bin/uv /usr/local/bin/uv
 COPY --from=builder --chown=apl:apl /usr/local/bin/uvx /usr/local/bin/uvx

--- a/tests/Dockerfile_unittest
+++ b/tests/Dockerfile_unittest
@@ -56,7 +56,12 @@ RUN echo '. $HOME/.venv/bin/activate' >> ~apl/.bashrc
 COPY --chown=apl:apl . /app/ibet-Wallet-API
 RUN cd /app/ibet-Wallet-API \
  && uv venv $UV_PROJECT_ENVIRONMENT \
- && uv sync --frozen --no-install-project
+ && uv sync --frozen --no-install-project \
+ && PYTHON_BIN="$(uv python find $PYTHON_VERSION)" \
+ && PYTHON_ROOT="$(dirname "$(dirname "$PYTHON_BIN")")" \
+ && rm -f "$PYTHON_ROOT"/bin/pip "$PYTHON_ROOT"/bin/pip3 "$PYTHON_ROOT"/bin/pip3.* \
+ && rm -rf "$PYTHON_ROOT"/lib/python*/site-packages/pip "$PYTHON_ROOT"/lib/python*/site-packages/pip-*.dist-info \
+ && rm -rf /home/apl/.cache/uv
 
 FROM ubuntu:24.04 AS runner
 
@@ -89,7 +94,10 @@ RUN apt-get update -q \
 
 # copy python, dependencies and uv from builder stage
 USER apl
-COPY --from=builder --chown=apl:apl /home/apl/ /home/apl/
+COPY --from=builder --chown=apl:apl /home/apl/.bash_profile /home/apl/.bash_profile
+COPY --from=builder --chown=apl:apl /home/apl/.bashrc /home/apl/.bashrc
+COPY --from=builder --chown=apl:apl /home/apl/.local/share/uv/python/ /home/apl/.local/share/uv/python/
+COPY --from=builder --chown=apl:apl /home/apl/.venv/ /home/apl/.venv/
 COPY --from=builder --chown=apl:apl /app/ibet-Wallet-API/ /app/ibet-Wallet-API/
 COPY --from=builder --chown=apl:apl /usr/local/bin/uv /usr/local/bin/uv
 COPY --from=builder --chown=apl:apl /usr/local/bin/uvx /usr/local/bin/uvx


### PR DESCRIPTION
## 📌 Description

This pull request updates both the main and test Dockerfiles to optimize the runtime image by cleaning up unnecessary files related to pip and cache directories after building with uv.

<!-- Please provide a clear and concise description of the changes. -->

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
- None

## 🔄 Changes

<!-- List the major changes in this PR. -->

* Updated a `RUN` command to both `Dockerfile` and `tests/Dockerfile_unittest` that removes the pip package, pip-related metadata, and pip binaries from the uv-managed Python directory.

## 📌 Checklist

- [ ] I have added tests where necessary.
- [ ] I have updated the documentation where necessary.
