### PR TITLE
Bump uv to 0.11.19 and enable malware check

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -33,6 +33,8 @@ jobs:
             venv-${{ runner.os }}-
       - name: Install dependencies
         if: steps.cache-venv.outputs.cache-hit != 'true'
+        env:
+          UV_MALWARE_CHECK: "1"
         run: |
           uv sync --frozen --no-install-project
       - name: Run typecheck
@@ -61,6 +63,8 @@ jobs:
             venv-${{ runner.os }}-
       - name: Install dependencies
         if: steps.cache-venv.outputs.cache-hit != 'true'
+        env:
+          UV_MALWARE_CHECK: "1"
         run: |
           uv sync --frozen --no-install-project
       - name: Run guardrail checks

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/astral-sh/uv:0.11.18@sha256:78bc42400d77b0678ba95765305c826652ed5431f399257271dda681d0318f03 AS uv
+FROM ghcr.io/astral-sh/uv:0.11.19@sha256:b46b03ddfcfbf8f547af7e9eaefdf8a39c8cebcba7c98858d3162bd28cf536f6 AS uv
 
 FROM ubuntu:24.04@sha256:786a8b558f7be160c6c8c4a54f9a57274f3b4fb1491cf65146521ae77ff1dc54 AS builder
 
@@ -55,7 +55,7 @@ RUN echo '. $HOME/.venv/bin/activate' >> ~apl/.bashrc
 COPY --chown=apl:apl . /app/ibet-Wallet-API
 RUN cd /app/ibet-Wallet-API \
  && uv venv $UV_PROJECT_ENVIRONMENT \
- && uv sync --frozen --no-install-project --no-dev \
+ && UV_MALWARE_CHECK=1 uv sync --frozen --no-install-project --no-dev \
  && PYTHON_BIN="$(uv python find $PYTHON_VERSION)" \
  && PYTHON_ROOT="$(dirname "$(dirname "$PYTHON_BIN")")" \
  && rm -f "$PYTHON_ROOT"/bin/pip "$PYTHON_ROOT"/bin/pip3 "$PYTHON_ROOT"/bin/pip3.* \

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: format lint typecheck doc test test_guardrail_check test_guardrail test_migrations run
 
 install:
-	uv sync --frozen --no-install-project --all-extras
+	UV_MALWARE_CHECK=1 uv sync --frozen --no-install-project --all-extras
 	uv run pre-commit install
 
 update:

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ $ uv venv
 
 Install python packages with:
 ```bash
-$ uv sync --frozen --no-install-project --no-dev
+$ make install
 ```
 
 ### Dependency update policy
@@ -78,12 +78,12 @@ See [DB Migration Guide](migrations/README.md).
 
 ## Starting and Stopping the Server
 
-You can start (or stop) the API server with:
+You can start the API server with:
 ```bash
-$ ./bin/run_server.sh start(stop)
+$ make run
 ```
 
-Open your browser at [http://0.0.0.0:5000](http://0.0.0.0:5000).
+Open your browser at [http://127.0.0.1:8000](http://127.0.0.1:8000).
 
 You will see the JSON response as:
 ```json
@@ -101,7 +101,7 @@ $ ./bin/run_processor.sh
 
 #### Swagger UI
 
-Now go to [http://0.0.0.0:5000/docs](http://0.0.0.0:5000/docs).
+Now go to [http://127.0.0.1:8000/docs](http://127.0.0.1:8000/docs).
 
 You will see the automatic interactive API documentation provided by Swagger UI:
 
@@ -109,7 +109,7 @@ You will see the automatic interactive API documentation provided by Swagger UI:
 
 #### ReDoc
 
-And now, go to [http://0.0.0.0:5000/redoc](http://0.0.0.0:5000/redoc).
+And now, go to [http://127.0.0.1:8000/redoc](http://127.0.0.1:8000/redoc).
 
 You will see the alternative automatic documentation provided by ReDoc:
 
@@ -125,7 +125,7 @@ $ uv venv
 
 Install packages with:
 ```bash
-$ uv sync --frozen --no-install-project
+$ make install
 ```
 
 You can run the tests with:

--- a/README_JA.md
+++ b/README_JA.md
@@ -57,7 +57,7 @@ $ uv venv
 
 以下のコマンドで Python パッケージをインストールします。
 ```bash
-$ uv sync --frozen --no-install-project --no-dev
+$ make install
 ```
 
 ### 依存関係の更新ポリシー
@@ -84,7 +84,7 @@ API サーバーの起動（停止）
 $ ./bin/run_server.sh start(stop)
 ```
 
-ブラウザで、[http://0.0.0.0:5000](http://0.0.0.0:5000) を開くと、以下のJSONのレスポンスを確認できるはずです。
+ブラウザで、[http://127.0.0.1:8000](http://127.0.0.1:8000) を開くと、以下のJSONのレスポンスを確認できるはずです。
 ```json
 {"server":"ibet-Wallet-API"}
 ```
@@ -99,7 +99,7 @@ $ ./bin/run_processor.sh
 
 #### Swagger UI
 
-サーバーを起動した状態で、[http://0.0.0.0:5000/docs](http://0.0.0.0:5000/docs) を開いてください。
+サーバーを起動した状態で、[http://127.0.0.1:8000/docs](http://127.0.0.1:8000/docs) を開いてください。
 
 Swagger UI 形式のドキュメントを参照することができるはずです。
 
@@ -108,7 +108,7 @@ Swagger UI 形式のドキュメントを参照することができるはずで
 
 #### ReDoc
 
-同様に、[http://0.0.0.0:5000/redoc](http://0.0.0.0:5000/redoc) を開いてください。
+同様に、[http://127.0.0.1:8000/redoc](http://127.0.0.1:8000/redoc) を開いてください。
 
 ReDoc 形式のドキュメントを参照することができるはずです。
 
@@ -124,7 +124,7 @@ $ uv venv
 
 テストで利用するパッケージをインストールします。
 ```bash
-$ uv sync --frozen --no-install-project
+$ make install
 ```
 
 以下のようにテストを実行します。

--- a/tests/Dockerfile_unittest
+++ b/tests/Dockerfile_unittest
@@ -1,4 +1,4 @@
-FROM ghcr.io/astral-sh/uv:0.11.18@sha256:78bc42400d77b0678ba95765305c826652ed5431f399257271dda681d0318f03 AS uv
+FROM ghcr.io/astral-sh/uv:0.11.19@sha256:b46b03ddfcfbf8f547af7e9eaefdf8a39c8cebcba7c98858d3162bd28cf536f6 AS uv
 
 FROM ubuntu:24.04@sha256:786a8b558f7be160c6c8c4a54f9a57274f3b4fb1491cf65146521ae77ff1dc54 AS builder
 
@@ -55,7 +55,7 @@ RUN echo '. $HOME/.venv/bin/activate' >> ~apl/.bashrc
 COPY --chown=apl:apl . /app/ibet-Wallet-API
 RUN cd /app/ibet-Wallet-API \
  && uv venv $UV_PROJECT_ENVIRONMENT \
- && uv sync --frozen --no-install-project \
+ && UV_MALWARE_CHECK=1 uv sync --frozen --no-install-project \
  && PYTHON_BIN="$(uv python find $PYTHON_VERSION)" \
  && PYTHON_ROOT="$(dirname "$(dirname "$PYTHON_BIN")")" \
  && rm -f "$PYTHON_ROOT"/bin/pip "$PYTHON_ROOT"/bin/pip3 "$PYTHON_ROOT"/bin/pip3.* \


### PR DESCRIPTION
## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->

This pull request updates dependency installation to enable malware checking, upgrades the `uv` package manager to version 0.11.19, and improves developer experience by standardizing on `make install` for local setup. 

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
None

## 🔄 Changes

<!-- List the major changes in this PR. -->

**Dependency management and security:**
* Upgraded the `uv` package manager from version 0.11.18 to 0.11.19 in both `Dockerfile` and `tests/Dockerfile_unittest` for improved dependency handling. 
* Enabled the `UV_MALWARE_CHECK=1` environment variable during all `uv sync` commands in Dockerfiles, the `Makefile`, and GitHub Actions workflows to ensure malware scanning during dependency installation. 

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
