### PR TITLE
Add contract_version to token list

### DIFF
--- a/app/api/routers/public_info.py
+++ b/app/api/routers/public_info.py
@@ -123,6 +123,7 @@ async def list_all_public_tokens(
                     IbetBondToken(
                         token_address=token.token_address,
                         token_template="ibetBond",
+                        contract_version=token.contract_version,
                         key_manager=token.key_manager,
                         product_type=1,
                         issuer_address=token.issuer_address,
@@ -139,6 +140,7 @@ async def list_all_public_tokens(
                     IbetShareToken(
                         token_address=token.token_address,
                         token_template="ibetShare",
+                        contract_version=token.contract_version,
                         key_manager=token.key_manager,
                         product_type=share_product_type,
                         issuer_address=token.issuer_address,
@@ -149,6 +151,7 @@ async def list_all_public_tokens(
                     IbetMembershipToken(
                         token_address=token.token_address,
                         token_template="ibetMembership",
+                        contract_version=token.contract_version,
                         key_manager=token.key_manager,
                         product_type=1,
                         issuer_address=token.issuer_address,
@@ -159,6 +162,7 @@ async def list_all_public_tokens(
                     IbetCouponToken(
                         token_address=token.token_address,
                         token_template="ibetCoupon",
+                        contract_version=token.contract_version,
                         key_manager=token.key_manager,
                         product_type=1,
                         issuer_address=token.issuer_address,

--- a/app/model/db/public_info.py
+++ b/app/model/db/public_info.py
@@ -46,6 +46,10 @@ class TokenList(Base):
     token_template: Mapped[
         Literal["ibetBond", "ibetShare", "ibetMembership", "ibetCoupon"]
     ] = mapped_column(String(50), nullable=False)
+    # Contract Version
+    contract_version: Mapped[str] = mapped_column(
+        String(20), nullable=False, default="25_09"
+    )
     # Key Manager
     key_manager: Mapped[list[str]] = mapped_column(JSON, nullable=False)
     # Product Type
@@ -58,6 +62,7 @@ class TokenList(Base):
         return {
             "token_address": self.token_address,
             "token_template": self.token_template,
+            "contract_version": self.contract_version,
             "key_manager": self.key_manager,
             "product_type": self.product_type,
             "issuer_address": self.issuer_address,

--- a/app/model/schema/public_info.py
+++ b/app/model/schema/public_info.py
@@ -36,6 +36,7 @@ from app.model.type import EthereumAddress
 class TokenBase(BaseModel):
     token_address: EthereumAddress
     key_manager: list[str]
+    contract_version: str
     issuer_address: EthereumAddress | None
 
 

--- a/app/model/type/token_list.py
+++ b/app/model/type/token_list.py
@@ -27,6 +27,7 @@ from app.model.type.base import EthereumAddress
 
 class TokenListItem(BaseModel):
     token_template: Literal["ibetBond", "ibetShare", "ibetMembership", "ibetCoupon"]
+    contract_version: str = "25_09"
     product_type: int
     token_address: EthereumAddress
     key_manager: list[str]

--- a/batch/sub_indexers/indexer_PublicInfo_TokenList.py
+++ b/batch/sub_indexers/indexer_PublicInfo_TokenList.py
@@ -113,6 +113,7 @@ class Processor:
         _token_list = TokenList()
         _token_list.token_address = token_list_item.token_address
         _token_list.token_template = token_list_item.token_template
+        _token_list.contract_version = token_list_item.contract_version
         _token_list.key_manager = token_list_item.key_manager
         _token_list.product_type = token_list_item.product_type
         _token_list.issuer_address = token_list_item.issuer_address

--- a/docs/ibet_wallet_api.yaml
+++ b/docs/ibet_wallet_api.yaml
@@ -7007,6 +7007,9 @@ components:
             type: string
           type: array
           title: Key Manager
+        contract_version:
+          type: string
+          title: Contract Version
         issuer_address:
           anyOf:
             - type: string
@@ -7024,6 +7027,7 @@ components:
       required:
         - token_address
         - key_manager
+        - contract_version
         - issuer_address
         - token_template
         - product_type
@@ -7038,6 +7042,9 @@ components:
             type: string
           type: array
           title: Key Manager
+        contract_version:
+          type: string
+          title: Contract Version
         issuer_address:
           anyOf:
             - type: string
@@ -7055,6 +7062,7 @@ components:
       required:
         - token_address
         - key_manager
+        - contract_version
         - issuer_address
         - token_template
         - product_type
@@ -7078,6 +7086,9 @@ components:
             type: string
           type: array
           title: Key Manager
+        contract_version:
+          type: string
+          title: Contract Version
         issuer_address:
           anyOf:
             - type: string
@@ -7095,6 +7106,7 @@ components:
       required:
         - token_address
         - key_manager
+        - contract_version
         - issuer_address
         - token_template
         - product_type
@@ -7152,6 +7164,9 @@ components:
             type: string
           type: array
           title: Key Manager
+        contract_version:
+          type: string
+          title: Contract Version
         issuer_address:
           anyOf:
             - type: string
@@ -7174,6 +7189,7 @@ components:
       required:
         - token_address
         - key_manager
+        - contract_version
         - issuer_address
         - token_template
         - product_type

--- a/migrations/versions/85d3431e23dd_v26_6_0_feature_1822.py
+++ b/migrations/versions/85d3431e23dd_v26_6_0_feature_1822.py
@@ -1,0 +1,50 @@
+"""v26_6_0_feature_1822
+
+Revision ID: 85d3431e23dd
+Revises: 93f1494c3975
+Create Date: 2026-05-19 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+from app.database import get_db_schema
+
+# revision identifiers, used by Alembic.
+revision = "85d3431e23dd"
+down_revision = "93f1494c3975"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "token_list",
+        sa.Column("contract_version", sa.String(length=20), nullable=True),
+        schema=get_db_schema(),
+    )
+
+    token_list = sa.Table(
+        "token_list",
+        sa.MetaData(),
+        sa.Column("contract_version", sa.String(length=20)),
+        schema=get_db_schema(),
+    )
+
+    op.get_bind().execute(
+        token_list.update()
+        .where(token_list.c.contract_version.is_(None))
+        .values(contract_version="25_09")
+    )
+
+    op.alter_column(
+        "token_list",
+        "contract_version",
+        existing_type=sa.String(length=20),
+        nullable=False,
+        schema=get_db_schema(),
+    )
+
+
+def downgrade():
+    op.drop_column("token_list", "contract_version", schema=get_db_schema())

--- a/tests/app/model/type/test_token_list.py
+++ b/tests/app/model/type/test_token_list.py
@@ -20,6 +20,19 @@ def test_token_list_item_addresses_are_converted_to_checksum():
 
     assert item.token_address == to_checksum_address(raw_token_address)
     assert item.issuer_address == to_checksum_address(raw_issuer_address)
+    assert item.contract_version == "25_09"
+
+
+def test_token_list_item_accepts_explicit_contract_version():
+    item = TokenListItem(
+        token_template="ibetBond",
+        contract_version="25_10",
+        product_type=0,
+        token_address="0x000000000000000000000000000000000000dead",
+        key_manager=[],
+    )
+
+    assert item.contract_version == "25_10"
 
 
 @pytest.mark.parametrize(

--- a/tests/app/public_info_ListAllPublicListedTokens_test.py
+++ b/tests/app/public_info_ListAllPublicListedTokens_test.py
@@ -104,6 +104,7 @@ class TestListAllPublicListedTokens:
             "tokens": [
                 {
                     "key_manager": ["0000000000000"],
+                    "contract_version": "25_09",
                     "product_type": 1,
                     "token_address": self.token_address_1,
                     "token_template": "ibetBond",
@@ -111,6 +112,7 @@ class TestListAllPublicListedTokens:
                 },
                 {
                     "key_manager": ["0000000000000"],
+                    "contract_version": "25_09",
                     "product_type": 1,
                     "token_address": self.token_address_2,
                     "token_template": "ibetBond",
@@ -118,6 +120,7 @@ class TestListAllPublicListedTokens:
                 },
                 {
                     "key_manager": ["1111111111111"],
+                    "contract_version": "25_09",
                     "product_type": 5,
                     "token_address": self.token_address_3,
                     "token_template": "ibetShare",
@@ -125,6 +128,7 @@ class TestListAllPublicListedTokens:
                 },
                 {
                     "key_manager": [],
+                    "contract_version": "25_09",
                     "product_type": 1,
                     "token_address": self.token_address_4,
                     "token_template": "ibetMembership",
@@ -132,6 +136,7 @@ class TestListAllPublicListedTokens:
                 },
                 {
                     "key_manager": [],
+                    "contract_version": "25_09",
                     "product_type": 1,
                     "token_address": self.token_address_5,
                     "token_template": "ibetCoupon",
@@ -194,6 +199,7 @@ class TestListAllPublicListedTokens:
             "tokens": [
                 {
                     "key_manager": ["0000000000000"],
+                    "contract_version": "25_09",
                     "product_type": 1,
                     "token_address": self.token_address_1,
                     "token_template": "ibetBond",
@@ -201,6 +207,7 @@ class TestListAllPublicListedTokens:
                 },
                 {
                     "key_manager": ["0000000000000"],
+                    "contract_version": "25_09",
                     "product_type": 1,
                     "token_address": self.token_address_2,
                     "token_template": "ibetBond",
@@ -263,6 +270,7 @@ class TestListAllPublicListedTokens:
             "tokens": [
                 {
                     "key_manager": ["1111111111111"],
+                    "contract_version": "25_09",
                     "product_type": 5,
                     "token_address": self.token_address_3,
                     "token_template": "ibetShare",
@@ -325,6 +333,7 @@ class TestListAllPublicListedTokens:
             "tokens": [
                 {
                     "key_manager": [],
+                    "contract_version": "25_09",
                     "product_type": 1,
                     "token_address": self.token_address_4,
                     "token_template": "ibetMembership",
@@ -387,6 +396,7 @@ class TestListAllPublicListedTokens:
             "tokens": [
                 {
                     "key_manager": [],
+                    "contract_version": "25_09",
                     "product_type": 1,
                     "token_address": self.token_address_5,
                     "token_template": "ibetCoupon",
@@ -432,6 +442,7 @@ class TestListAllPublicListedTokens:
             "tokens": [
                 {
                     "key_manager": ["1111111111111"],
+                    "contract_version": "25_09",
                     "product_type": 5,
                     "token_address": self.token_address_3,
                     "token_template": "ibetShare",
@@ -477,6 +488,7 @@ class TestListAllPublicListedTokens:
             "tokens": [
                 {
                     "key_manager": ["0000000000000"],
+                    "contract_version": "25_09",
                     "product_type": 1,
                     "token_address": self.token_address_1,
                     "token_template": "ibetBond",
@@ -511,6 +523,7 @@ class TestListAllPublicListedTokens:
             "tokens": [
                 {
                     "key_manager": ["0000000000000"],
+                    "contract_version": "25_09",
                     "product_type": 1,
                     "token_address": self.token_address_1,
                     "token_template": "ibetBond",


### PR DESCRIPTION
## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->

This pull request introduces support for the `contract_version` field in the token list functionality. The changes ensure that the `contract_version` is stored in the database, included in API schemas and responses, and properly handled throughout the codebase. The default value for `contract_version` is set to `"25_09"` for backward compatibility, and the database migration updates existing records accordingly. 

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
- Close #1822

## 🔄 Changes

<!-- List the major changes in this PR. -->

**Database and Model Changes:**

* Added a new `contract_version` column to the `token_list` table, with a default value of `"25_09"`, and provided a migration script to update existing records and enforce non-nullability. (`app/model/db/public_info.py`, `migrations/versions/85d3431e23dd_v26_6_0_feature_1822.py`) 
* Updated the `TokenList` model and related schemas to include the `contract_version` field, ensuring it is available in the ORM, Pydantic models, and JSON serialization. (`app/model/db/public_info.py`, `app/model/schema/public_info.py`, `app/model/type/token_list.py`) 

**API and Batch Processing Updates:**

* Modified the API endpoint that lists all public tokens to include the `contract_version` field in all token types, and updated the batch sub-indexer to handle the new field. (`app/api/routers/public_info.py`, `batch/sub_indexers/indexer_PublicInfo_TokenList.py`)

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
