### PR TITLE
fix: change email sending error log level to ERROR and update test assertions

### DIFF
--- a/batch/processor_Send_Mail.py
+++ b/batch/processor_Send_Mail.py
@@ -85,7 +85,7 @@ class Processor:
                         )
                         smtp_mail.send_mail()
                     except (SMTPException, SESException, IndexError):
-                        LOG.warning(f"Could not send email: id={mail.id}")
+                        LOG.exception(f"Could not send email: id={mail.id}")
                         continue
                     finally:
                         db_session.delete(mail)

--- a/tests/batch/processor_Send_Mail_test.py
+++ b/tests/batch/processor_Send_Mail_test.py
@@ -204,7 +204,7 @@ class TestProcessorSendMail:
         with (
             mock.patch(
                 "app.model.mail.mail.Mail.send_mail",
-                MagicMock(side_effect=SMTPException()),
+                MagicMock(side_effect=SMTPException("smtp auth failed")),
             ),
             mock.patch("app.model.mail.mail.SMTP_SENDER_EMAIL", "sender@a.test"),
         ):
@@ -214,9 +214,16 @@ class TestProcessorSendMail:
         # Assertion
         assert len(session.scalars(select(Mail)).all()) == 0
 
-        assert 1 == caplog.record_tuples.count(
-            (LOG.name, logging.WARNING, "Could not send email: id=1")
-        )
+        error_logs = [
+            record
+            for record in caplog.records
+            if record.name == LOG.name
+            and record.levelno == logging.ERROR
+            and record.message == "Could not send email: id=1"
+        ]
+        assert 1 == len(error_logs)
+        assert error_logs[0].exc_info is not None
+        assert SMTPException is error_logs[0].exc_info[0]
 
         assert 1 == caplog.record_tuples.count((LOG.name, logging.INFO, "Process end"))
 


### PR DESCRIPTION
## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->
This pull request improves error handling and logging for email sending failures, and updates the corresponding test to ensure correct behavior when exceptions occur.

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
- Close #1803 

## 🔄 Changes

<!-- List the major changes in this PR. -->
**Error handling and logging improvements:**

* Changed the log statement in `processor_Send_Mail.py` to use `LOG.exception` instead of `LOG.warning`, ensuring that stack traces are included in the logs when email sending fails.

## 📌 Checklist

- [x] I have added tests where necessary.
- [ ] I have updated the documentation where necessary.
