### PR TITLE
Remove npm Dependabot config and pin jrm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,15 +37,3 @@ updates:
       all-dependencies:
         patterns:
           - "*"
-
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    allow:
-      - dependency-name: "*"
-        dependency-type: "direct"
-    groups:
-      all-dependencies:
-        patterns:
-          - "*"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -108,7 +108,7 @@ jobs:
         with:
           node-version: 20
       - name: Install junit-report-merger
-        run: npm install -g junit-report-merger
+        run: npm install -g junit-report-merger@9.0.3
       - name: Merge reports
         run: jrm cov/pytest.xml "cov/pytest-*.xml"
       - name: Pytest coverage comment


### PR DESCRIPTION
## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->

Remove npm dependabot config.

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
None

## 🔄 Changes

<!-- List the major changes in this PR. -->

- Remove the npm package-ecosystem entry from .github/dependabot.yml so Dependabot no longer opens npm dependency updates for the repo. 
- In .github/workflows/pr.yml, pin the globally installed junit-report-merger (jrm) to version 9.0.3 to ensure a consistent tool version during CI report merging.

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
