### PR TITLE
refactor: enforce non-null constraints on notification fields

### DIFF
--- a/app/api/routers/notification.py
+++ b/app/api/routers/notification.py
@@ -18,7 +18,7 @@ SPDX-License-Identifier: Apache-2.0
 """
 
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Annotated, Any, Optional, Sequence
+from typing import TYPE_CHECKING, Annotated, Optional, Sequence
 
 from eth_utils.address import to_checksum_address
 from fastapi import APIRouter, Path, Query
@@ -125,23 +125,14 @@ async def list_all_notifications(
         await async_session.scalars(stmt)
     ).all()
 
-    notifications: list[dict[str, Any]] = []
-    for i, _notification in enumerate(_notification_list):
-        # TODO: Migrate notification.created to NOT NULL and update ORM typing
-        assert _notification.created is not None
-        notification_data = {
+    notifications = [
+        {
             **_notification.json(),
             "sort_id": sort_id + i + 1,
-            "created": "{}/{:02d}/{:02d} {:02d}:{:02d}:{:02d}".format(
-                _notification.created.year,
-                _notification.created.month,
-                _notification.created.day,
-                _notification.created.hour,
-                _notification.created.minute,
-                _notification.created.second,
-            ),
+            "created": Notification.format_datetime(_notification.created),
         }
-        notifications.append(notification_data)
+        for i, _notification in enumerate(_notification_list)
+    ]
     data: dict[str, object] = {
         "result_set": {
             "count": count,
@@ -153,55 +144,31 @@ async def list_all_notifications(
     }
 
     if TYPE_CHECKING:
-        type_checked_notifications: list[NotificationSchema] = []
-        for i, _notification in enumerate(_notification_list):
-            assert _notification.created is not None
-            notification_data = _notification.json()
-            notification_type_value = notification_data["notification_type"]
-            priority_value = notification_data["priority"]
-            block_timestamp_value = notification_data["block_timestamp"]
-            is_read_value = notification_data["is_read"]
-            is_flagged_value = notification_data["is_flagged"]
-            is_deleted_value = notification_data["is_deleted"]
-            metainfo_value = notification_data["metainfo"]
-            account_address_value = notification_data["account_address"]
-            created_value = "{}/{:02d}/{:02d} {:02d}:{:02d}:{:02d}".format(
-                _notification.created.year,
-                _notification.created.month,
-                _notification.created.day,
-                _notification.created.hour,
-                _notification.created.minute,
-                _notification.created.second,
+        type_checked_notifications = [
+            NotificationSchema(
+                notification_category=_notification.notification_category,
+                id=_notification.notification_id,
+                notification_type=NotificationType(_notification.notification_type),
+                priority=_notification.priority,
+                block_timestamp=Notification.format_datetime(
+                    _notification.block_timestamp
+                ),
+                is_read=_notification.is_read,
+                is_flagged=_notification.is_flagged,
+                is_deleted=_notification.is_deleted,
+                deleted_at=(
+                    Notification.format_datetime(_notification.deleted_at)
+                    if _notification.deleted_at is not None
+                    else None
+                ),
+                args=_notification.args,
+                metainfo=_notification.metainfo,
+                account_address=_notification.address,
+                sort_id=sort_id + i + 1,
+                created=Notification.format_datetime(_notification.created),
             )
-            # TODO: Migrate notification.notification_type, priority, block_timestamp,
-            # is_read, is_flagged, is_deleted, metainfo, and address to NOT NULL and
-            # update ORM typing.
-            assert notification_type_value is not None
-            assert priority_value is not None
-            assert block_timestamp_value is not None
-            assert is_read_value is not None
-            assert is_flagged_value is not None
-            assert is_deleted_value is not None
-            assert metainfo_value is not None
-            assert account_address_value is not None
-            type_checked_notifications.append(
-                NotificationSchema(
-                    notification_category=notification_data["notification_category"],
-                    id=notification_data["id"],
-                    notification_type=NotificationType(notification_type_value),
-                    priority=priority_value,
-                    block_timestamp=block_timestamp_value,
-                    is_read=is_read_value,
-                    is_flagged=is_flagged_value,
-                    is_deleted=is_deleted_value,
-                    deleted_at=notification_data["deleted_at"],
-                    args=notification_data["args"],
-                    metainfo=metainfo_value,
-                    account_address=account_address_value,
-                    sort_id=sort_id + i + 1,
-                    created=created_value,
-                )
-            )
+            for i, _notification in enumerate(_notification_list)
+        ]
         _ = GenericSuccessResponse[NotificationsResponse](
             meta=Success200MetaModel(code=200, message="OK"),
             data=NotificationsResponse(
@@ -331,38 +298,26 @@ async def update_notification(
     await async_session.commit()
 
     if TYPE_CHECKING:
-        # TODO: Migrate notification.notification_type to NOT NULL and update ORM typing.
-        assert notification.notification_type is not None
-        # TODO: Migrate notification.priority to NOT NULL and update ORM typing.
-        assert notification.priority is not None
-        # TODO: Migrate notification.is_read to NOT NULL and update ORM typing.
-        assert notification.is_read is not None
-        # TODO: Migrate notification.is_flagged to NOT NULL and update ORM typing.
-        assert notification.is_flagged is not None
-        # TODO: Migrate notification.is_deleted to NOT NULL and update ORM typing.
-        assert notification.is_deleted is not None
-        # TODO: Migrate notification.address to NOT NULL and update ORM typing.
-        assert notification.address is not None
-        update_response_payload = notification.json()
-        block_timestamp_value = update_response_payload["block_timestamp"]
-        deleted_at_value = update_response_payload["deleted_at"]
-        metainfo_value = update_response_payload["metainfo"]
-        assert isinstance(block_timestamp_value, str)
-        assert deleted_at_value is None or isinstance(deleted_at_value, str)
-        assert isinstance(metainfo_value, dict)
+        deleted_at = (
+            Notification.format_datetime(notification.deleted_at)
+            if notification.deleted_at is not None
+            else None
+        )
         _ = GenericSuccessResponse[NotificationUpdateResponse](
             meta=Success200MetaModel(code=200, message="OK"),
             data=NotificationUpdateResponse(
                 notification_type=NotificationType(notification.notification_type),
                 id=notification.notification_id,
                 priority=notification.priority,
-                block_timestamp=block_timestamp_value,
+                block_timestamp=Notification.format_datetime(
+                    notification.block_timestamp
+                ),
                 is_read=notification.is_read,
                 is_flagged=notification.is_flagged,
                 is_deleted=notification.is_deleted,
-                deleted_at=deleted_at_value,
-                args=update_response_payload["args"],
-                metainfo=metainfo_value,
+                deleted_at=deleted_at,
+                args=notification.args,
+                metainfo=notification.metainfo,
                 account_address=notification.address,
             ),
         )

--- a/app/model/db/notification.py
+++ b/app/model/db/notification.py
@@ -93,23 +93,25 @@ class Notification(Base):
     notification_id: Mapped[str] = mapped_column(String(256), primary_key=True)
 
     # 通知タイプ(例：BuySettlementOK, BuyAgreementなど)
-    notification_type: Mapped[str | None] = mapped_column(String(256), index=True)
+    notification_type: Mapped[str] = mapped_column(
+        String(256), index=True, nullable=False
+    )
 
     # 通知の重要度
     #   0: Low
     #   1: Medium
     #   2: High
-    priority: Mapped[int | None] = mapped_column(Integer, index=True)
+    priority: Mapped[int] = mapped_column(Integer, index=True, nullable=False)
 
     # 通知対象のユーザーのアドレス
     address: Mapped[str | None] = mapped_column(String(256), index=True)
 
     # 既読フラグ
-    is_read: Mapped[bool | None] = mapped_column(Boolean, default=False)
+    is_read: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     # 重要フラグ
-    is_flagged: Mapped[bool | None] = mapped_column(Boolean, default=False)
+    is_flagged: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     # 削除フラグ
-    is_deleted: Mapped[bool | None] = mapped_column(Boolean, default=False)
+    is_deleted: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     # 削除日付
     deleted_at: Mapped[datetime | None] = mapped_column(DateTime, default=None)
 
@@ -118,12 +120,12 @@ class Notification(Base):
     #  Postgres: Stored as UTC datetime.
     #  MySQL: Before 23.3, stored as JST datetime.
     #         From 23.3, stored as UTC datetime.
-    block_timestamp: Mapped[datetime | None] = mapped_column(DateTime)
+    block_timestamp: Mapped[datetime] = mapped_column(DateTime, nullable=False)
 
     # 通知イベントの内容
     args: Mapped[dict[str, object] | None] = mapped_column(JSON)
     # 通知のメタデータ（通知イベントには入っていないが、取りたい情報。トークン名など）
-    metainfo: Mapped[dict[str, object] | None] = mapped_column(JSON)
+    metainfo: Mapped[dict[str, object]] = mapped_column(JSON, nullable=False)
 
     if engine.name == "mysql":
         # NOTE:MySQLではDatetime型で小数秒桁を指定しない場合、整数秒しか保存されない
@@ -140,36 +142,29 @@ class Notification(Base):
             self.notification_id, self.notification_type
         )
 
+    @staticmethod
+    def format_datetime(_datetime: datetime) -> str:
+        return "{}/{:02d}/{:02d} {:02d}:{:02d}:{:02d}".format(
+            _datetime.year,
+            _datetime.month,
+            _datetime.day,
+            _datetime.hour,
+            _datetime.minute,
+            _datetime.second,
+        )
+
     def json(self) -> "NotificationJSONDict":
         return {
             "notification_category": self.notification_category,
             "notification_type": self.notification_type,
             "id": self.notification_id,
             "priority": self.priority,
-            "block_timestamp": (
-                "{}/{:02d}/{:02d} {:02d}:{:02d}:{:02d}".format(
-                    self.block_timestamp.year,
-                    self.block_timestamp.month,
-                    self.block_timestamp.day,
-                    self.block_timestamp.hour,
-                    self.block_timestamp.minute,
-                    self.block_timestamp.second,
-                )
-                if self.block_timestamp is not None
-                else None
-            ),
+            "block_timestamp": self.format_datetime(self.block_timestamp),
             "is_read": self.is_read,
             "is_flagged": self.is_flagged,
             "is_deleted": self.is_deleted,
             "deleted_at": (
-                "{}/{:02d}/{:02d} {:02d}:{:02d}:{:02d}".format(
-                    self.deleted_at.year,
-                    self.deleted_at.month,
-                    self.deleted_at.day,
-                    self.deleted_at.hour,
-                    self.deleted_at.minute,
-                    self.deleted_at.second,
-                )
+                self.format_datetime(self.deleted_at)
                 if self.deleted_at is not None
                 else None
             ),

--- a/app/model/schema/notification.py
+++ b/app/model/schema/notification.py
@@ -41,16 +41,16 @@ from app.model.type import EthereumAddress
 ############################
 class NotificationJSONDict(TypedDict):
     notification_category: Literal["event_log", "attribute_change"]
-    notification_type: str | None
+    notification_type: str
     id: str
-    priority: int | None
-    block_timestamp: str | None
-    is_read: bool | None
-    is_flagged: bool | None
-    is_deleted: bool | None
+    priority: int
+    block_timestamp: str
+    is_read: bool
+    is_flagged: bool
+    is_deleted: bool
     deleted_at: str | None
     args: object
-    metainfo: dict[str, Any] | None
+    metainfo: dict[str, Any]
     account_address: EthereumAddress | None
 
 
@@ -115,7 +115,7 @@ class Notification(BaseModel):
     deleted_at: Optional[str] = Field(description="datetime of deletion")
     args: object
     metainfo: NotificationMetainfo | dict[str, Any]
-    account_address: EthereumAddress
+    account_address: EthereumAddress | None
     sort_id: int
     created: str = Field(description="datetime of create")
 
@@ -140,4 +140,4 @@ class NotificationUpdateResponse(BaseModel):
     deleted_at: Optional[str] = Field(description="datetime of deletion")
     args: object
     metainfo: NotificationMetainfo | dict[str, Any]
-    account_address: EthereumAddress
+    account_address: EthereumAddress | None

--- a/docs/ibet_wallet_api.yaml
+++ b/docs/ibet_wallet_api.yaml
@@ -8071,7 +8071,9 @@ components:
             - type: object
           title: Metainfo
         account_address:
-          type: string
+          anyOf:
+            - type: string
+            - type: 'null'
           title: Account Address
         sort_id:
           type: integer
@@ -8199,7 +8201,9 @@ components:
             - type: object
           title: Metainfo
         account_address:
-          type: string
+          anyOf:
+            - type: string
+            - type: 'null'
           title: Account Address
       type: object
       required:

--- a/migrations/versions/93f1494c3975_v26_6_0_feature_1794.py
+++ b/migrations/versions/93f1494c3975_v26_6_0_feature_1794.py
@@ -42,6 +42,7 @@ def upgrade():
         notification.c.notification_type.is_(None),
         notification.c.block_timestamp.is_(None),
         notification.c.metainfo.is_(None),
+        notification.c.metainfo == sa.JSON.NULL,
     )
 
     connection.execute(

--- a/migrations/versions/93f1494c3975_v26_6_0_feature_1794.py
+++ b/migrations/versions/93f1494c3975_v26_6_0_feature_1794.py
@@ -1,0 +1,169 @@
+"""v26_6_0_feature_1794
+
+Revision ID: 93f1494c3975
+Revises: c3e1f4a7b91d
+Create Date: 2026-04-07 16:55:27.314211
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+from app.database import get_db_schema
+
+# revision identifiers, used by Alembic.
+revision = "93f1494c3975"
+down_revision = "c3e1f4a7b91d"
+branch_labels = None
+depends_on = None
+
+
+def _get_notification_table() -> sa.Table:
+    return sa.Table(
+        "notification",
+        sa.MetaData(),
+        sa.Column("notification_type", sa.String(length=256)),
+        sa.Column("priority", sa.Integer()),
+        sa.Column("is_read", sa.Boolean()),
+        sa.Column("is_flagged", sa.Boolean()),
+        sa.Column("is_deleted", sa.Boolean()),
+        sa.Column("block_timestamp", sa.DateTime()),
+        sa.Column("metainfo", sa.JSON()),
+        schema=get_db_schema(),
+    )
+
+
+def upgrade():
+    ############################
+    # Migration for notification not null columns
+    ############################
+    notification = _get_notification_table()
+    connection = op.get_bind()
+    notification_invalid_condition = sa.or_(
+        notification.c.notification_type.is_(None),
+        notification.c.block_timestamp.is_(None),
+        notification.c.metainfo.is_(None),
+    )
+
+    connection.execute(
+        notification.update()
+        .where(notification.c.priority.is_(None))
+        .values(priority=0)
+    )
+    connection.execute(
+        notification.update()
+        .where(notification.c.is_read.is_(None))
+        .values(is_read=False)
+    )
+    connection.execute(
+        notification.update()
+        .where(notification.c.is_flagged.is_(None))
+        .values(is_flagged=False)
+    )
+    connection.execute(
+        notification.update()
+        .where(notification.c.is_deleted.is_(None))
+        .values(is_deleted=False)
+    )
+    connection.execute(notification.delete().where(notification_invalid_condition))
+
+    op.alter_column(
+        "notification",
+        "notification_type",
+        existing_type=sa.String(length=256),
+        nullable=False,
+        schema=get_db_schema(),
+    )
+    op.alter_column(
+        "notification",
+        "priority",
+        existing_type=sa.Integer(),
+        nullable=False,
+        schema=get_db_schema(),
+    )
+    op.alter_column(
+        "notification",
+        "is_read",
+        existing_type=sa.Boolean(),
+        nullable=False,
+        schema=get_db_schema(),
+    )
+    op.alter_column(
+        "notification",
+        "is_flagged",
+        existing_type=sa.Boolean(),
+        nullable=False,
+        schema=get_db_schema(),
+    )
+    op.alter_column(
+        "notification",
+        "is_deleted",
+        existing_type=sa.Boolean(),
+        nullable=False,
+        schema=get_db_schema(),
+    )
+    op.alter_column(
+        "notification",
+        "block_timestamp",
+        existing_type=sa.DateTime(),
+        nullable=False,
+        schema=get_db_schema(),
+    )
+    op.alter_column(
+        "notification",
+        "metainfo",
+        existing_type=sa.JSON(),
+        nullable=False,
+        schema=get_db_schema(),
+    )
+
+
+def downgrade():
+    op.alter_column(
+        "notification",
+        "metainfo",
+        existing_type=sa.JSON(),
+        nullable=True,
+        schema=get_db_schema(),
+    )
+    op.alter_column(
+        "notification",
+        "block_timestamp",
+        existing_type=sa.DateTime(),
+        nullable=True,
+        schema=get_db_schema(),
+    )
+    op.alter_column(
+        "notification",
+        "is_deleted",
+        existing_type=sa.Boolean(),
+        nullable=True,
+        schema=get_db_schema(),
+    )
+    op.alter_column(
+        "notification",
+        "is_flagged",
+        existing_type=sa.Boolean(),
+        nullable=True,
+        schema=get_db_schema(),
+    )
+    op.alter_column(
+        "notification",
+        "is_read",
+        existing_type=sa.Boolean(),
+        nullable=True,
+        schema=get_db_schema(),
+    )
+    op.alter_column(
+        "notification",
+        "priority",
+        existing_type=sa.Integer(),
+        nullable=True,
+        schema=get_db_schema(),
+    )
+    op.alter_column(
+        "notification",
+        "notification_type",
+        existing_type=sa.String(length=256),
+        nullable=True,
+        schema=get_db_schema(),
+    )

--- a/migrations/versions/93f1494c3975_v26_6_0_feature_1794.py
+++ b/migrations/versions/93f1494c3975_v26_6_0_feature_1794.py
@@ -32,17 +32,33 @@ def _get_notification_table() -> sa.Table:
     )
 
 
+def _get_metainfo_null_condition(
+    dialect_name: str, notification: sa.Table
+) -> sa.ColumnElement[bool]:
+    if dialect_name == "mysql":
+        return sa.or_(
+            notification.c.metainfo.is_(None),
+            sa.func.json_type(notification.c.metainfo) == "NULL",
+        )
+    return sa.or_(
+        notification.c.metainfo.is_(None),
+        sa.func.json_typeof(notification.c.metainfo) == "null",
+    )
+
+
 def upgrade():
     ############################
     # Migration for notification not null columns
     ############################
     notification = _get_notification_table()
     connection = op.get_bind()
+    metainfo_null_condition = _get_metainfo_null_condition(
+        connection.dialect.name, notification
+    )
     notification_invalid_condition = sa.or_(
         notification.c.notification_type.is_(None),
         notification.c.block_timestamp.is_(None),
-        notification.c.metainfo.is_(None),
-        notification.c.metainfo == sa.JSON.NULL,
+        metainfo_null_condition,
     )
 
     connection.execute(

--- a/tests/app/notification_Notifications_GET_test.py
+++ b/tests/app/notification_Notifications_GET_test.py
@@ -137,13 +137,32 @@ class TestNotificationsGet:
         # Prepare data
         self._insert_test_data(session)
 
+        n = Notification()
+        n.notification_category = "attribute_change"
+        n.notification_id = "0x00000100000000000000000000"
+        n.notification_type = "TransferableChanged"
+        n.priority = 0
+        n.address = None
+        n.is_read = False
+        n.is_flagged = False
+        n.is_deleted = False
+        n.deleted_at = None
+        n.block_timestamp = datetime(2017, 1, 10, 10, 0, 0)
+        n.args = {
+            "previous": True,
+            "current": False,
+        }
+        n.metainfo = {}
+        n.created = datetime.strptime("2022/01/01 20:20:30", "%Y/%m/%d %H:%M:%S")
+        session.add(n)
+
         session.commit()
 
         # Request target API
         resp = client.get(self.apiurl)
 
         assumed_body: dict[str, Any] = {
-            "result_set": {"count": 5, "offset": None, "limit": None, "total": 5},
+            "result_set": {"count": 6, "offset": None, "limit": None, "total": 6},
             "notifications": [
                 {
                     "notification_category": "event_log",
@@ -234,6 +253,25 @@ class TestNotificationsGet:
                     "metainfo": {},
                     "account_address": "0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf",
                     "created": "2022/01/01 19:20:30",
+                },
+                {
+                    "notification_category": "attribute_change",
+                    "notification_type": "TransferableChanged",
+                    "id": "0x00000100000000000000000000",
+                    "sort_id": 6,
+                    "priority": 0,
+                    "block_timestamp": "2017/01/10 10:00:00",
+                    "is_read": False,
+                    "is_flagged": False,
+                    "is_deleted": False,
+                    "deleted_at": None,
+                    "args": {
+                        "previous": True,
+                        "current": False,
+                    },
+                    "metainfo": {},
+                    "account_address": None,
+                    "created": "2022/01/01 20:20:30",
                 },
             ],
         }

--- a/tests/migrations/upgrade_test.py
+++ b/tests/migrations/upgrade_test.py
@@ -1407,8 +1407,9 @@ class TestMigrationsUpgrade:
             ]
             metainfo_1 = notification_rows[0]["metainfo"]
             metainfo_2 = notification_rows[1]["metainfo"]
-            if engine.name == "mysql":
+            if isinstance(metainfo_1, str):
                 metainfo_1 = json.loads(metainfo_1)
+            if isinstance(metainfo_2, str):
                 metainfo_2 = json.loads(metainfo_2)
 
             assert (

--- a/tests/migrations/upgrade_test.py
+++ b/tests/migrations/upgrade_test.py
@@ -54,7 +54,7 @@ REVISION_24_3: Final = "3d3b90fda898"
 REVISION_24_6: Final = "418af51b07b5"
 REVISION_25_6: Final = "9a28ed8d4afd"
 REVISION_26_3: Final = "d7de2d20be69"
-REVISION_26_6: Final = "4df7e2c1b8a3"
+REVISION_26_6: Final = "93f1494c3975"
 
 REVISION_UP_TO_1_8 = [REVISION_22_3]
 REVISION_UP_TO_22_6 = REVISION_UP_TO_1_8 + [REVISION_22_6]
@@ -1078,23 +1078,27 @@ class TestMigrationsUpgrade:
                 unlocks = list(unlocks)
                 assert unlocks[0].data == {}
 
-    def test_upgrade_v26_3_feature_1792(
+    def test_upgrade_v26_6(
         self, alembic_runner: MigrationContext, caplog: LogCaptureFixture
     ):
-        # 1. Migrate to v26.3 initial
+        # 1. Migrate to v26.3
         alembic_runner.migrate_up_to(REVISION_26_3)
         schema = get_db_schema()
         listing_table_key = f"{schema}.listing" if schema else "listing"
         executable_contract_table_key = (
             f"{schema}.executable_contract" if schema else "executable_contract"
         )
+        consume_coupon_table_key = (
+            f"{schema}.consume_coupon" if schema else "consume_coupon"
+        )
+        notification_table_key = f"{schema}.notification" if schema else "notification"
         meta = MetaData()
         meta.reflect(bind=engine)
 
         # 2. Insert test record
         listing = meta.tables.get(listing_table_key)
         assert listing is not None
-        stmt1 = insert(listing).values(
+        listing_stmt1 = insert(listing).values(
             token_address="0x0000000000000000000000000000000000000011",
             is_public=None,
             max_holding_quantity=1,
@@ -1103,7 +1107,7 @@ class TestMigrationsUpgrade:
             created=None,
             modified=None,
         )
-        stmt2 = insert(listing).values(
+        listing_stmt2 = insert(listing).values(
             token_address=None,
             is_public=True,
             max_holding_quantity=1,
@@ -1112,7 +1116,7 @@ class TestMigrationsUpgrade:
             created=None,
             modified=None,
         )
-        stmt3 = insert(listing).values(
+        listing_stmt3 = insert(listing).values(
             token_address="0x0000000000000000000000000000000000000014",
             is_public=False,
             max_holding_quantity=1,
@@ -1124,33 +1128,159 @@ class TestMigrationsUpgrade:
 
         executable_contract = meta.tables.get(executable_contract_table_key)
         assert executable_contract is not None
-        stmt4 = insert(executable_contract).values(
+        executable_contract_stmt1 = insert(executable_contract).values(
             contract_address="0x0000000000000000000000000000000000000011",
             created=None,
             modified=None,
         )
-        stmt5 = insert(executable_contract).values(
+        executable_contract_stmt2 = insert(executable_contract).values(
             contract_address="0x0000000000000000000000000000000000000014",
             created=None,
             modified=None,
         )
-        stmt6 = insert(executable_contract).values(
+        executable_contract_stmt3 = insert(executable_contract).values(
             contract_address="0x0000000000000000000000000000000000000015",
             created=None,
             modified=None,
         )
+        consume_coupon = meta.tables.get(consume_coupon_table_key)
+        assert consume_coupon is not None
+
+        current_dt = datetime(2026, 4, 3, 0, 0, 0)
+        consume_coupon_valid_block_timestamp = datetime(2026, 4, 3, 12, 0, 0)
+        consume_coupon_stmt1 = insert(consume_coupon).values(
+            transaction_hash="0x0000000000000000000000000000000000000000000000000000000000000011",
+            token_address="0x0000000000000000000000000000000000000011",
+            account_address="0x0000000000000000000000000000000000000012",
+            amount=100,
+            block_timestamp=consume_coupon_valid_block_timestamp,
+            created=current_dt,
+            modified=current_dt,
+        )
+        consume_coupon_stmt2 = insert(consume_coupon).values(
+            transaction_hash="0x0000000000000000000000000000000000000000000000000000000000000022",
+            token_address="0x0000000000000000000000000000000000000021",
+            account_address="0x0000000000000000000000000000000000000022",
+            amount=None,
+            block_timestamp=consume_coupon_valid_block_timestamp,
+            created=current_dt,
+            modified=current_dt,
+        )
+        consume_coupon_stmt3 = insert(consume_coupon).values(
+            transaction_hash="0x0000000000000000000000000000000000000000000000000000000000000033",
+            token_address="0x0000000000000000000000000000000000000031",
+            account_address="0x0000000000000000000000000000000000000032",
+            amount=300,
+            block_timestamp=None,
+            created=current_dt,
+            modified=current_dt,
+        )
+        notification = meta.tables.get(notification_table_key)
+        assert notification is not None
+
+        current_dt = datetime(2026, 4, 7, 0, 0, 0)
+        notification_valid_block_timestamp = datetime(2026, 4, 7, 12, 0, 0)
+
+        notification_stmt1 = insert(notification).values(
+            notification_category="event_log",
+            notification_id="0x00000000000000000000000011",
+            notification_type="Transfer",
+            priority=1,
+            address="0x0000000000000000000000000000000000000011",
+            is_read=True,
+            is_flagged=False,
+            is_deleted=False,
+            deleted_at=None,
+            block_timestamp=notification_valid_block_timestamp,
+            args={"amount": 100},
+            metainfo={"token_name": "test"},
+            created=current_dt,
+            modified=current_dt,
+        )
+        notification_stmt2 = insert(notification).values(
+            notification_category="attribute_change",
+            notification_id="0x00000000000000000000000022",
+            notification_type="TransferableChanged",
+            priority=None,
+            address=None,
+            is_read=None,
+            is_flagged=None,
+            is_deleted=None,
+            deleted_at=None,
+            block_timestamp=notification_valid_block_timestamp,
+            args={"previous": True, "current": False},
+            metainfo={"attribute": "transferable"},
+            created=current_dt,
+            modified=current_dt,
+        )
+        notification_stmt3 = insert(notification).values(
+            notification_category="event_log",
+            notification_id="0x00000000000000000000000033",
+            notification_type=None,
+            priority=0,
+            address="0x0000000000000000000000000000000000000033",
+            is_read=False,
+            is_flagged=False,
+            is_deleted=False,
+            deleted_at=None,
+            block_timestamp=notification_valid_block_timestamp,
+            args={},
+            metainfo={},
+            created=current_dt,
+            modified=current_dt,
+        )
+        notification_stmt4 = insert(notification).values(
+            notification_category="event_log",
+            notification_id="0x00000000000000000000000044",
+            notification_type="ForceLock",
+            priority=0,
+            address="0x0000000000000000000000000000000000000044",
+            is_read=False,
+            is_flagged=False,
+            is_deleted=False,
+            deleted_at=None,
+            block_timestamp=None,
+            args={},
+            metainfo={},
+            created=current_dt,
+            modified=current_dt,
+        )
+        notification_stmt5 = insert(notification).values(
+            notification_category="event_log",
+            notification_id="0x00000000000000000000000055",
+            notification_type="ForceUnlock",
+            priority=0,
+            address="0x0000000000000000000000000000000000000055",
+            is_read=False,
+            is_flagged=False,
+            is_deleted=False,
+            deleted_at=None,
+            block_timestamp=notification_valid_block_timestamp,
+            args={},
+            metainfo=None,
+            created=current_dt,
+            modified=current_dt,
+        )
 
         with engine.connect() as conn:
-            conn.execute(stmt1)
-            conn.execute(stmt2)
-            conn.execute(stmt3)
-            conn.execute(stmt4)
-            conn.execute(stmt5)
-            conn.execute(stmt6)
+            conn.execute(listing_stmt1)
+            conn.execute(listing_stmt2)
+            conn.execute(listing_stmt3)
+            conn.execute(executable_contract_stmt1)
+            conn.execute(executable_contract_stmt2)
+            conn.execute(executable_contract_stmt3)
+            conn.execute(consume_coupon_stmt1)
+            conn.execute(consume_coupon_stmt2)
+            conn.execute(consume_coupon_stmt3)
+            conn.execute(notification_stmt1)
+            conn.execute(notification_stmt2)
+            conn.execute(notification_stmt3)
+            conn.execute(notification_stmt4)
+            conn.execute(notification_stmt5)
             conn.commit()
 
-        # 3. Run to head
-        alembic_runner.migrate_up_to("head")
+        # 3. Run to v26.6
+        alembic_runner.migrate_up_to(REVISION_26_6)
 
         inspector = inspect(engine)
         listing_columns = {
@@ -1170,12 +1300,37 @@ class TestMigrationsUpgrade:
         assert executable_contract_columns["created"]["nullable"] is False
         assert executable_contract_columns["modified"]["nullable"] is False
 
+        consume_coupon_columns = {
+            column["name"]: column
+            for column in inspector.get_columns("consume_coupon", schema=schema)
+        }
+        assert consume_coupon_columns["amount"]["nullable"] is False
+        assert consume_coupon_columns["block_timestamp"]["nullable"] is False
+
+        notification_columns = {
+            column["name"]: column
+            for column in inspector.get_columns("notification", schema=schema)
+        }
+        assert notification_columns["notification_type"]["nullable"] is False
+        assert notification_columns["priority"]["nullable"] is False
+        assert notification_columns["is_read"]["nullable"] is False
+        assert notification_columns["is_flagged"]["nullable"] is False
+        assert notification_columns["is_deleted"]["nullable"] is False
+        assert notification_columns["block_timestamp"]["nullable"] is False
+        assert notification_columns["metainfo"]["nullable"] is False
+        assert notification_columns["address"]["nullable"] is True
+        assert notification_columns["deleted_at"]["nullable"] is True
+
         post_meta = MetaData()
         post_meta.reflect(bind=engine)
         listing = post_meta.tables.get(listing_table_key)
         executable_contract = post_meta.tables.get(executable_contract_table_key)
+        consume_coupon = post_meta.tables.get(consume_coupon_table_key)
+        notification = post_meta.tables.get(notification_table_key)
         assert listing is not None
         assert executable_contract is not None
+        assert consume_coupon is not None
+        assert notification is not None
 
         with engine.connect() as conn:
             listing_rows = conn.execute(
@@ -1209,76 +1364,53 @@ class TestMigrationsUpgrade:
             assert executable_contract_rows[0]["created"] is not None
             assert executable_contract_rows[0]["modified"] is not None
 
-    def test_upgrade_v26_6_feature_1793(
-        self, alembic_runner: MigrationContext, caplog: LogCaptureFixture
-    ):
-        alembic_runner.migrate_up_to(REVISION_26_6)
-        schema = get_db_schema()
-        consume_coupon_table_key = (
-            f"{schema}.consume_coupon" if schema else "consume_coupon"
-        )
-        meta = MetaData()
-        meta.reflect(bind=engine)
-
-        consume_coupon = meta.tables.get(consume_coupon_table_key)
-        assert consume_coupon is not None
-
-        current_dt = datetime(2026, 4, 3, 0, 0, 0)
-        valid_block_timestamp = datetime(2026, 4, 3, 12, 0, 0)
-        stmt1 = insert(consume_coupon).values(
-            transaction_hash="0x0000000000000000000000000000000000000000000000000000000000000011",
-            token_address="0x0000000000000000000000000000000000000011",
-            account_address="0x0000000000000000000000000000000000000012",
-            amount=100,
-            block_timestamp=valid_block_timestamp,
-            created=current_dt,
-            modified=current_dt,
-        )
-        stmt2 = insert(consume_coupon).values(
-            transaction_hash="0x0000000000000000000000000000000000000000000000000000000000000022",
-            token_address="0x0000000000000000000000000000000000000021",
-            account_address="0x0000000000000000000000000000000000000022",
-            amount=None,
-            block_timestamp=valid_block_timestamp,
-            created=current_dt,
-            modified=current_dt,
-        )
-        stmt3 = insert(consume_coupon).values(
-            transaction_hash="0x0000000000000000000000000000000000000000000000000000000000000033",
-            token_address="0x0000000000000000000000000000000000000031",
-            account_address="0x0000000000000000000000000000000000000032",
-            amount=300,
-            block_timestamp=None,
-            created=current_dt,
-            modified=current_dt,
-        )
-
-        with engine.connect() as conn:
-            conn.execute(stmt1)
-            conn.execute(stmt2)
-            conn.execute(stmt3)
-            conn.commit()
-
-        alembic_runner.migrate_up_to("head")
-
-        inspector = inspect(engine)
-        consume_coupon_columns = {
-            column["name"]: column
-            for column in inspector.get_columns("consume_coupon", schema=schema)
-        }
-        assert consume_coupon_columns["amount"]["nullable"] is False
-        assert consume_coupon_columns["block_timestamp"]["nullable"] is False
-
-        post_meta = MetaData()
-        post_meta.reflect(bind=engine)
-        consume_coupon = post_meta.tables.get(consume_coupon_table_key)
-        assert consume_coupon is not None
-
-        with engine.connect() as conn:
             consume_coupon_rows = conn.execute(
                 select(consume_coupon).order_by(consume_coupon.c.id)
             ).mappings()
             consume_coupon_rows = list(consume_coupon_rows)
             assert len(consume_coupon_rows) == 1
             assert consume_coupon_rows[0]["amount"] == 100
-            assert consume_coupon_rows[0]["block_timestamp"] == valid_block_timestamp
+            assert (
+                consume_coupon_rows[0]["block_timestamp"]
+                == consume_coupon_valid_block_timestamp
+            )
+
+            notification_rows = conn.execute(
+                select(notification).order_by(notification.c.notification_id)
+            ).mappings()
+            notification_rows = list(notification_rows)
+            assert len(notification_rows) == 2
+            metainfo_1 = notification_rows[0]["metainfo"]
+            metainfo_2 = notification_rows[1]["metainfo"]
+            if engine.name == "mysql":
+                metainfo_1 = json.loads(metainfo_1)
+                metainfo_2 = json.loads(metainfo_2)
+
+            assert (
+                notification_rows[0]["notification_id"]
+                == "0x00000000000000000000000011"
+            )
+            assert notification_rows[0]["priority"] == 1
+            assert bool(notification_rows[0]["is_read"]) is True
+            assert bool(notification_rows[0]["is_flagged"]) is False
+            assert bool(notification_rows[0]["is_deleted"]) is False
+            assert (
+                notification_rows[0]["block_timestamp"]
+                == notification_valid_block_timestamp
+            )
+            assert metainfo_1 == {"token_name": "test"}
+
+            assert (
+                notification_rows[1]["notification_id"]
+                == "0x00000000000000000000000022"
+            )
+            assert notification_rows[1]["priority"] == 0
+            assert bool(notification_rows[1]["is_read"]) is False
+            assert bool(notification_rows[1]["is_flagged"]) is False
+            assert bool(notification_rows[1]["is_deleted"]) is False
+            assert notification_rows[1]["address"] is None
+            assert (
+                notification_rows[1]["block_timestamp"]
+                == notification_valid_block_timestamp
+            )
+            assert metainfo_2 == {"attribute": "transferable"}

--- a/tests/migrations/upgrade_test.py
+++ b/tests/migrations/upgrade_test.py
@@ -35,6 +35,7 @@ from sqlalchemy import (
     Text,
     insert,
     inspect,
+    null,
     select,
     text,
 )
@@ -1261,6 +1262,22 @@ class TestMigrationsUpgrade:
             created=current_dt,
             modified=current_dt,
         )
+        notification_stmt6 = insert(notification).values(
+            notification_category="event_log",
+            notification_id="0x00000000000000000000000066",
+            notification_type="Lock",
+            priority=0,
+            address="0x0000000000000000000000000000000000000066",
+            is_read=False,
+            is_flagged=False,
+            is_deleted=False,
+            deleted_at=None,
+            block_timestamp=notification_valid_block_timestamp,
+            args={},
+            metainfo=null(),
+            created=current_dt,
+            modified=current_dt,
+        )
 
         with engine.connect() as conn:
             conn.execute(listing_stmt1)
@@ -1277,6 +1294,7 @@ class TestMigrationsUpgrade:
             conn.execute(notification_stmt3)
             conn.execute(notification_stmt4)
             conn.execute(notification_stmt5)
+            conn.execute(notification_stmt6)
             conn.commit()
 
         # 3. Run to v26.6
@@ -1380,6 +1398,13 @@ class TestMigrationsUpgrade:
             ).mappings()
             notification_rows = list(notification_rows)
             assert len(notification_rows) == 2
+            assert [
+                notification_row["notification_id"]
+                for notification_row in notification_rows
+            ] == [
+                "0x00000000000000000000000011",
+                "0x00000000000000000000000022",
+            ]
             metainfo_1 = notification_rows[0]["metainfo"]
             metainfo_2 = notification_rows[1]["metainfo"]
             if engine.name == "mysql":


### PR DESCRIPTION
## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->
This PR updates notification nullability for issue #1794.

Fields that should always exist are aligned across the migration, ORM model, and API schema. `address` stays nullable because some notification types do not have an address.

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
- Close #1794 

## 🔄 Changes

<!-- List the major changes in this PR. -->

- Added a migration to make these notification fields `NOT NULL`:
  - `notification_type`
  - `priority`
  - `is_read`
  - `is_flagged`
  - `is_deleted`
  - `block_timestamp`
  - `metainfo`
- Backfilled `priority` with `0` and boolean flags with `False`
- Deleted invalid notification rows with missing `notification_type`, `block_timestamp`, or `metainfo`

## 📌 Checklist

- [x] I have added tests where necessary.
- [ ] I have updated the documentation where necessary.
