### PR TITLE
Add uv exclude-newer and update lockfile

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,3 +118,6 @@ include = [
     "batch/**/*",
     "cmd/**/*",
 ]
+
+[tool.uv]
+exclude-newer = "7 days"

--- a/typings/fastapi/testclient.pyi
+++ b/typings/fastapi/testclient.pyi
@@ -1,0 +1,50 @@
+"""
+Copyright BOOSTRY Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+from typing import Any, Literal
+
+import httpx
+
+class TestClient:
+    def __init__(
+        self,
+        app: Any,
+        base_url: str = ...,
+        raise_server_exceptions: bool = ...,
+        root_path: str = ...,
+        backend: Literal["asyncio", "trio"] = ...,
+        backend_options: dict[str, Any] | None = ...,
+        cookies: Any = ...,
+        headers: dict[str, str] | None = ...,
+        follow_redirects: bool = ...,
+        client: tuple[str, int] = ...,
+    ) -> None: ...
+    def request(
+        self,
+        method: str,
+        url: Any,
+        **kwargs: Any,
+    ) -> httpx.Response: ...
+    def get(self, url: Any, **kwargs: Any) -> httpx.Response: ...
+    def options(self, url: Any, **kwargs: Any) -> httpx.Response: ...
+    def head(self, url: Any, **kwargs: Any) -> httpx.Response: ...
+    def post(self, url: Any, **kwargs: Any) -> httpx.Response: ...
+    def put(self, url: Any, **kwargs: Any) -> httpx.Response: ...
+    def patch(self, url: Any, **kwargs: Any) -> httpx.Response: ...
+    def delete(self, url: Any, **kwargs: Any) -> httpx.Response: ...

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,10 @@ version = 1
 revision = 3
 requires-python = "==3.14.2"
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P7D"
+
 [[package]]
 name = "aiohappyeyeballs"
 version = "2.6.2"
@@ -13,7 +17,7 @@ wheels = [
 
 [[package]]
 name = "aiohttp"
-version = "3.13.5"
+version = "3.14.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohappyeyeballs" },
@@ -24,42 +28,49 @@ dependencies = [
     { name = "propcache" },
     { name = "yarl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/77/9a/152096d4808df8e4268befa55fba462f440f14beab85e8ad9bf990516918/aiohttp-3.13.5.tar.gz", hash = "sha256:9d98cc980ecc96be6eb4c1994ce35d28d8b1f5e5208a23b421187d1209dbb7d1", size = 7858271, upload-time = "2026-03-31T22:01:03.343Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/78/8ea7308cac6934de8c74a14f3d5f65d1c89287426688be79538d0e5c013d/aiohttp-3.14.1.tar.gz", hash = "sha256:307f2cff90a764d329e77040603fa032db89c5c24fdad50c4c15334cba744035", size = 7955794, upload-time = "2026-06-07T21:09:35.529Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/ce/46572759afc859e867a5bc8ec3487315869013f59281ce61764f76d879de/aiohttp-3.13.5-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:eb4639f32fd4a9904ab8fb45bf3383ba71137f3d9d4ba25b3b3f3109977c5b8c", size = 745721, upload-time = "2026-03-31T21:58:50.229Z" },
-    { url = "https://files.pythonhosted.org/packages/13/fe/8a2efd7626dbe6049b2ef8ace18ffda8a4dfcbe1bcff3ac30c0c7575c20b/aiohttp-3.13.5-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:7e5dc4311bd5ac493886c63cbf76ab579dbe4641268e7c74e48e774c74b6f2be", size = 497663, upload-time = "2026-03-31T21:58:52.232Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/91/cc8cc78a111826c54743d88651e1687008133c37e5ee615fee9b57990fac/aiohttp-3.13.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:756c3c304d394977519824449600adaf2be0ccee76d206ee339c5e76b70ded25", size = 499094, upload-time = "2026-03-31T21:58:54.566Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/33/a8362cb15cf16a3af7e86ed11962d5cd7d59b449202dc576cdc731310bde/aiohttp-3.13.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ecc26751323224cf8186efcf7fbcbc30f4e1d8c7970659daf25ad995e4032a56", size = 1726701, upload-time = "2026-03-31T21:58:56.864Z" },
-    { url = "https://files.pythonhosted.org/packages/45/0c/c091ac5c3a17114bd76cbf85d674650969ddf93387876cf67f754204bd77/aiohttp-3.13.5-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:10a75acfcf794edf9d8db50e5a7ec5fc818b2a8d3f591ce93bc7b1210df016d2", size = 1683360, upload-time = "2026-03-31T21:58:59.072Z" },
-    { url = "https://files.pythonhosted.org/packages/23/73/bcee1c2b79bc275e964d1446c55c54441a461938e70267c86afaae6fba27/aiohttp-3.13.5-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:0f7a18f258d124cd678c5fe072fe4432a4d5232b0657fca7c1847f599233c83a", size = 1773023, upload-time = "2026-03-31T21:59:01.776Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/ef/720e639df03004fee2d869f771799d8c23046dec47d5b81e396c7cda583a/aiohttp-3.13.5-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:df6104c009713d3a89621096f3e3e88cc323fd269dbd7c20afe18535094320be", size = 1853795, upload-time = "2026-03-31T21:59:04.568Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/c9/989f4034fb46841208de7aeeac2c6d8300745ab4f28c42f629ba77c2d916/aiohttp-3.13.5-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:241a94f7de7c0c3b616627aaad530fe2cb620084a8b144d3be7b6ecfe95bae3b", size = 1730405, upload-time = "2026-03-31T21:59:07.221Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/75/ee1fd286ca7dc599d824b5651dad7b3be7ff8d9a7e7b3fe9820d9180f7db/aiohttp-3.13.5-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c974fb66180e58709b6fc402846f13791240d180b74de81d23913abe48e96d94", size = 1558082, upload-time = "2026-03-31T21:59:09.484Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/20/1e9e6650dfc436340116b7aa89ff8cb2bbdf0abc11dfaceaad8f74273a10/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:6e27ea05d184afac78aabbac667450c75e54e35f62238d44463131bd3f96753d", size = 1692346, upload-time = "2026-03-31T21:59:12.068Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/40/8ebc6658d48ea630ac7903912fe0dd4e262f0e16825aa4c833c56c9f1f56/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a79a6d399cef33a11b6f004c67bb07741d91f2be01b8d712d52c75711b1e07c7", size = 1698891, upload-time = "2026-03-31T21:59:14.552Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/78/ea0ae5ec8ba7a5c10bdd6e318f1ba5e76fcde17db8275188772afc7917a4/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:c632ce9c0b534fbe25b52c974515ed674937c5b99f549a92127c85f771a78772", size = 1742113, upload-time = "2026-03-31T21:59:17.068Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/66/9d308ed71e3f2491be1acb8769d96c6f0c47d92099f3bc9119cada27b357/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:fceedde51fbd67ee2bcc8c0b33d0126cc8b51ef3bbde2f86662bd6d5a6f10ec5", size = 1553088, upload-time = "2026-03-31T21:59:19.541Z" },
-    { url = "https://files.pythonhosted.org/packages/da/a6/6cc25ed8dfc6e00c90f5c6d126a98e2cf28957ad06fa1036bd34b6f24a2c/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:f92995dfec9420bb69ae629abf422e516923ba79ba4403bc750d94fb4a6c68c1", size = 1757976, upload-time = "2026-03-31T21:59:22.311Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/2b/cce5b0ffe0de99c83e5e36d8f828e4161e415660a9f3e58339d07cce3006/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:20ae0ff08b1f2c8788d6fb85afcb798654ae6ba0b747575f8562de738078457b", size = 1712444, upload-time = "2026-03-31T21:59:24.635Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/cf/9e1795b4160c58d29421eafd1a69c6ce351e2f7c8d3c6b7e4ca44aea1a5b/aiohttp-3.13.5-cp314-cp314-win32.whl", hash = "sha256:b20df693de16f42b2472a9c485e1c948ee55524786a0a34345511afdd22246f3", size = 438128, upload-time = "2026-03-31T21:59:27.291Z" },
-    { url = "https://files.pythonhosted.org/packages/22/4d/eaedff67fc805aeba4ba746aec891b4b24cebb1a7d078084b6300f79d063/aiohttp-3.13.5-cp314-cp314-win_amd64.whl", hash = "sha256:f85c6f327bf0b8c29da7d93b1cabb6363fb5e4e160a32fa241ed2dce21b73162", size = 464029, upload-time = "2026-03-31T21:59:29.429Z" },
-    { url = "https://files.pythonhosted.org/packages/79/11/c27d9332ee20d68dd164dc12a6ecdef2e2e35ecc97ed6cf0d2442844624b/aiohttp-3.13.5-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:1efb06900858bb618ff5cee184ae2de5828896c448403d51fb633f09e109be0a", size = 778758, upload-time = "2026-03-31T21:59:31.547Z" },
-    { url = "https://files.pythonhosted.org/packages/04/fb/377aead2e0a3ba5f09b7624f702a964bdf4f08b5b6728a9799830c80041e/aiohttp-3.13.5-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:fee86b7c4bd29bdaf0d53d14739b08a106fdda809ca5fe032a15f52fae5fe254", size = 512883, upload-time = "2026-03-31T21:59:34.098Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/a6/aa109a33671f7a5d3bd78b46da9d852797c5e665bfda7d6b373f56bff2ec/aiohttp-3.13.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:20058e23909b9e65f9da62b396b77dfa95965cbe840f8def6e572538b1d32e36", size = 516668, upload-time = "2026-03-31T21:59:36.497Z" },
-    { url = "https://files.pythonhosted.org/packages/79/b3/ca078f9f2fa9563c36fb8ef89053ea2bb146d6f792c5104574d49d8acb63/aiohttp-3.13.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cf20a8d6868cb15a73cab329ffc07291ba8c22b1b88176026106ae39aa6df0f", size = 1883461, upload-time = "2026-03-31T21:59:38.723Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/e3/a7ad633ca1ca497b852233a3cce6906a56c3225fb6d9217b5e5e60b7419d/aiohttp-3.13.5-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:330f5da04c987f1d5bdb8ae189137c77139f36bd1cb23779ca1a354a4b027800", size = 1747661, upload-time = "2026-03-31T21:59:41.187Z" },
-    { url = "https://files.pythonhosted.org/packages/33/b9/cd6fe579bed34a906d3d783fe60f2fa297ef55b27bb4538438ee49d4dc41/aiohttp-3.13.5-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6f1cbf0c7926d315c3c26c2da41fd2b5d2fe01ac0e157b78caefc51a782196cf", size = 1863800, upload-time = "2026-03-31T21:59:43.84Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/3f/2c1e2f5144cefa889c8afd5cf431994c32f3b29da9961698ff4e3811b79a/aiohttp-3.13.5-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:53fc049ed6390d05423ba33103ded7281fe897cf97878f369a527070bd95795b", size = 1958382, upload-time = "2026-03-31T21:59:46.187Z" },
-    { url = "https://files.pythonhosted.org/packages/66/1d/f31ec3f1013723b3babe3609e7f119c2c2fb6ef33da90061a705ef3e1bc8/aiohttp-3.13.5-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:898703aa2667e3c5ca4c54ca36cd73f58b7a38ef87a5606414799ebce4d3fd3a", size = 1803724, upload-time = "2026-03-31T21:59:48.656Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/b4/57712dfc6f1542f067daa81eb61da282fab3e6f1966fca25db06c4fc62d5/aiohttp-3.13.5-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0494a01ca9584eea1e5fbd6d748e61ecff218c51b576ee1999c23db7066417d8", size = 1640027, upload-time = "2026-03-31T21:59:51.284Z" },
-    { url = "https://files.pythonhosted.org/packages/25/3c/734c878fb43ec083d8e31bf029daae1beafeae582d1b35da234739e82ee7/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6cf81fe010b8c17b09495cbd15c1d35afbc8fb405c0c9cf4738e5ae3af1d65be", size = 1806644, upload-time = "2026-03-31T21:59:53.753Z" },
-    { url = "https://files.pythonhosted.org/packages/20/a5/f671e5cbec1c21d044ff3078223f949748f3a7f86b14e34a365d74a5d21f/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:c564dd5f09ddc9d8f2c2d0a301cd30a79a2cc1b46dd1a73bef8f0038863d016b", size = 1791630, upload-time = "2026-03-31T21:59:56.239Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/63/fb8d0ad63a0b8a99be97deac8c04dacf0785721c158bdf23d679a87aa99e/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:2994be9f6e51046c4f864598fd9abeb4fba6e88f0b2152422c9666dcd4aea9c6", size = 1809403, upload-time = "2026-03-31T21:59:59.103Z" },
-    { url = "https://files.pythonhosted.org/packages/59/0c/bfed7f30662fcf12206481c2aac57dedee43fe1c49275e85b3a1e1742294/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:157826e2fa245d2ef46c83ea8a5faf77ca19355d278d425c29fda0beb3318037", size = 1634924, upload-time = "2026-03-31T22:00:02.116Z" },
-    { url = "https://files.pythonhosted.org/packages/17/d6/fd518d668a09fd5a3319ae5e984d4d80b9a4b3df4e21c52f02251ef5a32e/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:a8aca50daa9493e9e13c0f566201a9006f080e7c50e5e90d0b06f53146a54500", size = 1836119, upload-time = "2026-03-31T22:00:04.756Z" },
-    { url = "https://files.pythonhosted.org/packages/78/b7/15fb7a9d52e112a25b621c67b69c167805cb1f2ab8f1708a5c490d1b52fe/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3b13560160d07e047a93f23aaa30718606493036253d5430887514715b67c9d9", size = 1772072, upload-time = "2026-03-31T22:00:07.494Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/df/57ba7f0c4a553fc2bd8b6321df236870ec6fd64a2a473a8a13d4f733214e/aiohttp-3.13.5-cp314-cp314t-win32.whl", hash = "sha256:9a0f4474b6ea6818b41f82172d799e4b3d29e22c2c520ce4357856fced9af2f8", size = 471819, upload-time = "2026-03-31T22:00:10.277Z" },
-    { url = "https://files.pythonhosted.org/packages/62/29/2f8418269e46454a26171bfdd6a055d74febf32234e474930f2f60a17145/aiohttp-3.13.5-cp314-cp314t-win_amd64.whl", hash = "sha256:18a2f6c1182c51baa1d28d68fea51513cb2a76612f038853c0ad3c145423d3d9", size = 505441, upload-time = "2026-03-31T22:00:12.791Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/a1/5fafa04e1ca91ddb47608699d60649c1c6db3cf41c99e78fc4056f9513db/aiohttp-3.14.1-cp314-cp314-android_24_arm64_v8a.whl", hash = "sha256:7c106c26852ca1c2047c6b80384f17100b4e439af276f21ef3d4e2f450ae7e15", size = 508531, upload-time = "2026-06-07T21:08:02.093Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/2e/bfa02f699d87ffc86d5959270b28f1cb410add3ccaced8ed2e0b8a5238fc/aiohttp-3.14.1-cp314-cp314-android_24_x86_64.whl", hash = "sha256:20205f7f5ade7aaec9f4b500549bbc071b046453aed72f9c06dcab87896a83e8", size = 514718, upload-time = "2026-06-07T21:08:04.476Z" },
+    { url = "https://files.pythonhosted.org/packages/85/a5/9594ad6289eebbc97d167c44213d557807f90e59115caad24de21ad2c3b1/aiohttp-3.14.1-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:62a759436b29e677181a9e76bab8b8f689a29cb9c535f45f7c48c9c830d3f8c3", size = 487918, upload-time = "2026-06-07T21:08:06.377Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/61/16a32c36c3c49edec122a3dc811f2057df2f94d3b14aa107c8017d981618/aiohttp-3.14.1-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:2964cbf553df4d7a57348da44d961d871895fc1ee4e8c322b2a95612c7b17fba", size = 494014, upload-time = "2026-06-07T21:08:08.263Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/89/3ebcf96ed99c05bec9c434aaac6963fd3cbab4a786ae739908a144d9ce44/aiohttp-3.14.1-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:237651caadc3a59badd39319c54642b5299e9cc98a3a194310e55d5bb9f5e397", size = 502398, upload-time = "2026-06-07T21:08:10.244Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/3d/b74870a0c2d40c355928cd5b96c7a11fa821b8a40fc41365e64479b151fb/aiohttp-3.14.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:896e12dfdbbab9d8f7e16d2b28c6769a60126fa92095d1ebf9473d02593a2448", size = 758018, upload-time = "2026-06-07T21:08:12.447Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/66/f42f5c984d99e49c6cff5f26f590750f2e2f7ef1fcfb99966ab5be1b632e/aiohttp-3.14.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d03f281ed22579314ba00821ce20115a7c0ac430660b4cc05704a3f818b3e004", size = 512462, upload-time = "2026-06-07T21:08:14.624Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a7/248e1aebe0c7810b0271e021a0f2a5eb6e78a051885b3c9df49f42a5802d/aiohttp-3.14.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:07eabb979d236335fed927e137a928c9adfb7df3b9ec7aa31726f133a62be983", size = 512824, upload-time = "2026-06-07T21:08:16.572Z" },
+    { url = "https://files.pythonhosted.org/packages/26/97/2aa0e5ba0727dc3bd5aaebb7ccbc510f7dfb7fb961ec87497cd496635ab1/aiohttp-3.14.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4fe1f1087cbadb280b5e1bb054a4f00d1423c74d6626c5e48400d871d34ecefe", size = 1749898, upload-time = "2026-06-07T21:08:18.635Z" },
+    { url = "https://files.pythonhosted.org/packages/00/8d/e97f6c96c891d457c8479d92a514ba194d0412f981d72c70341ee18488ed/aiohttp-3.14.1-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:367a9314fdc79dab0fac96e216cb41dd73c85bdca85306ce8999118ba7e0f333", size = 1710114, upload-time = "2026-06-07T21:08:20.892Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/e6/aa8d7e863048c8fceb5cd6ce74017311cec3ead07847387e12265fb4444e/aiohttp-3.14.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a24f677ebe83749039e7bdf862ff0bbb16818ae4193d4ef96505e269375bcce0", size = 1802541, upload-time = "2026-06-07T21:08:23.044Z" },
+    { url = "https://files.pythonhosted.org/packages/83/a8/72193137de57fda4ebfae4563182d082c8856e3b6e9871d0b46f028fb369/aiohttp-3.14.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c83afe0ba876be7e943d2e0ba645809ad441575d2840c895c21ee5de93b9377a", size = 1875776, upload-time = "2026-06-07T21:08:25.288Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/18/938441025db6769a3464596b2410af3afde0b21eb2f204c6f766f68af4bd/aiohttp-3.14.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:634e385930fb6d2d479cf3aa66515955863b77a5e3c2b5894ca259a25b308602", size = 1760329, upload-time = "2026-06-07T21:08:27.363Z" },
+    { url = "https://files.pythonhosted.org/packages/60/29/bf2496b4065e76e09fe48015aaffe5ce161d8f089b06ac6982070f653076/aiohttp-3.14.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:eeea07c4397bbc57719c4eed8f9c284874d4f175f9b6d57f7a1546b976d455ca", size = 1587293, upload-time = "2026-06-07T21:08:29.805Z" },
+    { url = "https://files.pythonhosted.org/packages/49/a2/2136674d52123b1354bd05dd5753c318db47dc0c927cc70b27bab3755456/aiohttp-3.14.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:335c0cc3e3545ce98dcb9cfcb836f40c3411f43fa03dab757597d80c89af8a35", size = 1714756, upload-time = "2026-06-07T21:08:32.094Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/b9/e5fd2e6f915503081c0f9b1e8540947037929c70c191da2e4d54b31a21a1/aiohttp-3.14.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:ae6be797afdef264e8a84864a85b196ca06045586481b3df8a967322fd2fa844", size = 1721052, upload-time = "2026-06-07T21:08:34.167Z" },
+    { url = "https://files.pythonhosted.org/packages/63/5a/2833e324a2263e104e31e2e91bc5bbee81bc499afd32203faee048a883f0/aiohttp-3.14.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:8560b4d712474335d08907db7973f71912d3a9a8f1dee992ec06b5d2fe359496", size = 1766888, upload-time = "2026-06-07T21:08:36.95Z" },
+    { url = "https://files.pythonhosted.org/packages/57/fa/dea6511870913162f3b2e8c42a7614eb203a4540b8c2da43e0bfb0548f3c/aiohttp-3.14.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:2b7edd08e0a5deb1e8564a2fcd8f4561014a3f05252334671bbf55ddd47db0e5", size = 1581679, upload-time = "2026-06-07T21:08:39.292Z" },
+    { url = "https://files.pythonhosted.org/packages/14/bd/3cf0d55e71784b33534e9710a67d382d900598b4787fbce6cc7317f8c42a/aiohttp-3.14.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:b6ff7fcee63287ae57b5df3e4f5957ce032122802509246dec1a5bcc55904c95", size = 1782021, upload-time = "2026-06-07T21:08:41.407Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/af/14bb5843eccbe234f4dfb78ab73e549d99727247e62ae5d62cbd22eaf5b0/aiohttp-3.14.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:6ffbb2f4ec1ceaff7e07d43922954da26b223d188bf30658e561b98e23089444", size = 1742574, upload-time = "2026-06-07T21:08:43.795Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/1e/fbeb7af9210a67ac0f9c9bec0f8f4568497924e33137a3d5b48e1cf85f3f/aiohttp-3.14.1-cp314-cp314-win32.whl", hash = "sha256:a9875b46d910cff3ea2f5962f9d266b465459fe634e22556ab9bd6fc1192eea0", size = 457773, upload-time = "2026-06-07T21:08:46.168Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/2b/13e8d741a9ec5db7d900c060554cf8352ab85e44e2a4469ebb9d377bda17/aiohttp-3.14.1-cp314-cp314-win_amd64.whl", hash = "sha256:af8b4b81a960eeaf1234971ac3cd0ba5901f3cd42eae42a46b4d089a8b492719", size = 485001, upload-time = "2026-06-07T21:08:48.401Z" },
+    { url = "https://files.pythonhosted.org/packages/df/30/491acfa2c4d6c3ff59c49a14fc1b50be3241e25bbb0c84c09e2da4d11395/aiohttp-3.14.1-cp314-cp314-win_arm64.whl", hash = "sha256:cf4491381b1b57425c315a56a439251b1bdac07b2275f19a8c44bc57744532ec", size = 453809, upload-time = "2026-06-07T21:08:50.7Z" },
+    { url = "https://files.pythonhosted.org/packages/34/e3/19dbe1a1f4cc6230eb9e314de7fe68053b0992f9302b27d12141a0b5db53/aiohttp-3.14.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:819c054312f1af92947e6a55883d1b66feefab11531a7fc45e0fb9b63880b5c2", size = 793320, upload-time = "2026-06-07T21:08:52.775Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/20/1b7182219ba1b108430d6e4dc53d25ae02dcfcf5a045b33af4e8c5167527/aiohttp-3.14.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:10ee9c1753a8f706345b22496c79fbddb5be0599e0823f3738b1534058e25340", size = 529077, upload-time = "2026-06-07T21:08:55Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/c8/14ce60ec31a2e5f5274bb17d383a6f7a3aabca31ac04eee05585bbadab16/aiohttp-3.14.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1601cc37baf5750ccacae618ec2daf020769581695550e3b654a911f859c563d", size = 532476, upload-time = "2026-06-07T21:08:57.176Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/02/9ac85e081e53da2e061b02fa7758fe0a12d17b8ce2d1f5e6c7cb76730328/aiohttp-3.14.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4d6e0ac9da31c9c04c84e1c0182ad8d6df35965a85cae29cd71d089621b3ae94", size = 1922347, upload-time = "2026-06-07T21:08:59.563Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/3e/d3ba07a0ab38b5389e10bec4362d21e10a4f667cba2d79ba30837b3a5059/aiohttp-3.14.1-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:9e8f2d660c350b3d0e259c7a7e3d9b7fc8b41210cbcc3d4a7076ff0a5e5c2fdc", size = 1786465, upload-time = "2026-06-07T21:09:01.909Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/cb/e2ee978a00cfb2df829704a69528b18154eba5939f45bc1efa8f33aee4c5/aiohttp-3.14.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4691802dda97be727f79d86818acaad7eb8e9252626a1d6b519fedbb92d5e251", size = 1909423, upload-time = "2026-06-07T21:09:04.357Z" },
+    { url = "https://files.pythonhosted.org/packages/73/5d/1430334858b1022b58ae50399a918f0bd6fe8fa7fa183598d657ff61e040/aiohttp-3.14.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c389c482a7e9b9dc3ee2701ac46c4125297a3818875b9c305ddb603c04828fd1", size = 2001906, upload-time = "2026-06-07T21:09:06.722Z" },
+    { url = "https://files.pythonhosted.org/packages/66/4e/560c7472d3d198a23aa5c8b19a5115bf6a9b77b7d3e4bb363da320430ad2/aiohttp-3.14.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fc0cacab7ba4e56f0f81c82a98c09bed2f39c940107b03a34b168bdf7597edd3", size = 1877095, upload-time = "2026-06-07T21:09:09.011Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/f1/4745806578d447db4a784a8591e2dae3afdfc2bcb96f8f81271b13df6543/aiohttp-3.14.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:979ed4717f59b8bb12e3963378fa285d93d367e15bcd66c721311826d3c44a6c", size = 1676222, upload-time = "2026-06-07T21:09:11.461Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/c9/48255813cca749a229ef0ab476004ec623728ad79a9c0840616f6c076325/aiohttp-3.14.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:38e1e7daaea81df51c952e18483f323d878499a1e2bfe564790e0f9701d6f203", size = 1842922, upload-time = "2026-06-07T21:09:14.118Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/c0/bbd054e2bee909f529523a5af3891052606af5143c09f5f183ec3b234676/aiohttp-3.14.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:4132e72c608fe9fecb8f409113567605915b83e9bdd3ea56538d2f9cd35002f1", size = 1825035, upload-time = "2026-06-07T21:09:16.447Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/ae/90395d4376deceb74e09ec26b6adf7d2015a6f8802d6d84446af860fef04/aiohttp-3.14.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:eefd9cc9b6d4a2db5f00a26bc3e4f9acf71926a6ec557cd56c9c6f27c290b665", size = 1849512, upload-time = "2026-06-07T21:09:18.742Z" },
+    { url = "https://files.pythonhosted.org/packages/93/bd/fb25f3049957553d4ce0ba6ae480aa2f592a6985497fca590837d16c1be0/aiohttp-3.14.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:b165790117eea512d7f3fb22f1f6dad3d55a7189571993eb015591c1401276d1", size = 1668571, upload-time = "2026-06-07T21:09:21.458Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/22/7f73303d64dd567ff3addca90b556690ed1233a47b8f55d242fb90af3681/aiohttp-3.14.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:ed09c7eb1c391271c2ed0314a51903e72a3acb653d5ccfc264cdf3ef11f8269d", size = 1881159, upload-time = "2026-06-07T21:09:23.813Z" },
+    { url = "https://files.pythonhosted.org/packages/44/be/0474c5a8b5640e1e4aa1923430a91f4151be82e511373fe764189b89aef5/aiohttp-3.14.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:99abd37084b82f5830c635fddd0b4993b9742a66eb746dacf433c8590e8f9e3c", size = 1841409, upload-time = "2026-06-07T21:09:26.207Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/3c/bb4a7cba26956cb3da4553cc2056cf67be5b5ff6e6d8fa4fbdff73bfb7ae/aiohttp-3.14.1-cp314-cp314t-win32.whl", hash = "sha256:47ddf841cdecc810749921d25606dee45857d12d2ad5ddb7b5bd7eab12e4b365", size = 494166, upload-time = "2026-06-07T21:09:28.505Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/84/ec80c2c1f66a952555a9f86df6b33af65108a6febfa0471b69013a12f807/aiohttp-3.14.1-cp314-cp314t-win_amd64.whl", hash = "sha256:5e78b522b7a6e27e0b25d19b247b75039ac4c94f99823e3c9e53ae1603a9f7e9", size = 530255, upload-time = "2026-06-07T21:09:30.843Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/71/6e22be134a4061ada85a92951b842f2657f17d926b727f3f94c56ae963d6/aiohttp-3.14.1-cp314-cp314t-win_arm64.whl", hash = "sha256:90d53f1609c29ccc2193945ef732428382a28f78d0456ae4d3daf0d48b74f0f6", size = 469640, upload-time = "2026-06-07T21:09:33.028Z" },
 ]
 
 [[package]]
@@ -226,15 +237,15 @@ wheels = [
 
 [[package]]
 name = "boto3-stubs"
-version = "1.43.12"
+version = "1.43.29"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore-stubs" },
     { name = "types-s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/50/66/bae15857e2e829023e981fc04101af5f8261156fdeb17c20137f58f6d5f2/boto3_stubs-1.43.12.tar.gz", hash = "sha256:86df9bad7101e55232c5c436b72910302a59226f2fc6dcebb1f0e9c68e6df76e", size = 102689, upload-time = "2026-05-20T20:01:33.984Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/5d/2775423ce41c2c84ce316ee6c10728da8ec9987580da600548322f18f3d8/boto3_stubs-1.43.29.tar.gz", hash = "sha256:4d7829eca11f02a652d72b353fbd81a5192ae55d9f7425b81d102a51f01d8e58", size = 103006, upload-time = "2026-06-12T20:09:21.913Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/2d/bb4f24e23d021fab5b07454910831794cfec3c16eb4eddf2a1c0bd306e5b/boto3_stubs-1.43.12-py3-none-any.whl", hash = "sha256:a0063805b7e9afae89635b7299362e85079aa6d3aa389f580868c4d60e259a4d", size = 70664, upload-time = "2026-05-20T20:01:28.919Z" },
+    { url = "https://files.pythonhosted.org/packages/88/84/458a709dbc263604803b723965c2570332aaaaf7914dba20a77e1f3e885a/boto3_stubs-1.43.29-py3-none-any.whl", hash = "sha256:6c4d1766c3b310d23c107a4bd437e139181c17492a468f62cc2a89dbcd7becf3", size = 70829, upload-time = "2026-06-12T20:09:16.37Z" },
 ]
 
 [package.optional-dependencies]
@@ -562,6 +573,7 @@ all = [
     { name = "mypy-boto3-rekognition" },
     { name = "mypy-boto3-repostspace" },
     { name = "mypy-boto3-resiliencehub" },
+    { name = "mypy-boto3-resiliencehubv2" },
     { name = "mypy-boto3-resource-explorer-2" },
     { name = "mypy-boto3-resource-groups" },
     { name = "mypy-boto3-resourcegroupstaggingapi" },
@@ -589,6 +601,7 @@ all = [
     { name = "mypy-boto3-sagemaker-geospatial" },
     { name = "mypy-boto3-sagemaker-metrics" },
     { name = "mypy-boto3-sagemaker-runtime" },
+    { name = "mypy-boto3-sagemakerjobruntime" },
     { name = "mypy-boto3-savingsplans" },
     { name = "mypy-boto3-scheduler" },
     { name = "mypy-boto3-schemas" },
@@ -680,14 +693,14 @@ wheels = [
 
 [[package]]
 name = "botocore-stubs"
-version = "1.42.41"
+version = "1.43.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "types-awscrt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0c/a8/a26608ff39e3a5866c6c79eda10133490205cbddd45074190becece3ff2a/botocore_stubs-1.42.41.tar.gz", hash = "sha256:dbeac2f744df6b814ce83ec3f3777b299a015cbea57a2efc41c33b8c38265825", size = 42411, upload-time = "2026-02-03T20:46:14.479Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7f/81/79693e833291c00dc89ee610e5e915381b6f08233912e28df50106840780/botocore_stubs-1.43.14.tar.gz", hash = "sha256:9e3bc1fdd51da7473f0df726c82747a1b0ae913449d629659765c247fecc2039", size = 42738, upload-time = "2026-05-25T06:06:37.484Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/32/76/cab7af7f16c0b09347f2ebe7ffda7101132f786acb767666dce43055faab/botocore_stubs-1.42.41-py3-none-any.whl", hash = "sha256:9423110fb0e391834bd2ed44ae5f879d8cb370a444703d966d30842ce2bcb5f0", size = 66759, upload-time = "2026-02-03T20:46:13.02Z" },
+    { url = "https://files.pythonhosted.org/packages/89/ca/f017727b11895908c5dedc829cf2ec35e0c4b2a26ba875db325fef2cefdf/botocore_stubs-1.43.14-py3-none-any.whl", hash = "sha256:fb98f1475c92fd718644e786b5c543a20f1b1f610e89e0a7191c3f1f429c75aa", size = 67093, upload-time = "2026-05-25T06:06:34.532Z" },
 ]
 
 [[package]]
@@ -808,14 +821,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.4.0"
+version = "8.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/23/e4/796662cd90cf80e3a363c99db2b88e0e394b988a575f60a17e16440cd011/click-8.4.0.tar.gz", hash = "sha256:638f1338fe1235c8f4e008e4a8a254fb5c5fbdcbb40ece3c9142ebb78e792973", size = 350843, upload-time = "2026-05-17T00:47:58.425Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz", hash = "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96", size = 353007, upload-time = "2026-05-22T04:08:37.769Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/ae/8e92f8058baf87f6c7d86ee7e457668690195cc77efedb8d3797a06e3940/click-8.4.0-py3-none-any.whl", hash = "sha256:40c50b7c6c6adac2823d411041ec84f3f103f1b280d5e9ce0d7f998995832f81", size = 116147, upload-time = "2026-05-17T00:47:56.842Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl", hash = "sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2", size = 116639, upload-time = "2026-05-22T04:08:35.26Z" },
 ]
 
 [[package]]
@@ -829,94 +842,91 @@ wheels = [
 
 [[package]]
 name = "coverage"
-version = "7.14.0"
+version = "7.14.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/23/7f/d0720730a397a999ffc0fd3f5bebef347338e3a47b727da66fbb228e2ff2/coverage-7.14.0.tar.gz", hash = "sha256:057a6af2f160a85384cde4ab36f0d2777bae1057bae255f95413cdd382aa5c74", size = 919489, upload-time = "2026-05-10T18:02:31.397Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/fd/0ab2772530e946e1be1abd0bc09e647ec9b02e88f0867857601fefca8953/coverage-7.14.1.tar.gz", hash = "sha256:30c08f7d90415aa98b3c990385dea2939b0da55f38515e5b369b83655f8523be", size = 920132, upload-time = "2026-05-26T20:41:36.783Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/18/b9a6586d73992807c26f9a5f274131be3d76b56b18a82b9392e2a25d2e45/coverage-7.14.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:9aed9fa983514ca032790f3fe0d1c0e42ca7e16b42432af1706b50a9a46bef5d", size = 220036, upload-time = "2026-05-10T18:01:33.057Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/9b/4165a1d56ddc302a0e2d518fd9d412a4fd0b57562618c78c5f21c57194f5/coverage-7.14.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ba3b8390db29296dbbf49e91b6fe08f990743a90c8f447ba4c2ffc29670dfa63", size = 220368, upload-time = "2026-05-10T18:01:34.705Z" },
-    { url = "https://files.pythonhosted.org/packages/69/aa/c12e52a5ba148d9995229d557e3be6e554fe469addc0e9241b2f0956d8ea/coverage-7.14.0-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:3a5d8e876dfa2f102e970b183863d6dedd023d3c0eeca1fe7a9787bc5f28b212", size = 251417, upload-time = "2026-05-10T18:01:36.949Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/51/ec641c26e6dca1b25a7d2035ba6ecb7c884ef1a100a9e42fbe4ce4405139/coverage-7.14.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5ebb8f4614a3787d567e610bbfdf96a4798dd69a1afb1bd8ad228d4111fe6ff3", size = 253924, upload-time = "2026-05-10T18:01:38.985Z" },
-    { url = "https://files.pythonhosted.org/packages/33/c4/59c3de0bd1b538824173fd518fed51c1ce740ca5ed68e74545983f4053a9/coverage-7.14.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b9bf47223dd8db3d4c4b2e443b02bace480d428f0822c3f991600448a176c97", size = 255269, upload-time = "2026-05-10T18:01:40.957Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/a9/36dfa153a62040296f6e7febfdb20a5720622f6ef5a81a41e8237b9a5344/coverage-7.14.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3485a836550b303d006d57cc06e3d5afaabc642c77050b7c985a97b13e3776b8", size = 257583, upload-time = "2026-05-10T18:01:42.607Z" },
-    { url = "https://files.pythonhosted.org/packages/26/7b/cc2c048d4114d9ab1c2409e9ee365e5ae10736df6dffcfc9444effa6c708/coverage-7.14.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3e7e88110bae996d199d1693ca8ec3fd52441d426401ae963437598667b4c5eb", size = 251434, upload-time = "2026-05-10T18:01:44.537Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/df/6770eaa576e604575e9a78055313250faef5faa84bd6f71a39fece519c43/coverage-7.14.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:15228a6800ce7bdf1b74800595e56db7138cecb338fdbf044806e10dcf182dfe", size = 253280, upload-time = "2026-05-10T18:01:46.175Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/9e/1c0264514a3f98259a6d64765a397b2c8373e3ba59ee722a4802d3ec0c61/coverage-7.14.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:9d26ac7f5398bafc5b57421ad994e8a4749e8a7a0e62d05ec7d53014d5963bfa", size = 251241, upload-time = "2026-05-10T18:01:48.732Z" },
-    { url = "https://files.pythonhosted.org/packages/64/16/4efdf3e3c4079cdbf0ece56a2fea872df9e8a3e15a13a0af4400e1075944/coverage-7.14.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2fb73254ff43c911c967a899e1359bc5049b4b115d6e8fbdde4937d0a2246cd5", size = 255516, upload-time = "2026-05-10T18:01:50.819Z" },
-    { url = "https://files.pythonhosted.org/packages/93/69/b1de96346603881b3d1bc8d6447c83200e1c9700ffbaff926ba01ff5724c/coverage-7.14.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:454a380af72c6adada298ed270d38c7a391288198dbfb8467f786f588751a90c", size = 251059, upload-time = "2026-05-10T18:01:52.773Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/66/2881853e0363a5e0a724d1103e53650795367471b6afb234f8b49e713bc6/coverage-7.14.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:65c86fb646d2bd2972e96bd1a8b45817ed907cee68655d6295fe7ec031d04cca", size = 252716, upload-time = "2026-05-10T18:01:54.506Z" },
-    { url = "https://files.pythonhosted.org/packages/55/5c/0d3305d002c41dcde873dbe456491e663dc55152ca526b630b5c47efd62f/coverage-7.14.0-cp314-cp314-win32.whl", hash = "sha256:6a6516b02a6101398e19a3f44820f69bab2590697f7def4331f668b14adaf828", size = 222788, upload-time = "2026-05-10T18:01:56.487Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/58/6e1b8f52fdc3184b47dc5037f5070d83a3d11042db1594b02d2a44d786c8/coverage-7.14.0-cp314-cp314-win_amd64.whl", hash = "sha256:45e0f79d8351fa76e256716df91eab12890d32678b9590df7ae1042e4bd4cf5d", size = 223600, upload-time = "2026-05-10T18:01:58.497Z" },
-    { url = "https://files.pythonhosted.org/packages/00/70/a18c408e674bc26281cadaedc7351f929bd2094e191e4b15271c30b084cc/coverage-7.14.0-cp314-cp314-win_arm64.whl", hash = "sha256:4b899594a8b2d81e5cc064a0d7f9cac2081fed91049456cae7676787e41549c9", size = 222168, upload-time = "2026-05-10T18:02:00.411Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/89/2681f071d238b62aff8dfc2ab44fc24cfdb38d1c01f391a80522ff5d3a16/coverage-7.14.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:f580f8c80acd94ac72e863efe2cab791d8c38d153e0b463b92dfa000d5c84cd1", size = 220766, upload-time = "2026-05-10T18:02:02.313Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/c7/c987babafd9207ffa1995e1ef1f9b26762cf4963aa768a66b6f0501e4616/coverage-7.14.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a2bd259c442cd43c49b30fbafc51776eb19ea396faf159d26a83e6a0a5f13b0c", size = 221035, upload-time = "2026-05-10T18:02:04.017Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/e9/d6a5ac3b333088143d6fc877d398a9a674dc03124a2f776e131f03864823/coverage-7.14.0-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:a706b908dfa85538863504c624b237a3cc34232bf403c057414ebfdb3b4d9f84", size = 262405, upload-time = "2026-05-10T18:02:05.915Z" },
-    { url = "https://files.pythonhosted.org/packages/38/b1/e70838d29a7c08e22d44398a46db90815bbcbf28de06992bd9210d1a8d8e/coverage-7.14.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:7333cd944ee4393b9b3d3c1b598c936d4fc8d70573a4c7dacfec5590dd50e436", size = 264530, upload-time = "2026-05-10T18:02:07.582Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/73/5c31ef97763288d03d9995152b96d5475b527c63d91c84b01caea894b83a/coverage-7.14.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0f162bc9a15b82d947b02651b0c7e1609d6f7a8735ca330cfadec8481dd97d5a", size = 266932, upload-time = "2026-05-10T18:02:09.401Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/76/dd56d80f29c5f05b4d76f7e7c6d47cafacae017189c75c5759d24f9ff0cc/coverage-7.14.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:362cb78e01a5dc82009d88004cf60f2e6b6d6fcbfdec05b05af73b0abf40118f", size = 268062, upload-time = "2026-05-10T18:02:11.399Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/c7/27ba85cd5b95614f159ff93ebff1901584a8d192e2e5e24c4943a7453f59/coverage-7.14.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:acebd068fca5512c3a6fde9c045f901613478781a73f0e82b307b214daef23fb", size = 261504, upload-time = "2026-05-10T18:02:13.257Z" },
-    { url = "https://files.pythonhosted.org/packages/13/2e/e8149f60ab5d5684c6eee881bdf34b127115cddbb958b196768dd9d63473/coverage-7.14.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:29fe3da551dface75deb2ccbf87b6b66e2e7ef38f6d89050b428be94afff3490", size = 264398, upload-time = "2026-05-10T18:02:15.063Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/7f/1261b025285323225f4b4abffa5a643649dfd67e25ddca7ebcbdea3b7cb3/coverage-7.14.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:b4cc4fce8672fffcb09b0eafc167b396b3ba53c4a7230f54b7aaffbf6c835fa9", size = 262000, upload-time = "2026-05-10T18:02:16.756Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/dc/829c54f60b9d08389439c00f813c752781c496fc5788c78d8006db4b4f2b/coverage-7.14.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:5d4a51aad8ba8bdcd2b8bd8f03d4aca19693fa2327a3470e4718a25b03481020", size = 265732, upload-time = "2026-05-10T18:02:18.817Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/b0/70bd1419941652fa062689cba9c3eeafb8f5e6fbb890bce41c3bdda5dbd6/coverage-7.14.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:9f323af3e1e4f68b60b7b247e37b8515563a61375518fa59de1af48ba28a3db6", size = 260847, upload-time = "2026-05-10T18:02:20.528Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/73/be40b2390656c654d35ea0015ea7ba3d945769cf80790ad5e0bb2d56d2ba/coverage-7.14.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:1a0abc7342ea9711c469dd8b821c6c311e6bc6aac1442e5fbd6b27fae0a8f3db", size = 263166, upload-time = "2026-05-10T18:02:22.337Z" },
-    { url = "https://files.pythonhosted.org/packages/29/55/4a643f712fcf7cf2881f8ec1e0ccb7b164aff3108f69b51801246c8799f2/coverage-7.14.0-cp314-cp314t-win32.whl", hash = "sha256:a9f864ef57b7172e2db87a096642dd51e179e085ab6b2c371c29e885f65c8fb2", size = 223573, upload-time = "2026-05-10T18:02:24.11Z" },
-    { url = "https://files.pythonhosted.org/packages/27/96/3acae5da0953be042c0b4dea6d6789d2f080701c77b88e44d5bd41b9219b/coverage-7.14.0-cp314-cp314t-win_amd64.whl", hash = "sha256:29943e552fdc08e082eb51400fb2f58e118a83b5542bd06531214e084399b644", size = 224680, upload-time = "2026-05-10T18:02:25.896Z" },
-    { url = "https://files.pythonhosted.org/packages/93/3d/6ab5d2dd8325d838737c6f8d83d62eb6230e0d70b87b51b57bbfd08fa767/coverage-7.14.0-cp314-cp314t-win_arm64.whl", hash = "sha256:742a73ea621953b012f2c4c2219b512180dd84489acf5b1596b0aafc55b9100b", size = 222703, upload-time = "2026-05-10T18:02:27.822Z" },
-    { url = "https://files.pythonhosted.org/packages/61/e8/cb8e80d6f9f55b99588625062822bf946cf03ed06315df4bd8397f5632a1/coverage-7.14.0-py3-none-any.whl", hash = "sha256:8de5b61163aee3d05c8a2beab6f47913df7981dad1baf82c414d99158c286ab1", size = 211764, upload-time = "2026-05-10T18:02:29.538Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/34/fc2f101b151af3799a101f0550b0454aa008afdc0add677394ec4aa8ea10/coverage-7.14.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d5ed429d0b8edaac649e889b4ffcedb6c80b06629a3f93050e3dddfb99235bee", size = 220091, upload-time = "2026-05-26T20:40:27.249Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/a7/1ebae2ab5b961b5c79bb09fe7b3ac99edb190d8be4a8c510b2cf66f46468/coverage-7.14.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8011224a62280e50dab346960c03cf47aca1a1e09e608c0fb33fd6e0cc8e9500", size = 220421, upload-time = "2026-05-26T20:40:30.084Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/90/92aca9cf0acc95123c96cd1eb1f08917897a7f5dee01e15738922971ec31/coverage-7.14.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:12c42ec1e14f553c4f817e989365982e646e27211f10a0f717855b94a79c8906", size = 251466, upload-time = "2026-05-26T20:40:32.542Z" },
+    { url = "https://files.pythonhosted.org/packages/26/2b/78048cbe3b999f6cbf9cc0d90abba6a88a3e0863a8c1c6cbc762f3f8802f/coverage-7.14.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:06144cd511cf2624873a035c5069cf297144f6e77a73ee3d7a55b605ec5efb42", size = 253973, upload-time = "2026-05-26T20:40:34.473Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/21/c2e33b29d1cfde484a19d437afc343c6cd30b08d78cbbf9f5aff14e57b2b/coverage-7.14.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a311d8e1da24be5c1ccf85cbfb06315dbaa1703d5a1eab3f6432c72b837917c8", size = 255318, upload-time = "2026-05-26T20:40:38.154Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/ee/aad2f108d63b769121005302f16bf66db8625c88ceaba466942e09a2607e/coverage-7.14.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c79cead5b5bc584d9c71451cb984d0e3a84e0c0937379c8efcbf27c8d661b851", size = 257633, upload-time = "2026-05-26T20:40:40.164Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/f8/11a2c29b4fd76d9849f81d0bb812ec0017a9396df3217214e38934a8c837/coverage-7.14.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:dcbf65f1f66a26cdd88c35cf68fb4729c5d1cd2e88added72420541dfb212034", size = 251488, upload-time = "2026-05-26T20:40:42.631Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/b8/9a5820de4b8ac2b71d85e3b5fb49108d7469c665f0e2ad0dd7569023e305/coverage-7.14.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fd86572566fb40189a8260446158235159bc7a82dfbc87a3b39cf4fb57fcec1c", size = 253329, upload-time = "2026-05-26T20:40:45.208Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ff/f33e4823667e27548e8fd8df44217515303f9808d0ff29817db56f87d990/coverage-7.14.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:7771b601718fdde84832c3a434ca9bbf4ae9adbc49d84198b4110700c3c77c36", size = 251291, upload-time = "2026-05-26T20:40:47.502Z" },
+    { url = "https://files.pythonhosted.org/packages/68/9b/489db0ebb209054766b90a9014a45f6d26eb724c02ec21311c3733b5a644/coverage-7.14.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:39b21e212c55af06fa375e3dbf90a8a8e38792f3a910c580066d23563830ddd5", size = 255564, upload-time = "2026-05-26T20:40:49.372Z" },
+    { url = "https://files.pythonhosted.org/packages/27/b5/16bc2d4c2409b23c7737edb68c83bc89e345f378050549fe1d75ac7d34d5/coverage-7.14.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:f2302660e32562a532b442480121aef8aa61a5bdb20b30bf0adab29f10a5a4b4", size = 251107, upload-time = "2026-05-26T20:40:51.677Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/0c/2629997469a00cd069d588a41c9dc887610f2775ae89d250c4791e65272a/coverage-7.14.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:03a6f93c1ec3b7f2e77b5dbcc5573a2c21f12529a5c6bbe0f16f72303cc2fa4d", size = 252764, upload-time = "2026-05-26T20:40:54.267Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/ee/f78d63c8f079e0d7211c7e2401fa17e311514534ba61bae03e4b287ce4ab/coverage-7.14.1-cp314-cp314-win32.whl", hash = "sha256:8a3ce026d73290f42f08dafecbd82c193a74df280461fbf97300fec51fd133ee", size = 222837, upload-time = "2026-05-26T20:40:56.496Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/b9/be539854f93a70dfbeec69117f33ec70dc42ff0b65b5b07ab8d40d04228e/coverage-7.14.1-cp314-cp314-win_amd64.whl", hash = "sha256:114c95ef29302423b87d159075805f4ab973254a2638a5d7d046c94887cc87d7", size = 223650, upload-time = "2026-05-26T20:40:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/9e/24e2842fef40f35ac82ba3a7719c8023d011bf3bf652d0675316a9d088a1/coverage-7.14.1-cp314-cp314-win_arm64.whl", hash = "sha256:a07891c3f4805442b31b71e84ba3cf29ed1aa9a428284e06deeb4b23e5b46343", size = 222218, upload-time = "2026-05-26T20:41:00.321Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/1d/ac0a9df5fe31c1e8bdd658074905fc12844a05c1a7e3fdb8417e97c31e23/coverage-7.14.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:1101a5ebb083aecb625ebb6209d4105b58f647b093cb2dc8122d7b33f743cfe1", size = 220822, upload-time = "2026-05-26T20:41:02.281Z" },
+    { url = "https://files.pythonhosted.org/packages/32/cf/f964fd9aff20323f9f1a726c97135f8a76bcd87b92dad141a456a43f3c64/coverage-7.14.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:851b9e1e4e8a4608e77c79714b2e77c0970d2ed7202a05e92ae407817481887b", size = 221084, upload-time = "2026-05-26T20:41:04.593Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/5e/7e5ef2aba844de2b80d678619fcf0841b42e3f37f16411226f3fe4c1016f/coverage-7.14.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:d5b89cdfb2ee051b71e8c3c70bd81a9eff81100f736a269136fe1a68efe00474", size = 262454, upload-time = "2026-05-26T20:41:06.641Z" },
+    { url = "https://files.pythonhosted.org/packages/64/62/75809bded87015cc4935524218a2a8ed8dd1a8498bfed30a2f4f7a4b4d34/coverage-7.14.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0177614a0370f227888b4e436a7c55686d6a9f90eb1ade2b624ba685a1686e86", size = 264578, upload-time = "2026-05-26T20:41:08.556Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/42/d33392dc14633525012d2d504fa1a33b05538bf535f5c1d64675e5754b78/coverage-7.14.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2d69af5dea2de76fc485a83032a630523f985198b7e25be901ec60181587b01e", size = 266981, upload-time = "2026-05-26T20:41:10.824Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/49/0157c4428c2aca7f1e09d5565930586fd5ae36f1655f08b0daa7cf1fcae1/coverage-7.14.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:35ab22d91de736e8966b980dc355cbcdd2c6dbbcfe275f9a2991bc8a91b3df65", size = 268112, upload-time = "2026-05-26T20:41:12.966Z" },
+    { url = "https://files.pythonhosted.org/packages/96/26/86b9ce71f4092b1ed325ce1421698081df1286b833400b6836912834d6e0/coverage-7.14.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:357d4e32935c36588aaba057d734fa32428c360c9fc2e4442afbf1b646beee6e", size = 261558, upload-time = "2026-05-26T20:41:15Z" },
+    { url = "https://files.pythonhosted.org/packages/20/4c/c311210c5472cf5401d8422b0d7812cdd520f24417673afabda6c323faca/coverage-7.14.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:51bd64741cc6fa065abd300ede1afe5a5291ece9c31da8b24884deda48bcc3f8", size = 264447, upload-time = "2026-05-26T20:41:17.369Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/71/59513f8710ed3e6b0ac0a050a5b7e977bb9c9e880354863b5d00d8809256/coverage-7.14.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:9132cd363a68a4c3daa7c8704a654b1e39d3360f6f5b8ddd470608a945236c07", size = 262048, upload-time = "2026-05-26T20:41:19.309Z" },
+    { url = "https://files.pythonhosted.org/packages/84/8d/bceed32dc494f5bbf50f775cd2e78ca814953942b5ea28d3c1c3ac316f14/coverage-7.14.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:07c6290b1697b862c0478eab545eec949a0d0e4d6d03497f446d706da3b4f2de", size = 265781, upload-time = "2026-05-26T20:41:21.559Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/c5/9348fe40dbfd4991aaf78df2c6c3098bfb2cc834d1fd362a64b4efef855a/coverage-7.14.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:5ea0c297e27133853b4d8a3eb799bff5a2dbd9f2f41537a240d337ac9b4df890", size = 260896, upload-time = "2026-05-26T20:41:23.428Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/92/1ea0f03929da7cf87206b1fa24f4c8e9c158be0455481af29ec0a1f3503f/coverage-7.14.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:01b7733daad0237daa01ef80fe2dfceffc911e6a17fa7b55d14aa8214eaaaecd", size = 263214, upload-time = "2026-05-26T20:41:25.419Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/a9/b2493c054c0e01a643266742ab45e15744e60743f9260cd930c7142b1124/coverage-7.14.1-cp314-cp314t-win32.whl", hash = "sha256:6adc5a36984624a70bf11d7184e20fa0a49aa7c47ffab43804106a1a695ea22e", size = 223624, upload-time = "2026-05-26T20:41:27.795Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/bd/3e1e6a57fccd2d7c83fcdf338e93ba98eb85c6e877dd34731ac585375490/coverage-7.14.1-cp314-cp314t-win_amd64.whl", hash = "sha256:ddf799247318f34dbcd2efa8c95a8d0642674e926bb1774cf9b63dfd2a389d1c", size = 224728, upload-time = "2026-05-26T20:41:30.098Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/d7/31066cf1d2f0c6c797fce911bcfa01dd35642dc6da992a950256097c5860/coverage-7.14.1-cp314-cp314t-win_arm64.whl", hash = "sha256:145986fe66647eb489f18d9a997567a3fd358584c4b5a808769113abc07466af", size = 222752, upload-time = "2026-05-26T20:41:32.123Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/3c/1a983b9a745d7f83d53f057bcc5bf79ba6a2bbc08266b3f0c7d6fe630c9b/coverage-7.14.1-py3-none-any.whl", hash = "sha256:a252f21c27e38347e60111a3266b03827422a7d5525951aceee313aa68bab1d2", size = 211815, upload-time = "2026-05-26T20:41:34.078Z" },
 ]
 
 [[package]]
 name = "cryptography"
-version = "48.0.0"
+version = "49.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9f/a9/db8f313fdcd85d767d4973515e1db101f9c71f95fced83233de224673757/cryptography-48.0.0.tar.gz", hash = "sha256:5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920", size = 832984, upload-time = "2026-05-04T22:59:38.133Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/99/d1c90d6041656cc6ee229dc99cd67fd0cd5aec3c5f7d72fffc27cc750054/cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493", size = 854345, upload-time = "2026-06-12T20:02:30.512Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/3d/01f6dd9190170a5a241e0e98c2d04be3664a9e6f5b9b872cde63aff1c3dd/cryptography-48.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:0c558d2cdffd8f4bbb30fc7134c74d2ca9a476f830bb053074498fbc86f41ed6", size = 8001587, upload-time = "2026-05-04T22:57:36.803Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/6e/e90527eef33f309beb811cf7c982c3aeffcce8e3edb178baa4ca3ae4a6fa/cryptography-48.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f5333311663ea94f75dd408665686aaf426563556bb5283554a3539177e03b8c", size = 4690433, upload-time = "2026-05-04T22:57:40.373Z" },
-    { url = "https://files.pythonhosted.org/packages/90/04/673510ed51ddff56575f306cf1617d80411ee76831ccd3097599140efdfe/cryptography-48.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7995ef305d7165c3f11ae07f2517e5a4f1d5c18da1376a0a9ed496336b69e5f3", size = 4710620, upload-time = "2026-05-04T22:57:42.935Z" },
-    { url = "https://files.pythonhosted.org/packages/14/d5/e9c4ef932c8d800490c34d8bd589d64a31d5890e27ec9e9ad532be893294/cryptography-48.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:40ba1f85eaa6959837b1d51c9767e230e14612eea4ef110ee8854ada22da1bf5", size = 4696283, upload-time = "2026-05-04T22:57:45.294Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/29/174b9dfb60b12d59ecfc6cfa04bc88c21b42a54f01b8aae09bb6e51e4c7f/cryptography-48.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:369a6348999f94bbd53435c894377b20ab95f25a9065c283570e70150d8abc3c", size = 5296573, upload-time = "2026-05-04T22:57:47.933Z" },
-    { url = "https://files.pythonhosted.org/packages/95/38/0d29a6fd7d0d1373f0c0c88a04ba20e359b257753ac497564cd660fc1d55/cryptography-48.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a0e692c683f4df67815a2d258b324e66f4738bd7a96a218c826dce4f4bd05d8f", size = 4743677, upload-time = "2026-05-04T22:57:50.067Z" },
-    { url = "https://files.pythonhosted.org/packages/30/be/eef653013d5c63b6a490529e0316f9ac14a37602965d4903efed1399f32b/cryptography-48.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:18349bbc56f4743c8b12dc32e2bccb2cf83ee8b69a3bba74ef8ae857e26b3d25", size = 4330808, upload-time = "2026-05-04T22:57:52.301Z" },
-    { url = "https://files.pythonhosted.org/packages/84/9e/500463e87abb7a0a0f9f256ec21123ecde0a7b5541a15e840ea54551fd81/cryptography-48.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:7e8eac43dfca5c4cccc6dad9a80504436fca53bb9bc3100a2386d730fbe6b602", size = 4695941, upload-time = "2026-05-04T22:57:54.603Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/dc/7303087450c2ec9e7fbb750e17c2abfbc658f23cbd0e54009509b7cc4091/cryptography-48.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9ccdac7d40688ecb5a3b4a604b8a88c8002e3442d6c60aead1db2a89a041560c", size = 5252579, upload-time = "2026-05-04T22:57:57.207Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/c0/7101d3b7215edcdc90c45da544961fd8ed2d6448f77577460fa75a8443f7/cryptography-48.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:bd72e68b06bb1e96913f97dd4901119bc17f39d4586a5adf2d3e47bc2b9d58b5", size = 4743326, upload-time = "2026-05-04T22:57:59.535Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/d8/5b833bad13016f562ab9d063d68199a4bd121d18458e439515601d3357ec/cryptography-48.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:59baa2cb386c4f0b9905bd6eb4c2a79a69a128408fd31d32ca4d7102d4156321", size = 4826672, upload-time = "2026-05-04T22:58:01.996Z" },
-    { url = "https://files.pythonhosted.org/packages/98/e1/7074eb8bf3c135558c73fc2bcf0f5633f912e6fb87e868a55c454080ef09/cryptography-48.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9249e3cd978541d665967ac2cb2787fd6a62bddf1e75b3e347a594d7dacf4f74", size = 4972574, upload-time = "2026-05-04T22:58:03.968Z" },
-    { url = "https://files.pythonhosted.org/packages/04/70/e5a1b41d325f797f39427aa44ef8baf0be500065ab6d8e10369d850d4a4f/cryptography-48.0.0-cp311-abi3-win32.whl", hash = "sha256:9c459db21422be75e2809370b829a87eb37f74cd785fc4aa9ea1e5f43b47cda4", size = 3294868, upload-time = "2026-05-04T22:58:06.467Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/ac/8ac51b4a5fc5932eb7ee5c517ba7dc8cd834f0048962b6b352f00f41ebf9/cryptography-48.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:5b012212e08b8dd5edc78ef54da83dd9892fd9105323b3993eff6bea65dc21d7", size = 3817107, upload-time = "2026-05-04T22:58:08.845Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/84/70e3feea9feea87fd7cbe77efb2712ae1e3e6edf10749dc6e95f4e60e455/cryptography-48.0.0-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:3cb07a3ed6431663cd321ea8a000a1314c74211f823e4177fefa2255e057d1ec", size = 7986556, upload-time = "2026-05-04T22:58:11.172Z" },
-    { url = "https://files.pythonhosted.org/packages/89/6e/18e07a618bb5442ba10cf4df16e99c071365528aa570dfcb8c02e25a303b/cryptography-48.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8c7378637d7d88016fa6791c159f698b3d3eed28ebf844ac36b9dc04a14dae18", size = 4684776, upload-time = "2026-05-04T22:58:13.712Z" },
-    { url = "https://files.pythonhosted.org/packages/be/6a/4ea3b4c6c6759794d5ee2103c304a5076dc4b19ae1f9fe47dba439e159e9/cryptography-48.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc90c0b39b2e3c65ef52c804b72e3c58f8a04ab2a1871272798e5f9572c17d20", size = 4698121, upload-time = "2026-05-04T22:58:16.448Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/59/6ff6ad6cae03bb887da2a5860b2c9805f8dac969ef01ce563336c49bd1d1/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:76341972e1eff8b4bea859f09c0d3e64b96ce931b084f9b9b7db8ef364c30eff", size = 4690042, upload-time = "2026-05-04T22:58:18.544Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/b4/fc334ed8cfd705aca282fe4d8f5ae64a8e0f74932e9feecb344610cf6e4d/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:55b7718303bf06a5753dcdccf2f3945cf18ad7bffde41b61226e4db31ab89a9c", size = 5282526, upload-time = "2026-05-04T22:58:20.75Z" },
-    { url = "https://files.pythonhosted.org/packages/11/08/9f8c5386cc4cd90d8255c7cdd0f5baf459a08502a09de30dc51f553d38dc/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:a64697c641c7b1b2178e573cbc31c7c6684cd56883a478d75143dbb7118036db", size = 4733116, upload-time = "2026-05-04T22:58:23.627Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/77/99307d7574045699f8805aa500fa0fb83422d115b5400a064ddd306d7750/cryptography-48.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:561215ea3879cb1cbbf272867e2efda62476f240fb58c64de6b393ae19246741", size = 4316030, upload-time = "2026-05-04T22:58:25.581Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/36/a608b98337af3cb2aff4818e406649d30572b7031918b04c87d979495348/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:ad64688338ed4bc1a6618076ba75fd7194a5f1797ac60b47afe926285adb3166", size = 4689640, upload-time = "2026-05-04T22:58:27.747Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/a6/825010a291b4438aecc1f568bc428189fc1175515223632477c07dc0a6df/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:906cbf0670286c6e0044156bc7d4af9cbb0ef6db9f73e52c3ec56ba6bdde5336", size = 5237657, upload-time = "2026-05-04T22:58:29.848Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/09/4e76a09b4caa29aad535ddc806f5d4c5d01885bd978bd984fbc6ca032cae/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:ea8990436d914540a40ab24b6a77c0969695ed52f4a4874c5137ccf7045a7057", size = 4732362, upload-time = "2026-05-04T22:58:32.009Z" },
-    { url = "https://files.pythonhosted.org/packages/18/78/444fa04a77d0cb95f417dda20d450e13c56ba8e5220fc892a1658f44f882/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c18684a7f0cc9a3cb60328f496b8e3372def7c5d2df39ac267878b05565aaaae", size = 4819580, upload-time = "2026-05-04T22:58:34.254Z" },
-    { url = "https://files.pythonhosted.org/packages/38/85/ea67067c70a1fd4be2c63d35eeed82658023021affccc7b17705f8527dd2/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9be5aafa5736574f8f15f262adc81b2a9869e2cfe9014d52a44633905b40d52c", size = 4963283, upload-time = "2026-05-04T22:58:36.376Z" },
-    { url = "https://files.pythonhosted.org/packages/75/54/cc6d0f3deac3e81c7f847e8a189a12b6cdd65059b43dad25d4316abd849a/cryptography-48.0.0-cp314-cp314t-win32.whl", hash = "sha256:c17dfe85494deaeddc5ce251aebd1d60bbe6afc8b62071bb0b469431a000124f", size = 3270954, upload-time = "2026-05-04T22:58:38.791Z" },
-    { url = "https://files.pythonhosted.org/packages/49/67/cc947e288c0758a4e5473d1dcb743037ab7785541265a969240b8885441a/cryptography-48.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27241b1dc9962e056062a8eef1991d02c3a24569c95975bd2322a8a52c6e5e12", size = 3797313, upload-time = "2026-05-04T22:58:40.746Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/63/61d4a4e1c6b6bab6ce1e213cd36a24c415d90e76d78c5eb8577c5541d2e8/cryptography-48.0.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:58d00498e8933e4a194f3076aee1b4a97dfec1a6da444535755822fe5d8b0b86", size = 7983482, upload-time = "2026-05-04T22:58:43.769Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/ac/f5b5995b87770c693e2596559ffafe195b4033a57f14a82268a2842953f3/cryptography-48.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:614d0949f4790582d2cc25553abd09dd723025f0c0e7c67376a1d77196743d6e", size = 4683266, upload-time = "2026-05-04T22:58:46.064Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/c6/8b14f67e18338fbc4adb76f66c001f5c3610b3e2d1837f268f47a347dbbb/cryptography-48.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7ce4bfae76319a532a2dc68f82cc32f5676ee792a983187dac07183690e5c66f", size = 4696228, upload-time = "2026-05-04T22:58:48.22Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/73/f808fbae9514bd91b47875b003f13e284c8c6bdfd904b7944e803937eec1/cryptography-48.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2eb992bbd4661238c5a397594c83f5b4dc2bc5b848c365c8f991b6780efcc5c7", size = 4689097, upload-time = "2026-05-04T22:58:50.9Z" },
-    { url = "https://files.pythonhosted.org/packages/93/01/d86632d7d28db8ae83221995752eeb6639ffb374c2d22955648cf8d52797/cryptography-48.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:22a5cb272895dce158b2cacdfdc3debd299019659f42947dbdac6f32d68fe832", size = 5283582, upload-time = "2026-05-04T22:58:53.017Z" },
-    { url = "https://files.pythonhosted.org/packages/02/e1/50edc7a50334807cc4791fc4a0ce7468b4a1416d9138eab358bfc9a3d70b/cryptography-48.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2b4d59804e8408e2fea7d1fbaf218e5ec984325221db76e6a241a9abd6cdd95c", size = 4730479, upload-time = "2026-05-04T22:58:55.611Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/af/99a582b1b1641ff5911ac559beb45097cf79efd4ead4657f578ef1af2d47/cryptography-48.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:984a20b0f62a26f48a3396c72e4bc34c66e356d356bf370053066b3b6d54634a", size = 4326481, upload-time = "2026-05-04T22:58:57.607Z" },
-    { url = "https://files.pythonhosted.org/packages/90/ee/89aa26a06ef0a7d7611788ffd571a7c50e368cc6a4d5eef8b4884e866edb/cryptography-48.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5a5ed8fde7a1d09376ca0b40e68cd59c69fe23b1f9768bd5824f54681626032a", size = 4688713, upload-time = "2026-05-04T22:59:00.077Z" },
-    { url = "https://files.pythonhosted.org/packages/70/ba/bcb1b0bb7a33d4c7c0c4d4c7874b4a62ae4f56113a5f4baefa362dfb1f0f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:8cd666227ef7af430aa5914a9910e0ddd703e75f039cef0825cd0da71b6b711a", size = 5238165, upload-time = "2026-05-04T22:59:02.317Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/70/ca4003b1ce5ca3dc3186ada51908c8a9b9ff7d5cab83cc0d43ee14ec144f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9071196d81abc88b3516ac8cdfad32e2b66dd4a5393a8e68a961e9161ddc6239", size = 4729947, upload-time = "2026-05-04T22:59:05.255Z" },
-    { url = "https://files.pythonhosted.org/packages/44/a0/4ec7cf774207905aef1a8d11c3750d5a1db805eb380ee4e16df317870128/cryptography-48.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e2d54c8be6152856a36f0882ab231e70f8ec7f14e93cf87db8a2ed056bf160c", size = 4822059, upload-time = "2026-05-04T22:59:07.802Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/75/a2e55f99c16fcac7b5d6c1eb19ad8e00799854d6be5ca845f9259eae1681/cryptography-48.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a5da777e32ffed6f85a7b2b3f7c5cbc88c146bfcd0a1d7baf5fcc6c52ee35dd4", size = 4960575, upload-time = "2026-05-04T22:59:09.851Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/23/6e6f32143ab5d8b36ca848a502c4bcd477ae75b9e1677e3530d669062578/cryptography-48.0.0-cp39-abi3-win32.whl", hash = "sha256:77a2ccbbe917f6710e05ba9adaa25fb5075620bf3ea6fb751997875aff4ae4bd", size = 3279117, upload-time = "2026-05-04T22:59:12.019Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/9a/0fea98a70cf1749d41d738836f6349d97945f7c89433a259a6c2642eefeb/cryptography-48.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:16cd65b9330583e4619939b3a3843eec1e6e789744bb01e7c7e2e62e33c239c8", size = 3792100, upload-time = "2026-05-04T22:59:14.884Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/22/adf66990e63584a68dfb50c24f48a125c07b1699899381c8151e63ed458c/cryptography-49.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:966fe0e9c67490071f14c0d2b1cb2dfb3023c5ce39457343931415f08382f2db", size = 4032100, upload-time = "2026-06-12T20:02:32.143Z" },
+    { url = "https://files.pythonhosted.org/packages/09/41/3797cfaf69cae04a13ee78ebd83f0678d9c02b4779d21ce24445326f1a69/cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db", size = 4692978, upload-time = "2026-06-12T20:01:21.305Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/8b/43011f7ebe515a8aa20d61f290a326cd890c2e738e16e59eaff8d9c3a412/cryptography-49.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0e959b578856a3924bc0cbb710fc12c387b9412a951389f3ca61704a9e25f325", size = 4716422, upload-time = "2026-06-12T20:01:48.566Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/91/01ce7303a4579e6d3a6abef01bd322848e9ea7a219adcabc5048b9033571/cryptography-49.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:53ecee2e23f7169b6117e99fc8a944e5e50f79e69758a83b52a00cb98ab2b2d2", size = 4700503, upload-time = "2026-06-12T20:02:47.091Z" },
+    { url = "https://files.pythonhosted.org/packages/62/99/a2c95cf8293f07491e9e27c20cc4dcd18176d944e674679adeb1d0173fd6/cryptography-49.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2eda353d8a27bcbcaa4cbed18994a74ab4d19a2ca897db188ea269ab9b71419b", size = 5309779, upload-time = "2026-06-12T20:02:08.987Z" },
+    { url = "https://files.pythonhosted.org/packages/20/2c/0622f20ff02b2ef32558733443805dc82fd4c275be01b2d19d14676f3a1b/cryptography-49.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2afe9051da7ae7bd5905da5a949280c7d2bb75682e188f650a9d0f2756b834c6", size = 4749683, upload-time = "2026-06-12T20:02:03.335Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5b/c5246635d5fd3b64e0d45ae10e99fd32fe9676a79915ccfe5a61ba9af1a5/cryptography-49.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:0b82e28ee398a386f0807bba7884d30f25218855690f45115831bcce5d90822c", size = 4337874, upload-time = "2026-06-12T20:02:54.323Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/88/05563c7fe2e914e87d1a536d06fe83e66b4e1d95cb593e05aea375531da8/cryptography-49.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ccac2bfebc306b862133e3bb71f3f6ee8bb525240089b2d952e4144b3a6d5da7", size = 4700283, upload-time = "2026-06-12T20:01:34.822Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b6/d7696e4e890d6ae1469935164c9e5215c557671cb78d6e3f458ccceaa632/cryptography-49.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:d0527ce944105f257f605a827d6ebead966c752038b6e8656abb9c5edee6fc68", size = 5265844, upload-time = "2026-06-12T20:01:24.09Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/3c/f3ad17eecc1a57b0ba236dc01f90e783c51f4a2f35f64777cc4f47a184b2/cryptography-49.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:cbc77da8c523d5abd028635ba850a6966fcee2c82e2bf65a41d1d8afe0f98be9", size = 4749290, upload-time = "2026-06-12T20:01:30.848Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/01/339573cf1023163a400b0b5d16f6d507de413b9f60be6fd1b77feeaf6737/cryptography-49.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b87e65d263b3e5d3bb92a57e2a6638e2f31110fa7aa890c7b2dbba42248d0a3f", size = 4834612, upload-time = "2026-06-12T20:01:29.246Z" },
+    { url = "https://files.pythonhosted.org/packages/71/fd/577302e213a1be9468f92d1afef66fcf1ef83d516819d9992ca547f592bd/cryptography-49.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:66ec79c3904820572d7e987abdf304281f141d37ad9a489b8e97066e7b9b6459", size = 4980804, upload-time = "2026-06-12T20:01:42.853Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/09/f42b1d190c5ba75f72062a387f8030d1d75f6ab035788f1d9c4b01de6525/cryptography-49.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:e5dfc1e64de5677cec922ffa8da89c546d0415bf6efdf081842e5d44c84e1f0e", size = 3810026, upload-time = "2026-06-12T20:02:39.262Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/9e/db72b3ae7fc9cfad53e630e56c6ae83b9b6ff0bf3718ffb8012d20b3aabf/cryptography-49.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:73a205dce83953d131a4aa1e0fd917a2fd1c5b1eef251e9d7152efefcbf5caf7", size = 4013892, upload-time = "2026-06-12T20:02:10.735Z" },
+    { url = "https://files.pythonhosted.org/packages/86/12/c48a424f38db03027be9f7ed5c7dc5de9933dbee992865f98b13727a009d/cryptography-49.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:196ecd6a36e4e9aa10270393bb98d8df88fccee0bf1e5128b91ae4eb4375896d", size = 4678835, upload-time = "2026-06-12T20:02:48.743Z" },
+    { url = "https://files.pythonhosted.org/packages/68/28/8a3ad4653662c93fc44dc4e5d8fd374c25c42e07b34bbfbadf49cf57a5a8/cryptography-49.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7abcee80084cda3f7691f3eb1ce480d8df49cec637b429aa35986c1de71738aa", size = 4697239, upload-time = "2026-06-12T20:02:56.03Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b2/2193fc74f81aee4f9b62733133b73b5176718932ed8f2e4b03fa040480a6/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:4ae387c9cb68ea569ca17e490d66d8142b81c3cc814bf179974b7d146e490bbb", size = 4685593, upload-time = "2026-06-12T20:02:50.666Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f1/1d3eaa243bfc5de4a187b22aa8c048b3e4980bfbe830ac46e6bac2e66947/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:f37d847238971164fdbc68ade6f6574aecc9c0af714190e2083429ff68f4ce9d", size = 5289961, upload-time = "2026-06-12T20:01:46.468Z" },
+    { url = "https://files.pythonhosted.org/packages/58/39/2d51306721330c486495853eda1c567880ff036de15a14c4b74f399934af/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:c2bc30226390d60ea19d9f82b19db005fe0452154a23c1c410c12ea801e43561", size = 4731145, upload-time = "2026-06-12T20:02:16.832Z" },
+    { url = "https://files.pythonhosted.org/packages/17/50/983e838c7fd0d87fd8c969bcdd328edaf5f756e38df5281637424c155873/cryptography-49.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:07cab27cc7b7e0fd28e5e26bb9eeedde5c135c868b46de4a27845abe94af6122", size = 4321719, upload-time = "2026-06-12T20:02:52.611Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/f5/8f571d7e27c55bce9f76f026143bcb1e040a4233149ecca0bea5fa5dd5f7/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:b20133d204d2bb56ba047642199603876c872026ca53e79c35b83772ab2cc505", size = 4685209, upload-time = "2026-06-12T20:02:07.282Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/84/0e27016a6fc5a0886f797018b26aa42f40c09a82332bff77822a451deaaa/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:b970c6da94d5bb18629db453d14f2a1300f6bf59b61e9b82377931ef95504866", size = 5246285, upload-time = "2026-06-12T20:01:32.439Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2d/5e1fb307cb5931881516b464c98774b3f2c36b5d4bb9a2830253cf553cad/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d8ecde755e2e91bf773fc94e8c9d730cd7f2007004cb492263a794ec3899a1c8", size = 4730441, upload-time = "2026-06-12T20:02:01.469Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/c0/bff5a02ee731d207d6a1ed51732549d8c53d2bc8da1d10ec6f2844201d68/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e3fb64c420688e5319ae25113a354015abbd8dffbfbc41781a1ea66fc7622ac3", size = 4815869, upload-time = "2026-06-12T20:01:36.574Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/26/814681d14248d95d73d5c3eea0c39a94eb8302df966f670a2c60de90974b/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32703d93296f5c1f4b53349ad3a250c2cae0fdecd3a3dd5d47e616d8d616af27", size = 4960948, upload-time = "2026-06-12T20:02:18.688Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fe/93ecac273d3738939d023612ad12cca9a3740a5345d69fda04134c43fd96/cryptography-49.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:33cd0565932807baddb67b96dbee92f2c374b5c89dee09fd74079aeb8c8dba61", size = 3799153, upload-time = "2026-06-12T20:01:39.059Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2a/5bb823f5bedcf80718cea7fbc95ec5515cca3769633c4b01a32be7f30e7c/cryptography-49.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ec5e529fb80935c94fe7b729f9972b50e351a0e6b50aa294fd5cabb109fcc29a", size = 4025947, upload-time = "2026-06-12T20:01:25.745Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/df/40577043ca124e17012f408ddddaeb213b856336ac82ddb3bc915f39e29f/cryptography-49.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f78ff2c9ed8dc2d036b0f4d640e22522213d047c1b14e61205a7e55c80a494d4", size = 4692429, upload-time = "2026-06-12T20:01:53.628Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/99/2d13299eb3dd27b02dcfaafcc91d6b5cb3329f7cbd6d8f51921acd566c1a/cryptography-49.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:35b151772baff2c74cba7fa290ceaff4c3b11c0c881eb93eb5dbc05a7cfbba18", size = 4700968, upload-time = "2026-06-12T20:02:45.383Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/4d/9c0cd02f95e2602dd5e563da149ee0830abef3537be8b34dc56281ebe27a/cryptography-49.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0f21641cf4b30fca7aee061ced0ec7ad7b073518088b7c9969a297c0ae796c69", size = 4697758, upload-time = "2026-06-12T20:01:41.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/01/186c825898477d77e2324d5360fefe622ff1d8d1963ec0554e2cada8ec77/cryptography-49.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9e82dcc8e56052715fb18b2429e3bca4823b1629136a2084fc45a9a5cecb9b64", size = 5298863, upload-time = "2026-06-12T20:02:24.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/7b/62cbbab75d0659865bf0273790031544a0b16c8072d258f9428dcd8190dc/cryptography-49.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6f2debedf9ca60cf1d5bd466475638af5130f89965605cd818484d19987d3a21", size = 4735983, upload-time = "2026-06-12T20:01:50.14Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/72/3e798c064bc39e471008075d0f9bc9daf77a80879c092e4a8e170c585ed4/cryptography-49.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:8c25ceb16df5b9435f3f6a9829204985b0e0cbee3b48aacd432c7d2c850b44d9", size = 4334173, upload-time = "2026-06-12T20:01:44.743Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ee/6fca21d1ac73e06f8bef71940abfd4d2f6472b4bca284d770f32bd4086f6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:28d8b15e6275f12c8a207dc309dfa957903c927d08d0cc937ee3f63f200693cc", size = 4697298, upload-time = "2026-06-12T20:02:20.918Z" },
+    { url = "https://files.pythonhosted.org/packages/67/d0/a5fcd3515f0bae49a7b6d0413cc1bdccdcc1fc0047037a0d480642cdc5d6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6fc361c34fb6aac015ce19435876635e5c6d21db31998b0920f675f131e043b8", size = 5254338, upload-time = "2026-06-12T20:02:22.737Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/84/84fe36f19caf857d61cb7fc9c63035a47ffabd84ea12d1d393148efa3615/cryptography-49.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2400ef9c9e2299a25614eb1dea3db54a69b1349efd043bfac9c67630d136df36", size = 4735650, upload-time = "2026-06-12T20:02:41.389Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a0/db537264e234f7273a73ec020873d6d6b39dfd8a53db78b550ca8320440e/cryptography-49.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:67e1d20ad9ef3a563c59ef22e7a8a0b8210bd26604369ea4a30a7c66aefe504e", size = 4834820, upload-time = "2026-06-12T20:01:51.847Z" },
+    { url = "https://files.pythonhosted.org/packages/93/77/8df9eb486495979bccecd1062e2eaf435250e84437040295b57d09048b0b/cryptography-49.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:42b0684e0e40cf26122427802486f6d93aea593612603a94fbf260c7eb1e9c1b", size = 4967968, upload-time = "2026-06-12T20:02:12.524Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e6/f60198ea8d9dfa15fff9ed4ca02ce362f6eadd9ba757dcc50634c4257b63/cryptography-49.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:026ac7423e6fa66872d3bf889be5974507da3944f866f704fa200eadacd00001", size = 3785547, upload-time = "2026-06-12T20:02:26.847Z" },
 ]
 
 [[package]]
@@ -975,11 +985,11 @@ wheels = [
 
 [[package]]
 name = "distlib"
-version = "0.4.0"
+version = "0.4.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/02/bd72be9134d25ed783ecbbc38a539ffaefbf90c78418c7fb7229600dbac7/distlib-0.4.3.tar.gz", hash = "sha256:f152097224a0ae24be5a0f6bae1b9359af82133bce63f98a95f86cae1aede9ed", size = 615141, upload-time = "2026-06-12T08:04:52.847Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
+    { url = "https://files.pythonhosted.org/packages/02/08/9c41fb51ab5b43eb21674aff13df270e8ba6c4b29c8624e328dc7a9482af/distlib-0.4.3-py2.py3-none-any.whl", hash = "sha256:4b0ce306c966eb73bc3a7b6abad017c556dadd92c44701562cd528ac7fde4d5b", size = 470628, upload-time = "2026-06-12T08:04:50.506Z" },
 ]
 
 [[package]]
@@ -1124,7 +1134,7 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.136.1"
+version = "0.136.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -1133,18 +1143,18 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5d/45/c130091c2dfa061bbfe3150f2a5091ef1adf149f2a8d2ae769ecaf6e99a2/fastapi-0.136.1.tar.gz", hash = "sha256:7af665ad7acfa0a3baf8983d393b6b471b9da10ede59c60045f49fbc89a0fa7f", size = 397448, upload-time = "2026-04-23T16:49:44.046Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/2d/ff8d91d7b564d464629a0fd50a4489c97fcb836ac230bf3a7269232a9b1f/fastapi-0.136.3.tar.gz", hash = "sha256:e487fae93ad408e6f47641ee4dfe389864fd7bec92e547ea8498fc13f43e83ab", size = 396410, upload-time = "2026-05-23T18:53:15.192Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5a/ff/2e4eca3ade2c22fe1dea7043b8ee9dabe47753349eb1b56a202de8af6349/fastapi-0.136.1-py3-none-any.whl", hash = "sha256:a6e9d7eeada96c93a4d69cb03836b44fa34e2854accb7244a1ece36cd4781c3f", size = 117683, upload-time = "2026-04-23T16:49:42.437Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/82/45359b62a067409bd929ae8a56b8ed13e5a8c8a61194b3c236920999ab83/fastapi-0.136.3-py3-none-any.whl", hash = "sha256:3d2a69bdf04b7e9f3afa292c3bc7a98816bbfafa10bc9b45f3f3700d2f761620", size = 117481, upload-time = "2026-05-23T18:53:16.924Z" },
 ]
 
 [[package]]
 name = "filelock"
-version = "3.29.0"
+version = "3.29.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b5/fe/997687a931ab51049acce6fa1f23e8f01216374ea81374ddee763c493db5/filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90", size = 57571, upload-time = "2026-04-19T15:39:10.068Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/f5/3557bf28e0f1943e4849154c821533706e6dea010f96fb6aa0b6949037d1/filelock-3.29.3.tar.gz", hash = "sha256:7fc1b3f39cf172fd8203812043c57b8a65aef9969f38b6704f628b881f761a84", size = 61956, upload-time = "2026-06-10T17:37:11.832Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258", size = 39812, upload-time = "2026-04-19T15:39:08.752Z" },
+    { url = "https://files.pythonhosted.org/packages/81/8f/b61d427c4f49a8bdadc93f4e7e74df8a6df6f77ee6e26bf0df53d3925363/filelock-3.29.3-py3-none-any.whl", hash = "sha256:e58333029cc9b925f39aad59b1d8f0a1ad836af4e60d7217f4a4dba87461261d", size = 42324, upload-time = "2026-06-10T17:37:10.37Z" },
 ]
 
 [[package]]
@@ -1281,23 +1291,23 @@ wheels = [
 
 [[package]]
 name = "grpcio"
-version = "1.80.0"
+version = "1.81.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b7/48/af6173dbca4454f4637a4678b67f52ca7e0c1ed7d5894d89d434fecede05/grpcio-1.80.0.tar.gz", hash = "sha256:29aca15edd0688c22ba01d7cc01cb000d72b2033f4a3c72a81a19b56fd143257", size = 12978905, upload-time = "2026-03-30T08:49:10.502Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/b5/1ff353970a87eda4c98251e34d2dfd214abd4982dc89119c9252a2a482d2/grpcio-1.81.1.tar.gz", hash = "sha256:6fa10a767143a5e82e8eaab53918af0cd8909a57a27f8cb2288b80a613ac671b", size = 13026582, upload-time = "2026-06-11T12:46:51.673Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c5/6d/e65307ce20f5a09244ba9e9d8476e99fb039de7154f37fb85f26978b59c3/grpcio-1.80.0-cp314-cp314-linux_armv7l.whl", hash = "sha256:3d4147a97c8344d065d01bbf8b6acec2cf86fb0400d40696c8bdad34a64ffc0e", size = 6017376, upload-time = "2026-03-30T08:48:10.005Z" },
-    { url = "https://files.pythonhosted.org/packages/69/10/9cef5d9650c72625a699c549940f0abb3c4bfdb5ed45a5ce431f92f31806/grpcio-1.80.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d8e11f167935b3eb089ac9038e1a063e6d7dbe995c0bb4a661e614583352e76f", size = 12018133, upload-time = "2026-03-30T08:48:12.927Z" },
-    { url = "https://files.pythonhosted.org/packages/04/82/983aabaad82ba26113caceeb9091706a0696b25da004fe3defb5b346e15b/grpcio-1.80.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f14b618fc30de822681ee986cfdcc2d9327229dc4c98aed16896761cacd468b9", size = 6574748, upload-time = "2026-03-30T08:48:16.386Z" },
-    { url = "https://files.pythonhosted.org/packages/07/d7/031666ef155aa0bf399ed7e19439656c38bbd143779ae0861b038ce82abd/grpcio-1.80.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:4ed39fbdcf9b87370f6e8df4e39ca7b38b3e5e9d1b0013c7b6be9639d6578d14", size = 7277711, upload-time = "2026-03-30T08:48:19.627Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/43/f437a78f7f4f1d311804189e8f11fb311a01049b2e08557c1068d470cb2e/grpcio-1.80.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2dcc70e9f0ba987526e8e8603a610fb4f460e42899e74e7a518bf3c68fe1bf05", size = 6785372, upload-time = "2026-03-30T08:48:22.373Z" },
-    { url = "https://files.pythonhosted.org/packages/93/3d/f6558e9c6296cb4227faa5c43c54a34c68d32654b829f53288313d16a86e/grpcio-1.80.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:448c884b668b868562b1bda833c5fce6272d26e1926ec46747cda05741d302c1", size = 7395268, upload-time = "2026-03-30T08:48:25.638Z" },
-    { url = "https://files.pythonhosted.org/packages/06/21/0fdd77e84720b08843c371a2efa6f2e19dbebf56adc72df73d891f5506f0/grpcio-1.80.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a1dc80fe55685b4a543555e6eef975303b36c8db1023b1599b094b92aa77965f", size = 8392000, upload-time = "2026-03-30T08:48:28.974Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/68/67f4947ed55d2e69f2cc199ab9fd85e0a0034d813bbeef84df6d2ba4d4b7/grpcio-1.80.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:31b9ac4ad1aa28ffee5503821fafd09e4da0a261ce1c1281c6c8da0423c83b6e", size = 7828477, upload-time = "2026-03-30T08:48:32.054Z" },
-    { url = "https://files.pythonhosted.org/packages/44/b6/8d4096691b2e385e8271911a0de4f35f0a6c7d05aff7098e296c3de86939/grpcio-1.80.0-cp314-cp314-win32.whl", hash = "sha256:367ce30ba67d05e0592470428f0ec1c31714cab9ef19b8f2e37be1f4c7d32fae", size = 4218563, upload-time = "2026-03-30T08:48:34.538Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/8c/bbe6baf2557262834f2070cf668515fa308b2d38a4bbf771f8f7872a7036/grpcio-1.80.0-cp314-cp314-win_amd64.whl", hash = "sha256:3b01e1f5464c583d2f567b2e46ff0d516ef979978f72091fd81f5ab7fa6e2e7f", size = 5019457, upload-time = "2026-03-30T08:48:37.308Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/58/19414622b1bf6981bc9c05a365bd548e71876c89000083b3af489251e9c0/grpcio-1.81.1-cp314-cp314-linux_armv7l.whl", hash = "sha256:506f48f2f9c29b143fca3dad7b0d518c188b6c9648c75a2ae6e2d9f2c13a060b", size = 6055336, upload-time = "2026-06-11T12:46:20.557Z" },
+    { url = "https://files.pythonhosted.org/packages/32/f1/2ec88adb92b0eba970dd0e0e7dd086341daa3c75eba4f735f9e44bf684b0/grpcio-1.81.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d865db4a6318e1c1bea83292e0ed231090538fc4ca45425b0f0480eb338bbc6e", size = 12056279, upload-time = "2026-06-11T12:46:24.255Z" },
+    { url = "https://files.pythonhosted.org/packages/41/36/e8c5f8c6ec71de73733695ebc809e98b178b534ec6d8eaa31a7ebab4ad4c/grpcio-1.81.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e2aa72e3ce1770317ef534f63d397b55e130725f5149bd36077c3b539019db27", size = 6608225, upload-time = "2026-06-11T12:46:27.601Z" },
+    { url = "https://files.pythonhosted.org/packages/30/22/96fc577a845ab093326d9ab1adb874bd4936c8cf98ac8ed2f3db13a0a2fb/grpcio-1.81.1-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:0490c30c261eded63f3f354979f9dc4502a9fb944cccb60cd9dc85f5a7349854", size = 7306576, upload-time = "2026-06-11T12:46:30.514Z" },
+    { url = "https://files.pythonhosted.org/packages/76/7b/61dab5d5969f28d97fb1009cead1df0a5cd987d3315e1b37f18a4449f8bc/grpcio-1.81.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:410482da976329fe5f4067270401b12cf2bd552ff8020f054ecfaddb5475f9d6", size = 6812165, upload-time = "2026-06-11T12:46:33.699Z" },
+    { url = "https://files.pythonhosted.org/packages/82/78/6e501929d4f5f96462fd82fd9f0f06e5f9612207582b862868d68757b27d/grpcio-1.81.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e3657301562ac3cb8018d30d0d3ebfa39932239f7b5703422057ef14b69949f5", size = 7422962, upload-time = "2026-06-11T12:46:36.511Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/7e/f2157589e66daa78ebb3165942d05a08bdea93b9d11c2bc1e172aef89685/grpcio-1.81.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:24c8e57504c8f45b237e40b99262d181071e5099a07053695b75d97bb53053a0", size = 8408176, upload-time = "2026-06-11T12:46:39.803Z" },
+    { url = "https://files.pythonhosted.org/packages/da/df/c6717fef716e00d235ffb96123baf6dce76d6004f6233fa767c502861460/grpcio-1.81.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b427c19380991a4eaab2f6144b64b99b412043314c6bf4ab544f97bb31ee4190", size = 7846681, upload-time = "2026-06-11T12:46:43.013Z" },
+    { url = "https://files.pythonhosted.org/packages/36/84/3502e9f210a6a5c4438c8aca3f88edd2e04f6a27f3d41b26cf0a0024b096/grpcio-1.81.1-cp314-cp314-win32.whl", hash = "sha256:61233fe8951e5c85dff81c2458b6528624760166946b5b47ea150a589168411f", size = 4264615, upload-time = "2026-06-11T12:46:45.741Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/b0/4af731ff7492c68a96e4c71bfd0f4590acde92b31c6fe4894e6465c10ff6/grpcio-1.81.1-cp314-cp314-win_amd64.whl", hash = "sha256:3768a5ff1b2125e6f552e561b6b2dca0e64982d8949689b4df145cf8b98d7821", size = 5070275, upload-time = "2026-06-11T12:46:48.486Z" },
 ]
 
 [[package]]
@@ -1345,17 +1355,24 @@ wheels = [
 
 [[package]]
 name = "httptools"
-version = "0.7.1"
+version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b5/46/120a669232c7bdedb9d52d4aeae7e6c7dfe151e99dc70802e2fc7a5e1993/httptools-0.7.1.tar.gz", hash = "sha256:abd72556974f8e7c74a259655924a717a2365b236c882c3f6f8a45fe94703ac9", size = 258961, upload-time = "2025-10-10T03:55:08.559Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/e5/d471fcb0e14523fe1c3f4ba58ca52480e7bd70ad7109a3846bc75892f7fb/httptools-0.8.0.tar.gz", hash = "sha256:6b2a32f18d97e16e90827d7a819ffa8dbd8cc245fc4e1fa9d1095b54ef4bd999", size = 271342, upload-time = "2026-05-25T22:17:48.841Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/34/50/9d095fcbb6de2d523e027a2f304d4551855c2f46e0b82befd718b8b20056/httptools-0.7.1-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:c08fe65728b8d70b6923ce31e3956f859d5e1e8548e6f22ec520a962c6757270", size = 203619, upload-time = "2025-10-10T03:54:54.321Z" },
-    { url = "https://files.pythonhosted.org/packages/07/f0/89720dc5139ae54b03f861b5e2c55a37dba9a5da7d51e1e824a1f343627f/httptools-0.7.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:7aea2e3c3953521c3c51106ee11487a910d45586e351202474d45472db7d72d3", size = 108714, upload-time = "2025-10-10T03:54:55.163Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/cb/eea88506f191fb552c11787c23f9a405f4c7b0c5799bf73f2249cd4f5228/httptools-0.7.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0e68b8582f4ea9166be62926077a3334064d422cf08ab87d8b74664f8e9058e1", size = 472909, upload-time = "2025-10-10T03:54:56.056Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/4a/a548bdfae6369c0d078bab5769f7b66f17f1bfaa6fa28f81d6be6959066b/httptools-0.7.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:df091cf961a3be783d6aebae963cc9b71e00d57fa6f149025075217bc6a55a7b", size = 470831, upload-time = "2025-10-10T03:54:57.219Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/31/14df99e1c43bd132eec921c2e7e11cda7852f65619bc0fc5bdc2d0cb126c/httptools-0.7.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:f084813239e1eb403ddacd06a30de3d3e09a9b76e7894dcda2b22f8a726e9c60", size = 452631, upload-time = "2025-10-10T03:54:58.219Z" },
-    { url = "https://files.pythonhosted.org/packages/22/d2/b7e131f7be8d854d48cb6d048113c30f9a46dca0c9a8b08fcb3fcd588cdc/httptools-0.7.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7347714368fb2b335e9063bc2b96f2f87a9ceffcd9758ac295f8bbcd3ffbc0ca", size = 452910, upload-time = "2025-10-10T03:54:59.366Z" },
-    { url = "https://files.pythonhosted.org/packages/53/cf/878f3b91e4e6e011eff6d1fa9ca39f7eb17d19c9d7971b04873734112f30/httptools-0.7.1-cp314-cp314-win_amd64.whl", hash = "sha256:cfabda2a5bb85aa2a904ce06d974a3f30fb36cc63d7feaddec05d2050acede96", size = 88205, upload-time = "2025-10-10T03:55:00.389Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/12/fa3fbf5f9517b273edea2dc982aa82a8c634091e67c590792b729017bc6f/httptools-0.8.0-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:de242a49b5d18e0a8776e654e9f6bf6d89f3875a5c35b425a0e7ce940feb3fd6", size = 206183, upload-time = "2026-05-25T22:17:24.004Z" },
+    { url = "https://files.pythonhosted.org/packages/30/fc/5e7c4cb443370f2090a3aba0453a07384d29ff66b7435bb90e77e1037599/httptools-0.8.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:159e9ab5f701ccd42e555a12f1ad8ff69702910fc1c996cf2bb66e5fcb7a231b", size = 112079, upload-time = "2026-05-25T22:17:25.216Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/53/771bd891eb0f236f32145d6a1775777ec85745f3cc983a1f23d1a3b8ddfe/httptools-0.8.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c4a9f1707e4823d54dfec6c33fa3697d302aed536ed352a7ebb5a061ddb869d0", size = 481596, upload-time = "2026-05-25T22:17:26.186Z" },
+    { url = "https://files.pythonhosted.org/packages/62/42/94e15bc68ce3d423243c45d7f1b0c7561f13844f97dc52ae23182fb65628/httptools-0.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d76ad7b951387e3632c8716a9bb03ac5b45c5f16119aa409db0459520887944e", size = 480865, upload-time = "2026-05-25T22:17:27.542Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/7c/fe2980fc03723272e30f135b62360b075f513dfe7cc73aef36c7f04012bd/httptools-0.8.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a3b7387147361c3fd47a0bde763c5c91b5b4cd4dc9989b8ece84ff436c99843b", size = 463189, upload-time = "2026-05-25T22:17:28.546Z" },
+    { url = "https://files.pythonhosted.org/packages/15/1b/47fc5fff68acd1bfa20b4734059c9a06cadb88119dcd5258b5b0d21d91c8/httptools-0.8.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f256d6ce930c52ca1cb2a960b7da03548c454e7d28b06059ad41bfe789036ce0", size = 466610, upload-time = "2026-05-25T22:17:29.816Z" },
+    { url = "https://files.pythonhosted.org/packages/60/bd/07b13c93ffd9bec9546e0d43f8e19378dd696dbd278511406bc07371ef1f/httptools-0.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:19d1ee275bb59ba2643ba9a3a1e51cc0c788caf2b8df506368e03f56fdd08527", size = 92705, upload-time = "2026-05-25T22:17:31.133Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/c4/121648f68ce066d7bd762d6b6d97e620847642d38d54f3d90ff11d947629/httptools-0.8.0-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:de1ed58a974e75d56560acc7e7fed01a454994429456f65209789992e41f2568", size = 215023, upload-time = "2026-05-25T22:17:32.401Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/b0/312a062ae741ae3e8baa8c8bf20be81b2e67337b259ab4349bebc7b6142e/httptools-0.8.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:e93c227b595c6926c1acee96891dd9da4be338cfbe82e5cd3bb9d8dd7dc4ac0b", size = 117405, upload-time = "2026-05-25T22:17:33.742Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/37/fccd705f795386bb05bf413012fecff2a33e5aa8c2f069096de3e9fd8702/httptools-0.8.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2a021c3a8e65cc125390d72f59b968afca3bdcaff25bd67965e0a055a14946ca", size = 558497, upload-time = "2026-05-25T22:17:34.732Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/39/f172e8003576de35f5ba77ff417cf0e34429d35dc014deef15afa337a72c/httptools-0.8.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:48774d39cbb70e2b1f71f88852a3087ae1d3a1eb80482bb48c13067ab080c14f", size = 571585, upload-time = "2026-05-25T22:17:35.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/b9/f5564760af99f3dbbf3f9104dc00e5da27e96cf433c6bdcf77617f70bf3f/httptools-0.8.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:88eead8ec8680a9f146c655bc88445a325bd7921cfd8194c7337e9467282427d", size = 543297, upload-time = "2026-05-25T22:17:37.08Z" },
+    { url = "https://files.pythonhosted.org/packages/99/67/8d9f2c313618e161b82f3873188e7196126da1d6e29688df40eb3997c77a/httptools-0.8.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2c032fa028f46871ec7e1fc59fc15e8023eab3e6bbe6ece786a1611719a5d081", size = 539535, upload-time = "2026-05-25T22:17:38.032Z" },
+    { url = "https://files.pythonhosted.org/packages/48/63/b906c01e53f50d432c0defe43ce52764a111dc1bdd028bafbeb54dcfd008/httptools-0.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:384c17174464c8e873398b7af24f0b1f44d992c820328413951a625323155d77", size = 108209, upload-time = "2026-05-25T22:17:39.473Z" },
 ]
 
 [[package]]
@@ -1503,11 +1520,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.15"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -1685,28 +1702,32 @@ wheels = [
 
 [[package]]
 name = "msgpack"
-version = "1.1.2"
+version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4d/f2/bfb55a6236ed8725a96b0aa3acbd0ec17588e6a2c3b62a93eb513ed8783f/msgpack-1.1.2.tar.gz", hash = "sha256:3b60763c1373dd60f398488069bcdc703cd08a711477b5d480eecc9f9626f47e", size = 173581, upload-time = "2025-10-08T09:15:56.596Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/23/6139781ca7aadf656fa8e384fa84693ffb13f299e6931b6526427fe5e297/msgpack-1.2.0.tar.gz", hash = "sha256:8e17af38197bf58e7e819041678f6178f4491493f5b8c8580414f40f7c2c3c41", size = 183017, upload-time = "2026-06-11T04:16:10.775Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/22/71/201105712d0a2ff07b7873ed3c220292fb2ea5120603c00c4b634bcdafb3/msgpack-1.1.2-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e23ce8d5f7aa6ea6d2a2b326b4ba46c985dbb204523759984430db7114f8aa00", size = 81127, upload-time = "2025-10-08T09:15:24.408Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/9f/38ff9e57a2eade7bf9dfee5eae17f39fc0e998658050279cbb14d97d36d9/msgpack-1.1.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6c15b7d74c939ebe620dd8e559384be806204d73b4f9356320632d783d1f7939", size = 84981, upload-time = "2025-10-08T09:15:25.812Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/a9/3536e385167b88c2cc8f4424c49e28d49a6fc35206d4a8060f136e71f94c/msgpack-1.1.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:99e2cb7b9031568a2a5c73aa077180f93dd2e95b4f8d3b8e14a73ae94a9e667e", size = 411885, upload-time = "2025-10-08T09:15:27.22Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/40/dc34d1a8d5f1e51fc64640b62b191684da52ca469da9cd74e84936ffa4a6/msgpack-1.1.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:180759d89a057eab503cf62eeec0aa61c4ea1200dee709f3a8e9397dbb3b6931", size = 419658, upload-time = "2025-10-08T09:15:28.4Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/ef/2b92e286366500a09a67e03496ee8b8ba00562797a52f3c117aa2b29514b/msgpack-1.1.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:04fb995247a6e83830b62f0b07bf36540c213f6eac8e851166d8d86d83cbd014", size = 403290, upload-time = "2025-10-08T09:15:29.764Z" },
-    { url = "https://files.pythonhosted.org/packages/78/90/e0ea7990abea5764e4655b8177aa7c63cdfa89945b6e7641055800f6c16b/msgpack-1.1.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8e22ab046fa7ede9e36eeb4cfad44d46450f37bb05d5ec482b02868f451c95e2", size = 415234, upload-time = "2025-10-08T09:15:31.022Z" },
-    { url = "https://files.pythonhosted.org/packages/72/4e/9390aed5db983a2310818cd7d3ec0aecad45e1f7007e0cda79c79507bb0d/msgpack-1.1.2-cp314-cp314-win32.whl", hash = "sha256:80a0ff7d4abf5fecb995fcf235d4064b9a9a8a40a3ab80999e6ac1e30b702717", size = 66391, upload-time = "2025-10-08T09:15:32.265Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/f1/abd09c2ae91228c5f3998dbd7f41353def9eac64253de3c8105efa2082f7/msgpack-1.1.2-cp314-cp314-win_amd64.whl", hash = "sha256:9ade919fac6a3e7260b7f64cea89df6bec59104987cbea34d34a2fa15d74310b", size = 73787, upload-time = "2025-10-08T09:15:33.219Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/b0/9d9f667ab48b16ad4115c1935d94023b82b3198064cb84a123e97f7466c1/msgpack-1.1.2-cp314-cp314-win_arm64.whl", hash = "sha256:59415c6076b1e30e563eb732e23b994a61c159cec44deaf584e5cc1dd662f2af", size = 66453, upload-time = "2025-10-08T09:15:34.225Z" },
-    { url = "https://files.pythonhosted.org/packages/16/67/93f80545eb1792b61a217fa7f06d5e5cb9e0055bed867f43e2b8e012e137/msgpack-1.1.2-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:897c478140877e5307760b0ea66e0932738879e7aa68144d9b78ea4c8302a84a", size = 85264, upload-time = "2025-10-08T09:15:35.61Z" },
-    { url = "https://files.pythonhosted.org/packages/87/1c/33c8a24959cf193966ef11a6f6a2995a65eb066bd681fd085afd519a57ce/msgpack-1.1.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a668204fa43e6d02f89dbe79a30b0d67238d9ec4c5bd8a940fc3a004a47b721b", size = 89076, upload-time = "2025-10-08T09:15:36.619Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/6b/62e85ff7193663fbea5c0254ef32f0c77134b4059f8da89b958beb7696f3/msgpack-1.1.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5559d03930d3aa0f3aacb4c42c776af1a2ace2611871c84a75afe436695e6245", size = 435242, upload-time = "2025-10-08T09:15:37.647Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/47/5c74ecb4cc277cf09f64e913947871682ffa82b3b93c8dad68083112f412/msgpack-1.1.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:70c5a7a9fea7f036b716191c29047374c10721c389c21e9ffafad04df8c52c90", size = 432509, upload-time = "2025-10-08T09:15:38.794Z" },
-    { url = "https://files.pythonhosted.org/packages/24/a4/e98ccdb56dc4e98c929a3f150de1799831c0a800583cde9fa022fa90602d/msgpack-1.1.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:f2cb069d8b981abc72b41aea1c580ce92d57c673ec61af4c500153a626cb9e20", size = 415957, upload-time = "2025-10-08T09:15:40.238Z" },
-    { url = "https://files.pythonhosted.org/packages/da/28/6951f7fb67bc0a4e184a6b38ab71a92d9ba58080b27a77d3e2fb0be5998f/msgpack-1.1.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:d62ce1f483f355f61adb5433ebfd8868c5f078d1a52d042b0a998682b4fa8c27", size = 422910, upload-time = "2025-10-08T09:15:41.505Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/03/42106dcded51f0a0b5284d3ce30a671e7bd3f7318d122b2ead66ad289fed/msgpack-1.1.2-cp314-cp314t-win32.whl", hash = "sha256:1d1418482b1ee984625d88aa9585db570180c286d942da463533b238b98b812b", size = 75197, upload-time = "2025-10-08T09:15:42.954Z" },
-    { url = "https://files.pythonhosted.org/packages/15/86/d0071e94987f8db59d4eeb386ddc64d0bb9b10820a8d82bcd3e53eeb2da6/msgpack-1.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:5a46bf7e831d09470ad92dff02b8b1ac92175ca36b087f904a0519857c6be3ff", size = 85772, upload-time = "2025-10-08T09:15:43.954Z" },
-    { url = "https://files.pythonhosted.org/packages/81/f2/08ace4142eb281c12701fc3b93a10795e4d4dc7f753911d836675050f886/msgpack-1.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:d99ef64f349d5ec3293688e91486c5fdb925ed03807f64d98d205d2713c60b46", size = 70868, upload-time = "2025-10-08T09:15:44.959Z" },
+    { url = "https://files.pythonhosted.org/packages/35/3d/a7e3cdafa8c0cf36c81e2fa848ec4d30cf089459af45b390ad03f9ce6f49/msgpack-1.2.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f854fa1a8b55d75d82ef9a905d9cdbeffdf7897c088f6020bd221867da5e56a5", size = 83032, upload-time = "2026-06-11T04:15:39.38Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/aa/53ddfba0e347cc4b484e95f629c5850b9e800ca8390c91ffc604407acf87/msgpack-1.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e90df581f80f53b372d5d9d9349078d729851a3a0d0bd74f53ccb598d01e45b8", size = 82600, upload-time = "2026-06-11T04:15:40.609Z" },
+    { url = "https://files.pythonhosted.org/packages/59/fd/e64c2c776e6dbad0af3c963fe0c0dd1ee1ba09efac478b233ab1db41868f/msgpack-1.2.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b276ed50d8ac75d1f134a433ae79af8557d0fa25ee5b4737da533dfc2ce382e8", size = 404342, upload-time = "2026-06-11T04:15:41.87Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/60/fb9a08e6ccba882dfd370a5837fe3a07572938fdfe954f0f17fdf3e574b9/msgpack-1.2.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:544d972459c92aa32e63b800d07c2d9cf2734a3be29cee3a0b478a622850e9f5", size = 412351, upload-time = "2026-06-11T04:15:43.253Z" },
+    { url = "https://files.pythonhosted.org/packages/37/4d/df5c575c274fedc68ac9c6c61d045161899efad2afcdc25138efa7edde69/msgpack-1.2.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a070147cc2cf6b8a891734e0f5c8fe8f70ed8739ab30ba140b058005a6e86af4", size = 373331, upload-time = "2026-06-11T04:15:44.754Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/a4/c8b98f8191e985ed2003d87664ce3c95cca41db5d0cf6bf4f54327d32ec8/msgpack-1.2.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7685e23b0f51745a751629c31713fbefdef8896b31b2bb38299dfa4ae6c0740c", size = 394654, upload-time = "2026-06-11T04:15:46.423Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/49/76f036720a602ea24428cfec5ec806f2487c0380b1bff0a2aa3094e15f87/msgpack-1.2.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:b9204daeee8d91a7ae5acf2d2a8e3983be9a3025f38aa21bfaefbd7eea84a7dc", size = 370624, upload-time = "2026-06-11T04:15:48.062Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/38/40af3d29232833705a43b0fce0d07425cc280a7b92ab2b29932425b40df4/msgpack-1.2.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:bfc057248609742ebbabf6bcd27fea4fd99c4980584e613c168c9b002318298f", size = 408038, upload-time = "2026-06-11T04:15:49.669Z" },
+    { url = "https://files.pythonhosted.org/packages/30/b2/f140ca450524dff4d8d0eb81eb9ed75f8f3e0b1f12e49c5b01617cfa0b1c/msgpack-1.2.0-cp314-cp314-win32.whl", hash = "sha256:a3faa7edf2388337ae849239878e92f0298b4dab4488e4f1834062f9d0c410c9", size = 65823, upload-time = "2026-06-11T04:15:51.062Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/13/6517bf966b841c7675ded30701a068ce141f3e698a27aaa35c702d8e078b/msgpack-1.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:1a3effc392a57744e4681e55d05f97d5ee7b598747d718340a9b4b8a970c40e1", size = 72484, upload-time = "2026-06-11T04:15:52.289Z" },
+    { url = "https://files.pythonhosted.org/packages/45/8c/1d948420fdaa24de4efdb8012a6a5bebe09c82ee002b8c2ca745e9917f1f/msgpack-1.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:56a318f7df6bec7b40928d6b0519961f20a510d8baabf6baa393a70444588f0a", size = 66657, upload-time = "2026-06-11T04:15:53.583Z" },
+    { url = "https://files.pythonhosted.org/packages/39/16/1674faa1b7bddc19e79b465fd8e88e2cf4e3f7cae90723740701e8541068/msgpack-1.2.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:afa4a65ab2097795e771a74a3a81ea49534aaeba874eaf426a3332268e045ae6", size = 86093, upload-time = "2026-06-11T04:15:54.98Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/24/f241bcfdd9e96b2246289357c5a5e5a496189fd41c5844bee802c116aac7/msgpack-1.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:409550770632bb28daa70a11d0ed5763f7db38f40b06f7db9f11dd2794d01102", size = 86372, upload-time = "2026-06-11T04:15:56.381Z" },
+    { url = "https://files.pythonhosted.org/packages/94/c9/57f8ab98a1b21808c27b6dd6029053e0a796ffbb9b371e460dbe997011a9/msgpack-1.2.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bf47e3cd11ce044965a9736a322afdd390b31ed602d1c1b10211d1a841f1d587", size = 428207, upload-time = "2026-06-11T04:15:57.739Z" },
+    { url = "https://files.pythonhosted.org/packages/17/6b/4fd4aa739f131ded751ca7167c8ee87d2aab32506ebbeea893b60b51d343/msgpack-1.2.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:204bc9f5d6e59c1718c0a4a84fc8ff71b5b4562faac257c1a68bca611ecf9b72", size = 426082, upload-time = "2026-06-11T04:15:59.356Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/00/db88e9a08fcd6513decaad06cbd5c168142bc3e662fb2f1aca3a563b7aa1/msgpack-1.2.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:610154307b27267266368bc1d1c7bb8aeb71da7be9356d403cb2442d9e6399f5", size = 378355, upload-time = "2026-06-11T04:16:00.916Z" },
+    { url = "https://files.pythonhosted.org/packages/54/84/eee4dd703d7a600cf46159d621c070b0b9468cf3dbade4ea8272bf5232a4/msgpack-1.2.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6799f157bb63e79f11e2e590cfdb28423fc18dd60c270c3914b5b4586ae36f7e", size = 410848, upload-time = "2026-06-11T04:16:02.745Z" },
+    { url = "https://files.pythonhosted.org/packages/12/0a/195e2c549fd4631eb7f157d016ff15a10c4c1cf82b6d0a9b1edaef5174b1/msgpack-1.2.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:72bd844902cf0a5ac3af2ef742f253cd0b1e5bcd184f49b4fb9a6a1f7bf305e8", size = 376152, upload-time = "2026-06-11T04:16:04.041Z" },
+    { url = "https://files.pythonhosted.org/packages/45/9b/bdd143fa79baec411dc658f5686fed680a18b36fcea5fccb6af1b8c7d832/msgpack-1.2.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3c0bd450f78d0d81722c80da6cdbf674a856967870a9db2f6c4debc4d8b3c67c", size = 417061, upload-time = "2026-06-11T04:16:05.63Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/ce/011ffcd8b919f55196ec53f12ae162e21c879d95afba226894314ff62c07/msgpack-1.2.0-cp314-cp314t-win32.whl", hash = "sha256:378caf74c4c718dfc17590ce68a6d710ed398ff6fcf08237de23b77755730b55", size = 70782, upload-time = "2026-06-11T04:16:07.105Z" },
+    { url = "https://files.pythonhosted.org/packages/57/a8/9b8791ca96b1be6b9f659c718271e2cb7f99f73f58aad2dd0b30f750f6c0/msgpack-1.2.0-cp314-cp314t-win_amd64.whl", hash = "sha256:553b42598165c4dd3235994fd6e4b0dfb1ce5f3fd33d94ba9609442643015f38", size = 77899, upload-time = "2026-06-11T04:16:08.353Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/04/3fa2dffb87bf598696b86bde7cd642d0a7590520c3fa24cd19611dfebeb7/msgpack-1.2.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2825bb1da548d214ab8a810906b7dd69a10f3838b615a2cc46e5172d3cb44f6e", size = 71004, upload-time = "2026-06-11T04:16:09.556Z" },
 ]
 
 [[package]]
@@ -1774,11 +1795,11 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-acm"
-version = "1.43.0"
+version = "1.43.29"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/40/ab/54583b89beb126a6eb180f236c4028306fb5db00ccd99827cc26bfba90f1/mypy_boto3_acm-1.43.0.tar.gz", hash = "sha256:1862893f6c97e27ea7d3e2bf2e649235ba5e6fd7bb6f5f782fda60ef23b75809", size = 21832, upload-time = "2026-04-29T22:56:45.862Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/10/0f/578ed875d3f04a3b031eda28060394cc9d45bb9585750a56e900b7e72d8a/mypy_boto3_acm-1.43.29.tar.gz", hash = "sha256:bd9767ab8f2686ffbc30614bf97dd0e71ed3513f091f5aca363bcad6d968d20f", size = 21852, upload-time = "2026-06-12T20:09:04.165Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/aa/e1/1cdee227eb79ec2581d378178827c9b244faf6cab71329b81f502ad756c9/mypy_boto3_acm-1.43.0-py3-none-any.whl", hash = "sha256:dfcc3ec5fac5a4a1a2f9c59ccbae39659d3fc661783f235baa2746beacd9a042", size = 31311, upload-time = "2026-04-29T22:56:44.277Z" },
+    { url = "https://files.pythonhosted.org/packages/43/d4/a6e6f592365d8c2109207c8d6fd3dee9af05ddb7163c2cf9dc28349fd952/mypy_boto3_acm-1.43.29-py3-none-any.whl", hash = "sha256:d10e10b8bb219ee5f0ca5092c225f39356894c293b45ad9c5fe833a13f065c2a", size = 31340, upload-time = "2026-06-12T20:09:01.923Z" },
 ]
 
 [[package]]
@@ -1801,11 +1822,11 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-amp"
-version = "1.43.0"
+version = "1.43.27"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d9/57/36a6dfaed7e8f1788dde7d68db6f7d5cf6f43a25b30b3f99016bd5a913c2/mypy_boto3_amp-1.43.0.tar.gz", hash = "sha256:c830f2ae020d8aa51bea5729408f68583cba970f8d8894788709b19c03e941e0", size = 27682, upload-time = "2026-04-29T22:56:52.854Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/a0/81caef2403acfe198827ff65dfe368b12ff210044d4a99ef5f43b63e06f4/mypy_boto3_amp-1.43.27.tar.gz", hash = "sha256:fb82d9bab2d10332ac1f0ad3de5c5165e412a73296ce09c8e3dfcdbf23466bcc", size = 27720, upload-time = "2026-06-10T19:56:02.467Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/60/35/2489c1de41654add6e6af5b018ee7232a63aeb2f70fffc5fc71db56d80bd/mypy_boto3_amp-1.43.0-py3-none-any.whl", hash = "sha256:5556bac9da4076f9c781de43a658b3fd140174f1e1a8be935559091db5b4f3a4", size = 35204, upload-time = "2026-04-29T22:56:50.308Z" },
+    { url = "https://files.pythonhosted.org/packages/48/0b/7747b9b87e2ffc178303d95b4ccce1a3e5774511eedd67dabc38d7abcc67/mypy_boto3_amp-1.43.27-py3-none-any.whl", hash = "sha256:bf1f1a78bd3dd139a0fc94e636d572efd36c5944acac43f68ee03681b414bb7d", size = 35301, upload-time = "2026-06-10T19:56:00.242Z" },
 ]
 
 [[package]]
@@ -1891,20 +1912,20 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-appflow"
-version = "1.43.0"
+version = "1.43.23"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/48/7b/16d79c195b0e9665efbeaa2dad9f52d89d07a534a89afdc363770f07cfb8/mypy_boto3_appflow-1.43.0.tar.gz", hash = "sha256:01a7b37454a81b426d59004e01dd5fde0521b69a4c2faf23f4dbde3d86e3b1d2", size = 31999, upload-time = "2026-04-29T22:57:08.055Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e9/30556dd77392b3a744fa0990800e6a91476a8fe7a0c7e19163a10c724c70/mypy_boto3_appflow-1.43.23.tar.gz", hash = "sha256:ed0619b8ec4edf6f95629581a0394e0588511cfddb5412c28559a8afbb6ecae0", size = 32008, upload-time = "2026-06-04T21:04:22.339Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f0/a1/af533507a150dcb517817595f8e3f43e93a7748481290f0ad481d1de32f8/mypy_boto3_appflow-1.43.0-py3-none-any.whl", hash = "sha256:7b5c3f56acedefceb21b06c4ef53b222faccd53525ccc76abf2e7b02de2b9b8f", size = 37324, upload-time = "2026-04-29T22:57:05.842Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/68/ee41662cadcd3167d6503ece2a9177763fdd793ad32fabc07906ec557f55/mypy_boto3_appflow-1.43.23-py3-none-any.whl", hash = "sha256:df2121d682c0c74eaae9e87bfba773f60fc5a288c28e0d9d6f868bd933b1821f", size = 37352, upload-time = "2026-06-04T21:04:18.659Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-appintegrations"
-version = "1.43.0"
+version = "1.43.23"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6a/f0/daa2a9fc0715ca537ca9936cdbc73777a6d26a24f64a80d1b746695ffc7f/mypy_boto3_appintegrations-1.43.0.tar.gz", hash = "sha256:f274bd91f3ac14844ca2217d232f1ccee182055d49345dc01f232322372fa775", size = 20280, upload-time = "2026-04-29T22:57:09.427Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/54/12f2a3a53a8eadd4a8fa6da287eed4980e8779433dd3771d44a92e3f3058/mypy_boto3_appintegrations-1.43.23.tar.gz", hash = "sha256:75d72bf070201678460d83c6c7c5ab362d7a460fbe5b503b71ca415e7f3a85b7", size = 20251, upload-time = "2026-06-04T21:04:20.471Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/36/18/c39278848cef3c8f625b58b8b2f12351f009dade24131bcac365ddf7d8a4/mypy_boto3_appintegrations-1.43.0-py3-none-any.whl", hash = "sha256:f913d3d3f76409d8b38cd5770aceef005bc5bb1ce5745fa3c3df3d9a38b0e4d5", size = 27373, upload-time = "2026-04-29T22:57:07.098Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/7e/dc756aa26f26612a2dd46e00e3c37d51c27ec0f9b605118d02b1b473d47d/mypy_boto3_appintegrations-1.43.23-py3-none-any.whl", hash = "sha256:1a9d52ec984d2999b4e48ac89ee947cfcf512e09dfcb9c4c9fdbb7cc996228ec", size = 27405, upload-time = "2026-06-04T21:04:18.607Z" },
 ]
 
 [[package]]
@@ -1963,11 +1984,11 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-appstream"
-version = "1.43.2"
+version = "1.43.17"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/48/8f/b6e28d4c9562f1627a5a2ec0da3758dd8a4834a96bcff797a15bd0cd12b2/mypy_boto3_appstream-1.43.2.tar.gz", hash = "sha256:94d22639380bd1f46ee4a8eff70e23e5e89fc69bf5aa385545dd7fe1b2067d06", size = 42546, upload-time = "2026-05-01T20:31:09.584Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/a1/5543bfce655f7cc9f8e3812c271a1ac0db22d7098732c083371fa3a28a22/mypy_boto3_appstream-1.43.17.tar.gz", hash = "sha256:72cefdd9c02a11347f57be84803bb06bc7272c929fa8180289be9a87a73441f7", size = 42570, upload-time = "2026-05-28T21:20:50.751Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/63/bc/c00bb016de3b753f65c3f13bd9b88caf5dfad26bf80002471243c8202d43/mypy_boto3_appstream-1.43.2-py3-none-any.whl", hash = "sha256:72cc1dcc2d812e05019cb2e502374b21788976eac66f14a2fb94f09df1fd0261", size = 49692, upload-time = "2026-05-01T20:31:07.38Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/fe/95341ecd90dd59e7cb443848c9fe8f14ac4cd3fb8d692bfabcacb66ddcbc/mypy_boto3_appstream-1.43.17-py3-none-any.whl", hash = "sha256:76c604b34e5fabddf216f771c037a0fa881cc5e861ca5870e334aa5c589b76cf", size = 49751, upload-time = "2026-05-28T21:20:48.735Z" },
 ]
 
 [[package]]
@@ -1981,11 +2002,11 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-arc-region-switch"
-version = "1.43.7"
+version = "1.43.22"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3b/b1/7d63f018d92bed8ded2751ddaef89f2c42bc4dd45b63b0374a93480d054c/mypy_boto3_arc_region_switch-1.43.7.tar.gz", hash = "sha256:78cdd3664e4d4e9305269658774787b1379523ee35d4a044c3f364a5d2add728", size = 28236, upload-time = "2026-05-13T19:40:57.981Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/54/a6587f7a31846737f9d4e9ac08a308de8d422f21659dad61379e71eda96d/mypy_boto3_arc_region_switch-1.43.22.tar.gz", hash = "sha256:dd105926e7d74052d24bbd6515a463a7616b633e1b162399b2f01446cacd1eca", size = 28790, upload-time = "2026-06-03T21:49:46.057Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6d/0e/e40f8635f85a55b2a7e70b5bfb03db729aacea85e44d5867359ca9d14e7e/mypy_boto3_arc_region_switch-1.43.7-py3-none-any.whl", hash = "sha256:ba6dc5316e18a4c97a57898c1dcadb5c2141ea144b18352ca0607595761bca87", size = 36552, upload-time = "2026-05-13T19:40:56.823Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/b0/e61816143e6de782c8825515e4fd48c63b930baa0e3570035eb4f7a445a5/mypy_boto3_arc_region_switch-1.43.22-py3-none-any.whl", hash = "sha256:b08bf8ef0d8a05592ab7bc83ce842813838b8f76d5255618c38c33107383970f", size = 37196, upload-time = "2026-06-03T21:49:43.83Z" },
 ]
 
 [[package]]
@@ -2017,11 +2038,11 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-auditmanager"
-version = "1.43.0"
+version = "1.43.23"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ba/1a/3746bcd6e4209a7e751415a549338584130fa3ab92b90472e95fa92456e9/mypy_boto3_auditmanager-1.43.0.tar.gz", hash = "sha256:db7cee588089e3d9e8f13e00960655d240e4cf48f9a5ed7113bb8a2a6b339bd5", size = 31380, upload-time = "2026-04-29T22:57:29.371Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8d/c0/eb01c1fb96d6ecec0d2d519e7818244d0a07c51cdb68e3e74bea00f78ff9/mypy_boto3_auditmanager-1.43.23.tar.gz", hash = "sha256:d10307194a4755d0147fc870e11b60537c0c6a7a76eab8830dbc78f5af7ddbd5", size = 31412, upload-time = "2026-06-04T21:04:21.191Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ba/1c/c110f7b044ef6dbd6fa61375e409effc779a2af26ca70713c825ce7f8ff0/mypy_boto3_auditmanager-1.43.0-py3-none-any.whl", hash = "sha256:b744a78f12b5daa0950783660ce42c413fed88a73e4cccade66470fd88f73b12", size = 34186, upload-time = "2026-04-29T22:57:26.661Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/e4/80b4356084774f4d4674dcb286e200f5ae0f99a4f2d0f34dfed267733c57/mypy_boto3_auditmanager-1.43.23-py3-none-any.whl", hash = "sha256:1c8a2c38d5d5f14cc1b0d229e3faa29282bef3dc882e976b2b97a621e60d7ab3", size = 34221, upload-time = "2026-06-04T21:04:18.659Z" },
 ]
 
 [[package]]
@@ -2053,11 +2074,11 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-backup"
-version = "1.43.0"
+version = "1.43.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ec/78/190ef21034256aac0e562a2165e974fb90f3378215c54f4f5c3f3d9a033d/mypy_boto3_backup-1.43.0.tar.gz", hash = "sha256:3b77c2337ded7c5f26c52df82941102f3e0e015f6b4a402d5447187ddd4c049f", size = 54321, upload-time = "2026-04-29T22:57:35.739Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/80/340bc38f40b42fe0d9eea6e3e02bf6c0989043fd44fb3ab363471288c180/mypy_boto3_backup-1.43.15.tar.gz", hash = "sha256:33252d37a73800145a07b9aad4b4bb9dd19ac1c51be38b0faf3b1dbec010d0e7", size = 54737, upload-time = "2026-05-26T21:14:53.854Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/30/8b/1ef4ee34f9189595eef02c229af447df2b21a01f0b497ac407b9006a5f0c/mypy_boto3_backup-1.43.0-py3-none-any.whl", hash = "sha256:d21b15b8dba34d5de57a59957886b49c291dff83fa190fe8c02e82f581f4dfdd", size = 58689, upload-time = "2026-04-29T22:57:33.137Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/92/fe42662f4f2844939498dc671d46e28183236625ef4a3d26809186448c77/mypy_boto3_backup-1.43.15-py3-none-any.whl", hash = "sha256:9d9442f81107f1946916a00675665c4ab5bc658d3b8250e16e1fb55e5062b7ea", size = 59147, upload-time = "2026-05-26T21:14:49.434Z" },
 ]
 
 [[package]]
@@ -2080,11 +2101,11 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-batch"
-version = "1.43.7"
+version = "1.43.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f6/f6/d964c99d17b845fa3205b94c35ea9b90d19a40749e4e3ec77a7cce4e2eed/mypy_boto3_batch-1.43.7.tar.gz", hash = "sha256:e178fff52ab4c08b3995d5fe5ac9d49152aa1a64f4c41f5fa70f06e8a9b4863c", size = 39759, upload-time = "2026-05-13T19:41:01.171Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/70/03/a0cc6b7cdcb6a3acbb99d97ddf2734b9165696d14d6f7f6a468fbde1ae54/mypy_boto3_batch-1.43.15.tar.gz", hash = "sha256:ab4941052baedde01e77c7795da9a29d19fc87db594cb5da2e528c8d9fb6d123", size = 39748, upload-time = "2026-05-26T21:14:52.479Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0a/75/b9ac66344e870ff1a542901e09e0966ab44e662b60d723d74061f1110ffb/mypy_boto3_batch-1.43.7-py3-none-any.whl", hash = "sha256:11ded070816edbd5f90b1bf3531b85893f545b391ea9911c89c37c2625083553", size = 44894, upload-time = "2026-05-13T19:40:56.882Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e7/3172ae7aaaca28e0972535ca1d55c78e7636fdccd5e61d8a5ea6b10b1651/mypy_boto3_batch-1.43.15-py3-none-any.whl", hash = "sha256:052f463beaa8f08f0982bc49795a1862992a67348449a413f5d624382fe98f4d", size = 44909, upload-time = "2026-05-26T21:14:49.402Z" },
 ]
 
 [[package]]
@@ -2125,11 +2146,11 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-bedrock"
-version = "1.43.8"
+version = "1.43.26"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e7/05/50600b0830fdfd573d56fa8f68f10812b8f79e829f06c50dcf6eb366eb4e/mypy_boto3_bedrock-1.43.8.tar.gz", hash = "sha256:16309e0a79ecfc6a8df1e462220e3a3c8791a76b5be2145a58875ec46eebe61e", size = 65048, upload-time = "2026-05-14T20:17:12.183Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/1d/e421f43f5bb53751a6f02e668d35fd37adebfca92df81ff33ac35cfc82ac/mypy_boto3_bedrock-1.43.26.tar.gz", hash = "sha256:68be0a3698f9a1494f646df0b3fc2e243ceff0007765ee57a62f69f238785cc6", size = 65587, upload-time = "2026-06-09T20:33:07.471Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a9/cb/7e9559462be5ee65112376eb7824e443ec1bf5514b65a0650b35880d4170/mypy_boto3_bedrock-1.43.8-py3-none-any.whl", hash = "sha256:3cf4de988e97b3fc39b7330bde92370c7cc0cc52f56e22705e946195c5f6c79a", size = 73403, upload-time = "2026-05-14T20:17:09.815Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/ef/5b5904d0da24e2aac2e4ee3d55aab2f8c8c884579db020772d71e4a69385/mypy_boto3_bedrock-1.43.26-py3-none-any.whl", hash = "sha256:4f224f895c7c643e613a19cd279df68c8b39d365d9c0b5d13103396f8d1c9845", size = 74079, upload-time = "2026-06-09T20:33:03.79Z" },
 ]
 
 [[package]]
@@ -2152,29 +2173,29 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-bedrock-agentcore"
-version = "1.43.11"
+version = "1.43.29"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a1/a5/92ed0831f2ec5febbe3617156c6662fc24fbec6dae58e2cf0aa6246b194f/mypy_boto3_bedrock_agentcore-1.43.11.tar.gz", hash = "sha256:0bc91a48df28564715cf69804891e51461d12546c939defa5a91f526da8d555c", size = 51438, upload-time = "2026-05-19T20:52:39.393Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/38/00fc54c7232289470666f205ae23d39724490310c14a18207ad2f0cd491f/mypy_boto3_bedrock_agentcore-1.43.29.tar.gz", hash = "sha256:2da85a7d515968d0bfd2a6c84e62fe63610889b8083ba9ead640e7fc556cc3a7", size = 53493, upload-time = "2026-06-12T20:09:03.027Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/3c/d5a61224569cc9c07e2e6a2bd4e923d771368b3f7f304b56eea44fc79769/mypy_boto3_bedrock_agentcore-1.43.11-py3-none-any.whl", hash = "sha256:944d608bdf9e6cdf70621bb8d34717b77315ab0fe4cd5c487dc1129de8f28cb2", size = 57967, upload-time = "2026-05-19T20:52:37.124Z" },
+    { url = "https://files.pythonhosted.org/packages/56/fe/37411ab587cd80c68129a6c1e9e8b019df2d4e8ba475b04ad8bd319dd346/mypy_boto3_bedrock_agentcore-1.43.29-py3-none-any.whl", hash = "sha256:cd10af54353dde038fad252df653668594fd38fd7f32ea9ed05e322b8cab2e39", size = 60587, upload-time = "2026-06-12T20:09:01.872Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-bedrock-agentcore-control"
-version = "1.43.7"
+version = "1.43.29"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7d/b8/4729df9bb3d8a16398fa0161952f38979a52f1ec431d242ef04b43f0a75f/mypy_boto3_bedrock_agentcore_control-1.43.7.tar.gz", hash = "sha256:6fa969fcc89956c9fc030d1dc58b575af83114823d3a9a26c55f6f28ce81c01b", size = 81011, upload-time = "2026-05-13T19:40:58.835Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8b/2e/27213ac6bc0cc71091d3e612d697293cecdb9fcb40f19d4dad1cc128a425/mypy_boto3_bedrock_agentcore_control-1.43.29.tar.gz", hash = "sha256:0841e67dbcf0b140720b3536fbeeafa36cfedd5d3db8b792e0750d81ed33de02", size = 85771, upload-time = "2026-06-12T20:09:05.671Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/07/82f0f171f145f824a50531d737aae63693d9751471977dab951b5130b334/mypy_boto3_bedrock_agentcore_control-1.43.7-py3-none-any.whl", hash = "sha256:1e76d00630d295b6fee83cce27d56381ca6b0bf8f0cd94fca3156842932418cc", size = 89042, upload-time = "2026-05-13T19:40:56.861Z" },
+    { url = "https://files.pythonhosted.org/packages/04/ea/fd37b6b87634ef33f4cce2969e9c0f3e403ed1cc18379fd5a243eaf51243/mypy_boto3_bedrock_agentcore_control-1.43.29-py3-none-any.whl", hash = "sha256:fd0750f945470377031758cb838f28db8097afa58b39448c9acebe1d3efe3b2b", size = 94127, upload-time = "2026-06-12T20:09:01.891Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-bedrock-data-automation"
-version = "1.43.0"
+version = "1.43.16"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0a/22/f45c868fa4818103cf014d38f28036cedeb13ab2cded3eb53b3d67ff39e9/mypy_boto3_bedrock_data_automation-1.43.0.tar.gz", hash = "sha256:4c8178c04f2b1021c5a7602469aec1637497f728e875f350781a21eda2cece02", size = 27547, upload-time = "2026-04-29T22:57:51.071Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/a7/b65f8df280ce5c4ac4da0a57e5c9f1a626d34df7fe36fb498bf319a9e68b/mypy_boto3_bedrock_data_automation-1.43.16.tar.gz", hash = "sha256:92c516a31898927de80df2b0d5a6db3e70d4a98fc72168744b85f89ba2de7e9e", size = 27619, upload-time = "2026-05-27T19:38:07.811Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/b2/9881c2ac84fc46d8d91f003fd47e92734d02e025caa3e7d96b0125dcd8ae/mypy_boto3_bedrock_data_automation-1.43.0-py3-none-any.whl", hash = "sha256:f39535eb65d9ce6f19cb729686b765a400023aa9a7b416e3c544f2c504645e0b", size = 34549, upload-time = "2026-04-29T22:57:49.78Z" },
+    { url = "https://files.pythonhosted.org/packages/af/32/e64f77e7a20c48b718ed1906c3fb0738ac015220c25ce7fe6845b0f9b5b1/mypy_boto3_bedrock_data_automation-1.43.16-py3-none-any.whl", hash = "sha256:510997f56365dd73d3f77890180a6793ebc7fb3b87a1141f9d45dadc63958dac", size = 34650, upload-time = "2026-05-27T19:38:05.234Z" },
 ]
 
 [[package]]
@@ -2188,11 +2209,11 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-bedrock-runtime"
-version = "1.43.12"
+version = "1.43.17"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2a/61/b6c98c9636f2014caa2d7194409d14170952afb7aa84413861cec2a03cb0/mypy_boto3_bedrock_runtime-1.43.12.tar.gz", hash = "sha256:02c1e7e49a386bc75f977ad1ce4838c7ad41c4c70e170405fe8e705c0ecd90ea", size = 29945, upload-time = "2026-05-20T20:01:21.374Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/b5/e38bfb6679c158c1e8a76a5c6ebaec3d9ee67be618c274195e1a0f5bdd64/mypy_boto3_bedrock_runtime-1.43.17.tar.gz", hash = "sha256:f2f49ae9e63c692ed4c4fec76f9f3a62739fe77495438f42e714fcef3553e0ed", size = 29929, upload-time = "2026-05-28T21:20:55.801Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/68/2718fb57d7b59f08728ec9dc14ab84814f10e35cd104a393c4e527eece8f/mypy_boto3_bedrock_runtime-1.43.12-py3-none-any.whl", hash = "sha256:edb53f120d36e6ecbd949891ee1846f20c24109cfac1beb09d3620472a0bf116", size = 36193, upload-time = "2026-05-20T20:01:20.04Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/0a/999908e7920061092318a4e2ac5d8cb973561178d05d1fe56231113f93cf/mypy_boto3_bedrock_runtime-1.43.17-py3-none-any.whl", hash = "sha256:c782c01e0e581e239e83ca1d740751acdd798756142b2364d81ec75c633e6a49", size = 36212, upload-time = "2026-05-28T21:20:53.454Z" },
 ]
 
 [[package]]
@@ -2224,20 +2245,20 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-budgets"
-version = "1.43.0"
+version = "1.43.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0b/24/e2b668431e9777c4ec9e38c01c853c68a9858bbdfaa520b03bb6a8dbfeed/mypy_boto3_budgets-1.43.0.tar.gz", hash = "sha256:29786288807dc9d1ddc060a59986da693e2ddac03b05d117406f471699ee135c", size = 22822, upload-time = "2026-04-29T22:58:02.465Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7f/42/65ad5197d54644689a76ea0470dc94b66de7b9a28631016a9aa1dd03e52b/mypy_boto3_budgets-1.43.15.tar.gz", hash = "sha256:ef1bac995f946f53241f7986198350165235a5f83dbfaf4eccdd8550ddfe0f36", size = 22824, upload-time = "2026-05-26T21:14:51.01Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/25/d378e49d7d91304008348c94424202541f857436f5838729ce4e4900c63b/mypy_boto3_budgets-1.43.0-py3-none-any.whl", hash = "sha256:b534a536c0a3106acca9a970fbed7cb05ee741c091dc3888713865123cddf6d3", size = 31709, upload-time = "2026-04-29T22:57:59.126Z" },
+    { url = "https://files.pythonhosted.org/packages/69/16/cb415ce64efb889aa37009856a243c834c3e10290a7417fd74276bf33d78/mypy_boto3_budgets-1.43.15-py3-none-any.whl", hash = "sha256:8fbc6d5b084e5c5ee8436207737f8e83853fbfad26e4702e04db0ce60603cb47", size = 31724, upload-time = "2026-05-26T21:14:49.443Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-ce"
-version = "1.43.0"
+version = "1.43.22"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1f/7f/26cc7aa215f446492ee26a6ec5953964c5c2c66c52be1b2d608116c35f8a/mypy_boto3_ce-1.43.0.tar.gz", hash = "sha256:46cbd0be489efa4d0e32382cdf4665c22472828d0b85993457bbcc01753a810f", size = 42649, upload-time = "2026-04-29T22:58:05.721Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/1d/ff11a73e49170badb695c4f1714914b4b11ce6cc672fda198828413cdf4d/mypy_boto3_ce-1.43.22.tar.gz", hash = "sha256:d42806da9d1d7651a3e23b6d695f5e8cff8303b711b40139eab27030d3c2818c", size = 42706, upload-time = "2026-06-03T21:49:47.389Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b3/0d/8de589b326f6d06b7a64a4443350e3abe9c71b854f976c697fb95069928d/mypy_boto3_ce-1.43.0-py3-none-any.whl", hash = "sha256:1e45bdefcfa95670ec2ecae234999c8eedd5feaabf294288248664cf70fedf6a", size = 49459, upload-time = "2026-04-29T22:58:02.973Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/de/396257e1bdd0c5f2552c3a1d101435a495de6c619b9d2e8b7225dc5aeb33/mypy_boto3_ce-1.43.22-py3-none-any.whl", hash = "sha256:4feac36d0a4ba2c46fe53d3f258e1dd1796ab4113c395edcbde9f6b98ca3dc86", size = 49534, upload-time = "2026-06-03T21:49:43.938Z" },
 ]
 
 [[package]]
@@ -2296,29 +2317,29 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-chime-sdk-voice"
-version = "1.43.0"
+version = "1.43.23"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7a/82/4018b776cadd43f905b80998b9d06a39d5f63576eddd3ec15ee64c341a95/mypy_boto3_chime_sdk_voice-1.43.0.tar.gz", hash = "sha256:56dbb9e840d0963bc6dc965b8aab77089ce1aae5086d8636fca9fb417c383e87", size = 37593, upload-time = "2026-04-29T22:58:14.059Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c0/61/ed30664179441e558b82a0e5842ea76d86fe2fbab620f8aaca2fbae10d33/mypy_boto3_chime_sdk_voice-1.43.23.tar.gz", hash = "sha256:e75328ca25613f7ef5459f290f4377f2a7a75a9b16dc74e7e0f2ffe8777c2a2f", size = 37597, upload-time = "2026-06-04T21:04:24.832Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/66/94/5b0dd2b8435a6ed9f0af43b7a37bd42cd4c6505ad97b15c5d7502c9f52b0/mypy_boto3_chime_sdk_voice-1.43.0-py3-none-any.whl", hash = "sha256:18e290d0b3badda2d2b2c0b962c32a09130d61186f5ccac4990195368de6cc95", size = 42053, upload-time = "2026-04-29T22:58:11.93Z" },
+    { url = "https://files.pythonhosted.org/packages/45/5d/b5de47f5d0f6add91aabc8213c7b5928128d69451acb29447ac633c17ec1/mypy_boto3_chime_sdk_voice-1.43.23-py3-none-any.whl", hash = "sha256:6996c259b17adf0dd637dc0b34f4d88f4eb15a78bf096bfd39f15a14ee82cbed", size = 42083, upload-time = "2026-06-04T21:04:22.888Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-cleanrooms"
-version = "1.43.0"
+version = "1.43.13"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/15/5b/34bbc4911b9d92cd73832cf1326cfbad5665fe293b34f45604f71512ded7/mypy_boto3_cleanrooms-1.43.0.tar.gz", hash = "sha256:890465a816591b8a67bb2e7b1d72b015827ae3ec244bdbfb87fa4a975f51e6c8", size = 52548, upload-time = "2026-04-29T22:58:15.286Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/9d/e1bab51bf4ceaff096c01da8df9d8c389397530caa1a5f7cd41f6c0a4f44/mypy_boto3_cleanrooms-1.43.13.tar.gz", hash = "sha256:cbd6ffa707116b8545674bf4ac3c337736139c2ca7ea581e36693d2532d1b442", size = 52690, upload-time = "2026-05-21T22:50:48.381Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/85/6e/c0a11de5f4fd966c41cade75eb66eab7dcb0edf9d68e6add9c8cf3cec7ef/mypy_boto3_cleanrooms-1.43.0-py3-none-any.whl", hash = "sha256:f6a6933eeca260fa6d43d35841b2577333ae5ff41ffa3c250075cc2c004ddc41", size = 57539, upload-time = "2026-04-29T22:58:13.025Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/e0/c12b43b2563985ad9fbcf21a94a2d22e37176a7e72a881ae1e5619ca9a96/mypy_boto3_cleanrooms-1.43.13-py3-none-any.whl", hash = "sha256:3cb3dfb9e6f8448331ca8d239efa7f9fd09df52e77aa1a825f4cbab37d6c9f6c", size = 57721, upload-time = "2026-05-21T22:50:47.027Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-cleanroomsml"
-version = "1.43.4"
+version = "1.43.13"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/35/c3/a7b653f8ebf8eaab25f81c06c3c4c2f9055dad2c9fcaa27dbfbba16f2a81/mypy_boto3_cleanroomsml-1.43.4.tar.gz", hash = "sha256:db876a2cdeab816a8c689def5348b8dafce1f3ea0ae1724dbd4048befa2e5d86", size = 38300, upload-time = "2026-05-05T19:53:14.009Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/9c/fd1051e5625b1e3a87cff07bc3dc8293af76fb3c8fd15fbe28c7c5739b88/mypy_boto3_cleanroomsml-1.43.13.tar.gz", hash = "sha256:a180eb8caefda60bab859b80a906d72fe17183e79515810079f7e9c2ec22d3ac", size = 38523, upload-time = "2026-05-21T22:50:53.792Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/95/c9/f4d98f13058d3b4d1f04027eea74f1aa23350b6fdf8f9f877a366abfaed6/mypy_boto3_cleanroomsml-1.43.4-py3-none-any.whl", hash = "sha256:d5c9c6a4595142dbacfc37104729c1190f0b5ae452277d509364ac8750c47ff3", size = 44365, upload-time = "2026-05-05T19:53:12.599Z" },
+    { url = "https://files.pythonhosted.org/packages/05/5f/67ce80d03a3dec955ffdb266daac757c830f67ec5d2aa1d7cd699e1b303e/mypy_boto3_cleanroomsml-1.43.13-py3-none-any.whl", hash = "sha256:b4fea1086d43d60013c5d470a07017376f2bcc5aa6448ae6b8dba9cd7bb304de", size = 44587, upload-time = "2026-05-21T22:50:51.731Z" },
 ]
 
 [[package]]
@@ -2350,11 +2371,11 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-cloudformation"
-version = "1.43.0"
+version = "1.43.23"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/bc/62/31c099df8c79b2c78a1f48a883049ae5a22a0bf5cf8a22bd332497a3ce1f/mypy_boto3_cloudformation-1.43.0.tar.gz", hash = "sha256:5be845bc3dc1b9cdbd8b6b071fad7c42d0221d4087ac0cc7c5b9dd219b324606", size = 61202, upload-time = "2026-04-29T22:58:21.903Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/3d/1854609fe398b7e4f8934f998e6ed30b61151bfd51f476bcc309f220e811/mypy_boto3_cloudformation-1.43.23.tar.gz", hash = "sha256:e6e4740a3a96cd31f3b6119633f224a25119e22d8248619bd23a23bbae8ca7a8", size = 61320, upload-time = "2026-06-04T21:04:27.496Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3e/c6/b53e4541b63499663a2ef0e6bcfb6e5ff4be067cea0393844eb031ba217e/mypy_boto3_cloudformation-1.43.0-py3-none-any.whl", hash = "sha256:bcb2f8b8231f6bd96cc18d17c1c72ea0dfa6dc8156966d8d12495445f5041f4c", size = 72215, upload-time = "2026-04-29T22:58:20.293Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/05/2861702650f1c2dc7b4da5baf4ff19b9dd0446034bf775f3a20a4757defd/mypy_boto3_cloudformation-1.43.23-py3-none-any.whl", hash = "sha256:20e2417e3b69273b43643063f3430939d5ef68f7857bbb1136728dca2eaa1163", size = 72246, upload-time = "2026-06-04T21:04:23.51Z" },
 ]
 
 [[package]]
@@ -2431,11 +2452,11 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-cloudwatch"
-version = "1.43.2"
+version = "1.43.26"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/14/79/46bb4c161fe95eab01a8c5af24b19eb8e7bbabd2afbe2508e53a4bd057f6/mypy_boto3_cloudwatch-1.43.2.tar.gz", hash = "sha256:a08fb826321b88da8043a4175d7dce7a28119ac22aca6e12d938b0ae33228d05", size = 37715, upload-time = "2026-05-01T20:31:12.325Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/24/2e47ffdd6cc58d90ecb634fae9fa695ac805a7affcb05029e5d5cb77e1ae/mypy_boto3_cloudwatch-1.43.26.tar.gz", hash = "sha256:3b5e21fbcba3b317be452039371999c9f44731d403afd83762b7b5e6a8d5ece7", size = 38271, upload-time = "2026-06-09T20:33:05.651Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e7/68/f89bdc77e617501d462fa437a9220bc3f5e4d02006efd2b4f5f82645264d/mypy_boto3_cloudwatch-1.43.2-py3-none-any.whl", hash = "sha256:954a9ac4a7d24310aa4df4e3de943fcc1fedb0b1cd0361c51d05951df0ac7918", size = 47177, upload-time = "2026-05-01T20:31:07.383Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/2e/8db4bb073227e49bc854b36d4d4c4852abe181239d79ab43ce64acdb7547/mypy_boto3_cloudwatch-1.43.26-py3-none-any.whl", hash = "sha256:56306a03a1d88315c9f38bf7605ea33c8915aa495761fba482dc39fe5952c493", size = 47792, upload-time = "2026-06-09T20:33:03.772Z" },
 ]
 
 [[package]]
@@ -2557,11 +2578,11 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-cognito-idp"
-version = "1.43.0"
+version = "1.43.19"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b5/c3/7f2435a242e5c75f3f4da89e13f757dff4f6fd7f372d9296b6de20c4ed47/mypy_boto3_cognito_idp-1.43.0.tar.gz", hash = "sha256:a319a322fc1e08ab0dfd0c9b9ae1c229e18fcd0319b09399e075ef527035e61f", size = 52485, upload-time = "2026-04-29T22:58:58.368Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/68/74/95d612428a6ba0c52237f32760ff6fc98f8f99601dd376c55089884cf060/mypy_boto3_cognito_idp-1.43.19.tar.gz", hash = "sha256:02286ae55f5398ae5eac65f4e8a786cc77edcaeebc05886489f9f61e7317046d", size = 53947, upload-time = "2026-06-01T20:03:13.748Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/31/b5553a3652b6e5d8cb8a197897607f94cf418e92dafd7129f6cb8b241f64/mypy_boto3_cognito_idp-1.43.0-py3-none-any.whl", hash = "sha256:8a82f2fcf5c0e6f6356a746d5edacbc4bf7640d7b1a0e35ba79a0762b4d2debb", size = 58628, upload-time = "2026-04-29T22:58:55.353Z" },
+    { url = "https://files.pythonhosted.org/packages/04/0f/32047c53ded5ff8af497b3e77b28807f1d5837aec9d63de407f49c980365/mypy_boto3_cognito_idp-1.43.19-py3-none-any.whl", hash = "sha256:f99c34d8a40a158b26539a4cc86d9bbc4cf50f78233007556bfbf8a1c32ed43d", size = 60140, upload-time = "2026-06-01T20:03:09.571Z" },
 ]
 
 [[package]]
@@ -2593,11 +2614,11 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-compute-optimizer"
-version = "1.43.0"
+version = "1.43.25"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/34/56/83e29e404f6d2ce86386173017c1a93b09ec2df6895aacc388aebd66f878/mypy_boto3_compute_optimizer-1.43.0.tar.gz", hash = "sha256:e9f3cef84b9640fec96ec55f333a42af9d361b47b0c7fa6fb9b12a127861967d", size = 40508, upload-time = "2026-04-29T22:59:05.774Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/70/47/417dc929a7887c2d93030b32484860419019c4148ffba00c74bfb5dc2f85/mypy_boto3_compute_optimizer-1.43.25.tar.gz", hash = "sha256:39eb5b07372f419dddedb5b97dde94963aa7eb5f80baca99821e211f4795f271", size = 41041, upload-time = "2026-06-08T21:18:23.172Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f2/d4/16a3e7e59aa03869dadf1b97bec78ff8b820d5c61194b44088d71ac8b30d/mypy_boto3_compute_optimizer-1.43.0-py3-none-any.whl", hash = "sha256:bbf7bf8c4e36064b2e152e2f3152683631f205a79a44d788b25b1663b7ba8fe9", size = 44392, upload-time = "2026-04-29T22:59:04.37Z" },
+    { url = "https://files.pythonhosted.org/packages/85/2b/ad243f3b82d3b2015bb1142770011971e741e6e85295c2d3dbf26fcbb827/mypy_boto3_compute_optimizer-1.43.25-py3-none-any.whl", hash = "sha256:c577ce4fa4af298d9fa8196241f04b283058ba5dfbeb9afc5d1b91e97adffa8c", size = 45023, upload-time = "2026-06-08T21:18:19.354Z" },
 ]
 
 [[package]]
@@ -2611,20 +2632,20 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-config"
-version = "1.43.0"
+version = "1.43.23"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/87/8b/b479cf5b6e71ed044683c73fe08397473493c3ed5f8841a0c3191a9af0b1/mypy_boto3_config-1.43.0.tar.gz", hash = "sha256:90f1b48f37879519bc74d282af1258d89c3f374e8f2fe0bfdf8801f6a873d816", size = 70158, upload-time = "2026-04-29T22:59:06.872Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/e9/c3eb4e77053769ec3ab44e66e6bb7b602021de7a41d0cf5ed2828ff7cc6e/mypy_boto3_config-1.43.23.tar.gz", hash = "sha256:e85c81fd5086b0c60304552ed15cd6a607bde250127e0e8255ec21926a71c9c4", size = 70307, upload-time = "2026-06-04T21:04:25.924Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/f8/e210b6c0571f6119b4be81320b7f8cb80b6137baacb7bc9b5966dddb7830/mypy_boto3_config-1.43.0-py3-none-any.whl", hash = "sha256:a32a7a4b88280de337d9a7673318c8beba8f96d117df501f7fb9534a823ac7f6", size = 70498, upload-time = "2026-04-29T22:59:04.876Z" },
+    { url = "https://files.pythonhosted.org/packages/af/ff/4f609a97e1f8655cc6e656e22a6c4972178dc4b7f340c2f377a6310cf2d0/mypy_boto3_config-1.43.23-py3-none-any.whl", hash = "sha256:1124c85a6217e4e103b7dad8e6dacdd4cd7c8b458b4bae62e64c8b7f638204d6", size = 70695, upload-time = "2026-06-04T21:04:23.919Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-connect"
-version = "1.43.10"
+version = "1.43.22"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ad/9b/8d902216a20c7a29577eb47ab19df9712db13a9eea846006e07241ca793d/mypy_boto3_connect-1.43.10.tar.gz", hash = "sha256:4ae512183ca85a8cfc0ddaf5f8b4ee550df9d0716b5b8a577bbcd1e187b96a2c", size = 168631, upload-time = "2026-05-18T20:46:42.726Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/be/eadfa68da9039dd1e94e93383e0a2e9a5eb0f32eb58b85fac85dd024034b/mypy_boto3_connect-1.43.22.tar.gz", hash = "sha256:5c67b2f627bfb8649715a07935fa105de43e2d0527a8a3d43ad329ab6cbb6999", size = 168828, upload-time = "2026-06-03T21:49:50.6Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/45/57/34042d57a6c23bf149a640f080d0646fd4d3ca343a858a4d3e9705ffbaf6/mypy_boto3_connect-1.43.10-py3-none-any.whl", hash = "sha256:90d0b6773f43f513371271fa17d8493cb32e5d6f6ff79a79f1493cb48d35fad8", size = 170507, upload-time = "2026-05-18T20:46:37.179Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/2c/ef2d0652655cfa0d60f83fc2f4608c24669cfcd8dfef3243368827008725/mypy_boto3_connect-1.43.22-py3-none-any.whl", hash = "sha256:680c0d8b9896fe54152888f1bafeeab0009c66ade6074a8b36da012f4c0ab171", size = 170691, upload-time = "2026-06-03T21:49:48.007Z" },
 ]
 
 [[package]]
@@ -2665,29 +2686,29 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-connecthealth"
-version = "1.43.0"
+version = "1.43.27"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d7/cd/dc7ff11dca719a573abda87743ce2669df862e8a5236b7c5642acead7cbd/mypy_boto3_connecthealth-1.43.0.tar.gz", hash = "sha256:cd238dc51dcb2f9ebc8fc3964db171f8173be40a791d354182980622420550d0", size = 20004, upload-time = "2026-04-29T22:59:17.373Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/81/27e96731f5085e2c693710a282813c91917a479dce24ad6d67480b45658e/mypy_boto3_connecthealth-1.43.27.tar.gz", hash = "sha256:d83a7df094baf477193c4185bb6bc92a977737591528a1bed8e7ebde64c22c52", size = 20022, upload-time = "2026-06-10T19:56:01.365Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/23/7822c75f9b0cb6c63ee6b56262173f4c45287f319f82d19563d82b15a2e6/mypy_boto3_connecthealth-1.43.0-py3-none-any.whl", hash = "sha256:2e6f932bd4d2affff110eebcd5036030cf99c239fb13cd84ecfd3c532d6243fb", size = 27656, upload-time = "2026-04-29T22:59:15.083Z" },
+    { url = "https://files.pythonhosted.org/packages/26/d3/7a97ea682ddbbe5bd409a1126ea53ae7c452ad7bb6de7b7a1e8098962d31/mypy_boto3_connecthealth-1.43.27-py3-none-any.whl", hash = "sha256:e1d03dae1948f6600d23275a61e274a9c89c526a2458452ea21876ded91c8afc", size = 27734, upload-time = "2026-06-10T19:56:00.222Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-connectparticipant"
-version = "1.43.0"
+version = "1.43.23"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/39/6e/22978b3c58ffebaea5e73b50234c78d833d9a24f6a1ca6139bbd766c321e/mypy_boto3_connectparticipant-1.43.0.tar.gz", hash = "sha256:abea5bb386522ac942b2eb2782a1bb675b9b5cbb3e48b22bc32c0b47f7e418cf", size = 17481, upload-time = "2026-04-29T22:59:18.857Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5d/c7/f50344f2c13a4a8e8a67a3039fbc8243164187126e1e836ef050a7d50edf/mypy_boto3_connectparticipant-1.43.23.tar.gz", hash = "sha256:6cf1e8fbd93e6d9795af1eb2b4789ab7c89e9e53ccaa69ad7a2df06a87f89b81", size = 17491, upload-time = "2026-06-04T21:04:29.617Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/af/5ea58b3da8ba7590814ff9657f995d2c760ef056c497d74ab466dc1f91ca/mypy_boto3_connectparticipant-1.43.0-py3-none-any.whl", hash = "sha256:9438a58647d2bfa4b58104058cac0e3d66c21ff84969853f461771050466eb1e", size = 22592, upload-time = "2026-04-29T22:59:15.508Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/e1/73584ff1c9f8c7aa741b73118676c0aa355d3885bc0fa635725c63fb337b/mypy_boto3_connectparticipant-1.43.23-py3-none-any.whl", hash = "sha256:d88d887e6a930f7da1f412eaf58fbefe475e4c39c28c839e2e82aebab933fe9a", size = 22627, upload-time = "2026-06-04T21:04:27.684Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-controlcatalog"
-version = "1.43.0"
+version = "1.43.17"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0b/f9/df3ca1ee93fe2d20f162b6bd176f507e24f1f9894891304c4266d8b8f0c2/mypy_boto3_controlcatalog-1.43.0.tar.gz", hash = "sha256:6ac8608759c157a6b5934f75c797955add93d909877e9e75e367a98e24db9fef", size = 18206, upload-time = "2026-04-29T22:59:21.236Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/c3/266d78a3c630c8d93e74c71a3fed4718c8bf839ad638fa0bbe4506cea9ec/mypy_boto3_controlcatalog-1.43.17.tar.gz", hash = "sha256:73edffd92efa57a7e0009f05d107659670d3af26800ab7fa8aee96edb8cb5d59", size = 18328, upload-time = "2026-05-28T21:20:56.352Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/83/8dfc8029c60c8ed3973d2bddfb599eb4f2435c9be343d8c6b9c8ecd6b18c/mypy_boto3_controlcatalog-1.43.0-py3-none-any.whl", hash = "sha256:2961585d0d12377b987386df11d99b40f81030d27418b87c728a186aaa6df0af", size = 24205, upload-time = "2026-04-29T22:59:17.912Z" },
+    { url = "https://files.pythonhosted.org/packages/93/18/a4f9bb04c480792a6e836bd477e77876541c8169c4e2d47266693695f213/mypy_boto3_controlcatalog-1.43.17-py3-none-any.whl", hash = "sha256:63f5747f8a3c165abc1947d5238630769680a41996cbdca2216a37eb05a27e4b", size = 24460, upload-time = "2026-05-28T21:20:53.894Z" },
 ]
 
 [[package]]
@@ -2701,11 +2722,11 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-cost-optimization-hub"
-version = "1.43.0"
+version = "1.43.25"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/17/0f844cebf7edc21950fa6bd0c8db79fa25cd65ce92cec70b588a60a3e2f0/mypy_boto3_cost_optimization_hub-1.43.0.tar.gz", hash = "sha256:ac2e88c4b3040ba396073f04f0ebe0228bbab210b933f97720931129b844d148", size = 20969, upload-time = "2026-04-29T22:59:23.349Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/42/e8/e25803803cf9f9d3a560d127b910da2c1f5587703b070e9f1296849a1bbd/mypy_boto3_cost_optimization_hub-1.43.25.tar.gz", hash = "sha256:f2b554c88714331a2c3ed74da733d7be4a533b9921dc75ff2726e049c954a778", size = 21243, upload-time = "2026-06-08T21:18:20.521Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4c/9a/cbc5ac2a414e79b7170dea390b3fbe4092806114a5ec9a5e8093e6eccf6f/mypy_boto3_cost_optimization_hub-1.43.0-py3-none-any.whl", hash = "sha256:61541af4c6e85c2e16c73eeed043a0e3c84ad04ce2af0e6b564ad6d039430eb8", size = 29744, upload-time = "2026-04-29T22:59:21.769Z" },
+    { url = "https://files.pythonhosted.org/packages/96/e5/7c0a49bc7dd94ba0af61dfee2fb502cda8d9501700a3e23d8ebc0043ee5f/mypy_boto3_cost_optimization_hub-1.43.25-py3-none-any.whl", hash = "sha256:30f66b6ff10aafb159c6c9d6b8db300dd0bf32ffb78c8be389b5a02768c6c0f0", size = 30110, upload-time = "2026-06-08T21:18:19.298Z" },
 ]
 
 [[package]]
@@ -2719,11 +2740,11 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-customer-profiles"
-version = "1.43.12"
+version = "1.43.17"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ff/d8/415fe8ce631fdb42ded020a1b18bfe7a381aaf31634ba1fc49e1cf682e4f/mypy_boto3_customer_profiles-1.43.12.tar.gz", hash = "sha256:a0e737e075acafb3f2529c1e3018b7a63a2b2162856e2e6a3570dd3c11765570", size = 54949, upload-time = "2026-05-20T20:01:22.337Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/c4/3f9b4d56e89ad9b3d63c30d2b689385f8cde2c525424c23b71b905b13fe0/mypy_boto3_customer_profiles-1.43.17.tar.gz", hash = "sha256:fbfaf9a1c685bffe191743e924c4a819e66d884de792a68c2f31beb040b236cb", size = 55378, upload-time = "2026-05-28T21:20:58.986Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/ec/8ed2718983aedd95198f9ace613c5ff21a205b1fa6812ca3592b0557f710/mypy_boto3_customer_profiles-1.43.12-py3-none-any.whl", hash = "sha256:6c23c06c1cba7ca22bc814ba358b7892bc4fb29ab0857ed87488b3fbbbcbf004", size = 62247, upload-time = "2026-05-20T20:01:20.067Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/e2/7aaa031da1db54d2235b73f5232a6591ee4ba5caf554bbf1e29d2a486745/mypy_boto3_customer_profiles-1.43.17-py3-none-any.whl", hash = "sha256:567d77191930c27661f771fed346d291cdd26f909ccc782922acf5929f08694e", size = 62653, upload-time = "2026-05-28T21:20:56.952Z" },
 ]
 
 [[package]]
@@ -2764,11 +2785,11 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-datazone"
-version = "1.43.8"
+version = "1.43.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/47/0e/83863b520b9ae5afe78570ecc7c5465865f9e91869d7ab692fff12fe080b/mypy_boto3_datazone-1.43.8.tar.gz", hash = "sha256:3192297491cd0adb362a92a0286980c3eb0f7f26cf30ae6cb687b25d6b07d124", size = 97059, upload-time = "2026-05-14T20:17:11.762Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/6f/7e1ce1ff1dc8477505a4eec98c8b0343b2422c2699db05c5a729b50744cc/mypy_boto3_datazone-1.43.15.tar.gz", hash = "sha256:629cffbd8e5b9ccbdd46be8cc05297fe43ef2be74c82bde5a19d202ef4cfba34", size = 97454, upload-time = "2026-05-26T21:14:55.815Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f9/3a/8879db7a729b0d82ed4729e15ddc5880b9da94930de48659c8ce85d63704/mypy_boto3_datazone-1.43.8-py3-none-any.whl", hash = "sha256:22dae87f847c0403e4200bcc37e99820baeffbe4742f772b38c078e086d4f407", size = 104274, upload-time = "2026-05-14T20:17:09.85Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f8/7261f8847bcca84f3fc16cf86aec69940d15b16379df51c5c429bc696e70/mypy_boto3_datazone-1.43.15-py3-none-any.whl", hash = "sha256:f48164fcf05dd6fd4d37d0beb03b45ed4b90de5d4eaeb79395c80ee9a4eae9e2", size = 104712, upload-time = "2026-05-26T21:14:54.23Z" },
 ]
 
 [[package]]
@@ -2782,11 +2803,11 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-deadline"
-version = "1.43.0"
+version = "1.43.25"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/cb/30/eb38216c532ce1875c84488b046df7c2de5353e7b4244c3d70e7b7ce4fa1/mypy_boto3_deadline-1.43.0.tar.gz", hash = "sha256:3b0786b03b0525d6eb5d8f14420696caf64dd2511ebd18dadfa05fd9ec7128e8", size = 61794, upload-time = "2026-04-29T22:59:37.276Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/d0/4a67663548dfcbb88471e1aecf4fbbdd71a8136108189913d04fc925f9d3/mypy_boto3_deadline-1.43.25.tar.gz", hash = "sha256:d403f909ebcf4dab2127c4bb6e869edfd0238ecef0dd7fc64bf87a5ecedbbe90", size = 62900, upload-time = "2026-06-08T21:18:21.305Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/33/e2/c97477242239fdffb313416f9a225319f66d05d4bcc99a1881fe319facd8/mypy_boto3_deadline-1.43.0-py3-none-any.whl", hash = "sha256:2f2744cd913d62dc7eb5b27e3962a52f3b8a7b16a4bc3d6daeb69605b977a673", size = 69171, upload-time = "2026-04-29T22:59:34.871Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/79/51c8b26c4e39beed1869698fbabe16988e4f411ac924e237f20e2777184c/mypy_boto3_deadline-1.43.25-py3-none-any.whl", hash = "sha256:70a94f28fa3d0048d6ddf4ad217e1862d15c64d0f2d2483b95b48b964f19041b", size = 70405, upload-time = "2026-06-08T21:18:19.318Z" },
 ]
 
 [[package]]
@@ -2809,11 +2830,11 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-devops-agent"
-version = "1.43.11"
+version = "1.43.29"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/29/e3/2a67d03bca5a65c848e5006b4195b3342db5dc3d0c40ada3111c1ab69ef7/mypy_boto3_devops_agent-1.43.11.tar.gz", hash = "sha256:767b6c6c4eee473f1645514eabbf710dd38a2b68ed80e0b2c1840675041a5a73", size = 34965, upload-time = "2026-05-19T20:52:38.7Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/10/e80e5011f81de61186b324ebe6365df1d105f42a6047cf3804945b9f874d/mypy_boto3_devops_agent-1.43.29.tar.gz", hash = "sha256:d806e8365b3a88c2316ed32189b638b97e00066c94a3d9f54925da623744a9ed", size = 40041, upload-time = "2026-06-12T20:09:06.753Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b0/91/85a1616cb655975ac710a8afcee1b4e86880e2afa933a401c8cb1f3c445e/mypy_boto3_devops_agent-1.43.11-py3-none-any.whl", hash = "sha256:3983d8738beb951e6af16ddcc82e9dda546f2c9f73f61345eccabde3a35bfe40", size = 40248, upload-time = "2026-05-19T20:52:37.113Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/2a/3ae32f060208617a5f1046ec311a49f7279b2a37f981aa52263cb1de6b6d/mypy_boto3_devops_agent-1.43.29-py3-none-any.whl", hash = "sha256:cecadc43f82dd8c148925521898899a4747d05d756dd69ca1c02d05e8dd1febe", size = 45437, upload-time = "2026-06-12T20:09:04.714Z" },
 ]
 
 [[package]]
@@ -2944,11 +2965,11 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-ec2"
-version = "1.43.10"
+version = "1.43.27"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/73/f7/1ef1d89fb66715514a1b4e5a8e2a06b5587fcecd0ddda757c8a1c445241d/mypy_boto3_ec2-1.43.10.tar.gz", hash = "sha256:7ee2d361ccf5a0d1a037cce84cd27c40f91dbf4265e5f8e6a6eb51b98f6cbe8f", size = 445858, upload-time = "2026-05-18T20:46:41.141Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/52/a23221fa2e8003ba27d82f5d37c63c14b9fabd428c484f3be031081cb718/mypy_boto3_ec2-1.43.27.tar.gz", hash = "sha256:0b3dc384a4f10d296e1f5e1aa9e63e94fb8219310ea02d03269ec0dd108fec68", size = 448191, upload-time = "2026-06-10T19:56:04.853Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/f4/6b12ffb91a2001d626ae0c61af5c55c4121d391e6460911ff147e5d8a7fb/mypy_boto3_ec2-1.43.10-py3-none-any.whl", hash = "sha256:622b7d83e4d6af7363bdbe486cc9049086a6407d77c16e1c82165c68c6d391ce", size = 434794, upload-time = "2026-05-18T20:46:37.276Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/b1/b2a3cef98a37adb35107e50cd1c7ac4d5fdc1364043d040c991896e6c65a/mypy_boto3_ec2-1.43.27-py3-none-any.whl", hash = "sha256:ac61df1936c465b21de811cb601afd4d213002c1ffca541af5af77ae89ed6d0c", size = 436996, upload-time = "2026-06-10T19:56:00.344Z" },
 ]
 
 [[package]]
@@ -2980,29 +3001,29 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-ecs"
-version = "1.43.10"
+version = "1.43.27"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/15/27/a9efc26c52d27de1a21581ab70a7e3e44d8a1d5690ee7d1b1d3b52cbd707/mypy_boto3_ecs-1.43.10.tar.gz", hash = "sha256:fd1398926851532e1809c75124fc91f86679925fb62f7a73d3829cd5964f7d4e", size = 60545, upload-time = "2026-05-18T20:46:45.792Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/94/30c1b1dd05bd125099f847285a1f1b2bcfe8339ffc6e12ccb80ec1605d61/mypy_boto3_ecs-1.43.27.tar.gz", hash = "sha256:c1daba74817ab5b8e1201551518f0629b3b090957228d1463e78a2b0aeeecd55", size = 60680, upload-time = "2026-06-10T19:56:08.22Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cd/a4/105632345070e18997871b3a6f9b3bed62472fd968a093203c901550a8c9/mypy_boto3_ecs-1.43.10-py3-none-any.whl", hash = "sha256:8807d4df9dbb94f74f93f345764ba09e4a2b0cdeba7b3a7c0ba43d32a6da6730", size = 69357, upload-time = "2026-05-18T20:46:43.274Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ed/5a8af7927f58f967ba4726a82878ec4a95670b66c741a3f7e82581baa50d/mypy_boto3_ecs-1.43.27-py3-none-any.whl", hash = "sha256:6f1c67b9c02e8360b03a33fdd047ad6739d4001818516aaaa288200205d86403", size = 69528, upload-time = "2026-06-10T19:56:05.268Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-efs"
-version = "1.43.0"
+version = "1.43.23"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3f/c9/7f5bf47d81b234be452b882ebeff2304cfc9172b366ffe4fffb451b1c649/mypy_boto3_efs-1.43.0.tar.gz", hash = "sha256:4790856b516e27f6f7eb5869271d1cf37448d19236564de87e54cfd823fa5ac2", size = 21794, upload-time = "2026-04-29T23:00:14.975Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7a/98/e87664cca5d6de560c265f6aa87d999196a6046e637b622206ad947c2abe/mypy_boto3_efs-1.43.23.tar.gz", hash = "sha256:d752a93d1c4621defa83f2388d7c0c439e64c0611056c6ac82f3145ec88b6cce", size = 21863, upload-time = "2026-06-04T21:04:31.251Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1a/50/98870cd2501bdd3c80fe8796882dcdf90e85123ae76d4b981f3974090660/mypy_boto3_efs-1.43.0-py3-none-any.whl", hash = "sha256:dfa3f10a320db8927a6915377f060166b77210b29f9b3442c56fa0206a70b7ac", size = 30267, upload-time = "2026-04-29T23:00:12.09Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/5c/5b35b416c6cddddd0ca3c22a17a50a9d0a060d27546c9c529f36ee92925f/mypy_boto3_efs-1.43.23-py3-none-any.whl", hash = "sha256:555ce57e1de00cf668784d38fc381620bf39f6929cee4848e92f4458a13066c2", size = 30300, upload-time = "2026-06-04T21:04:28.317Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-eks"
-version = "1.43.1"
+version = "1.43.29"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/17/d9/0fb81d0e5983ac9e713d64b48207b4abb4005c8a2e30993bd7d114856cba/mypy_boto3_eks-1.43.1.tar.gz", hash = "sha256:642e4308f3cb51620457d99502d1bf0c186b7486b0c2bb4c04263f0c607a32f3", size = 46084, upload-time = "2026-04-30T21:16:19.467Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/48/38d7db8dd6d6b80079d9f0fe05f33e6a84a47dc87a7dcd7c766d6e267d83/mypy_boto3_eks-1.43.29.tar.gz", hash = "sha256:8107419d413086ca3404d636516dac538e5ccfbe4ad5b4bd8125f9beb2044f60", size = 46285, upload-time = "2026-06-12T20:09:08.425Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/c5/c65df0ee702ec74eb7ea005d099c35209133becb922f0dd2d082dc5799cf/mypy_boto3_eks-1.43.1-py3-none-any.whl", hash = "sha256:0acf6ff0ada5343fdb145971e69fd64e5148f7aac36e7cafc312bcbf02c24173", size = 54600, upload-time = "2026-04-30T21:16:16.571Z" },
+    { url = "https://files.pythonhosted.org/packages/56/66/c5fde58d9684f446b7d3d020720641080d9f9faa6d016a0364115b4beaab/mypy_boto3_eks-1.43.29-py3-none-any.whl", hash = "sha256:1070b012846bf4a6e32b0ade5d5a7ed3b69e2d9f90a52d2b9475ebaaf278178a", size = 54867, upload-time = "2026-06-12T20:09:06.035Z" },
 ]
 
 [[package]]
@@ -3016,11 +3037,11 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-elasticache"
-version = "1.43.0"
+version = "1.43.20"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b5/4e/4fe7970f14f432c3b4c6fdc67125cebf909d29cbba1e781a62e9735e4c67/mypy_boto3_elasticache-1.43.0.tar.gz", hash = "sha256:e8d8e6a1732ef510e86f2add45661534f73a43c2432cff93cc0b32db3f842e09", size = 46188, upload-time = "2026-04-29T23:00:19.851Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/c7/78a9d528a16a7ccd256d2d73bdf6d28437f6ac982fbe630c302d541ab8a2/mypy_boto3_elasticache-1.43.20.tar.gz", hash = "sha256:c17273bf39505e0aab25f23f215fca566210e5eb5116e95debdfa6be0b0ad0e8", size = 46395, upload-time = "2026-06-02T22:17:13.746Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/08/8e/7b8dd7e5af657f8c4e6637f442c28a1fa6c18c9e01fa2040e7466427855b/mypy_boto3_elasticache-1.43.0-py3-none-any.whl", hash = "sha256:82affb21e4490ac77aadf44327f9ab8702abb7f083884565b4ee00ff330d4f24", size = 53353, upload-time = "2026-04-29T23:00:16.871Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/12/b9f08554e913e7262018aa47b21d0ec3f0b2830d2717415a5b1fbb2b0d34/mypy_boto3_elasticache-1.43.20-py3-none-any.whl", hash = "sha256:2071b0b5c6e31fd1b475471dd5a284fd5ef9009ec951135696a968397f11be8a", size = 53632, upload-time = "2026-06-02T22:17:09.672Z" },
 ]
 
 [[package]]
@@ -3052,20 +3073,20 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-elementalinference"
-version = "1.43.0"
+version = "1.43.16"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/13/b0/990819a9d8e8719d694d5e98046849f0810dc84c6c85587f3aee58ae7f27/mypy_boto3_elementalinference-1.43.0.tar.gz", hash = "sha256:0fb25bd89ccffebf1da47f7df2de0dddd2ea4df3126e7aa3b45fecdd237e7aa1", size = 17808, upload-time = "2026-04-29T23:00:26.989Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/86/af50f9f4725d61249659ee404e4cbe09b4a939625c4a4b802d20f3e0a090/mypy_boto3_elementalinference-1.43.16.tar.gz", hash = "sha256:088d0aefeb8211225dc8b1a3e6ef45af585545519d1cd3dc73f3cfb63f938cd8", size = 19079, upload-time = "2026-05-27T19:38:08.609Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c4/d3/45a66437706f2ab108d2aae0d2336cf96d11e45876519597e0ec8a169e5a/mypy_boto3_elementalinference-1.43.0-py3-none-any.whl", hash = "sha256:20cc9bacee1e95059aa74646afdfca12195d1696368693ccd6c4ccfdbb0e4824", size = 24882, upload-time = "2026-04-29T23:00:23.885Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/1c/66b47fb8cbf3900ca738e33317992b548e9b12791e76ff2a1134ff6f6732/mypy_boto3_elementalinference-1.43.16-py3-none-any.whl", hash = "sha256:3cc79853d8a458993739113771e51745cdd11e21069ea63853180a8df82272df", size = 26925, upload-time = "2026-05-27T19:38:05.235Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-emr"
-version = "1.43.0"
+version = "1.43.23"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/55/1a/6f349d5eb37247c0cd4b03bdaf564338cca75a7f99a0406d1e3268077c5a/mypy_boto3_emr-1.43.0.tar.gz", hash = "sha256:c69dd06ce5627f867d41b9ca50794f6c8587c6e5f379c524d9b6f5635fde907e", size = 44727, upload-time = "2026-04-29T23:00:29.062Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/44/548897be1ec970575dc0d00c66d022c8161403bb747a30f8de6d8be6a074/mypy_boto3_emr-1.43.23.tar.gz", hash = "sha256:79a4a12ac5f5f8947c64e9bbd1fd5b32451e241fcd121ab5c553a90aee001860", size = 46814, upload-time = "2026-06-04T21:04:33.335Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/e4/b7a059a6361b620f27f455401e94ab01599584fbafef41f66995612b74d2/mypy_boto3_emr-1.43.0-py3-none-any.whl", hash = "sha256:dd6b0bdb67a5a8ccc0c0386f62132562b53530b0e0bcb7af8c9b1348ccdc2919", size = 51985, upload-time = "2026-04-29T23:00:26.337Z" },
+    { url = "https://files.pythonhosted.org/packages/38/21/5fd77b59bcf2745368eee43094263aed8c6d5e5dbd0ecb85557fe89743ff/mypy_boto3_emr-1.43.23-py3-none-any.whl", hash = "sha256:a11303d7a539e93825e6bf6ccd0a5dad33a7c1ab8c65cc8dc72db6cf6af9a8c2", size = 54217, upload-time = "2026-06-04T21:04:30.147Z" },
 ]
 
 [[package]]
@@ -3079,11 +3100,11 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-emr-serverless"
-version = "1.43.0"
+version = "1.43.24"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4c/e5/4095dc97769cfc4d791035a0c6e0c76fcfd975e23b45d7b0f9fedbbf12df/mypy_boto3_emr_serverless-1.43.0.tar.gz", hash = "sha256:d8bcb74f2d61c3753935345fd4a088c3843fd56483ee914405a7ebd498982cf0", size = 21528, upload-time = "2026-04-29T23:00:31.656Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/b2/39ded3d5f0a8f2c76c275601cc08d76781cc40231db7acd4268cde118b5f/mypy_boto3_emr_serverless-1.43.24.tar.gz", hash = "sha256:55308a328fe2154352ea7dcfa65ee37fd6311cfc74f88a54d5ab5587c28e811e", size = 21590, upload-time = "2026-06-05T20:45:23.385Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/02/e0/6320beb8b4aac900a6b87dfeaf729830485be5f8d3c793471f0e515ff7cc/mypy_boto3_emr_serverless-1.43.0-py3-none-any.whl", hash = "sha256:51f3d8eef826daf044755c762f05494c4f893e93ec4d72bf299f8352347c56d0", size = 29904, upload-time = "2026-04-29T23:00:29.5Z" },
+    { url = "https://files.pythonhosted.org/packages/75/35/598c698f2d4b8827ba54be68f67d04ee3417d1ef543f39d6a8fe0ea2f740/mypy_boto3_emr_serverless-1.43.24-py3-none-any.whl", hash = "sha256:5d2c4f0af9a97ebddd7a9abd3d2ba4a1a3918b4b8005f74640e7c278df331163", size = 30030, upload-time = "2026-06-05T20:45:22.304Z" },
 ]
 
 [[package]]
@@ -3115,11 +3136,11 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-evs"
-version = "1.43.10"
+version = "1.43.13"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3e/95/326f21a4138528ee0654b9c3f608848e9cca42fe7ec271d473f5ace24c1d/mypy_boto3_evs-1.43.10.tar.gz", hash = "sha256:88b852b1effd54f52c68aa56c3a096061392c148ba720488600b1415e9ceb924", size = 20624, upload-time = "2026-05-18T20:46:47.031Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2a/69/8ff0a042d5807beacb553680fc3ac3f7c07fce5aab89b39b2ecbb6e06e01/mypy_boto3_evs-1.43.13.tar.gz", hash = "sha256:26bf7a7898549d9dbdd98a4a2dcab23dfbd892279c201e9780b9d6308df630aa", size = 20773, upload-time = "2026-05-21T22:50:54.63Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/a9/b50077ac9e153aa116f94ad99d94bda6d31094d19a3396b5fb8efccfc25e/mypy_boto3_evs-1.43.10-py3-none-any.whl", hash = "sha256:646d9ae4d24bb343417ec74e660f97e12ca9404cf657cebecdae7dd14c574a69", size = 28049, upload-time = "2026-05-18T20:46:44.37Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/97/a138ca238f408c8fd776a619d75ec30b9b23df22d64b5dc7efd39e05a6e0/mypy_boto3_evs-1.43.13-py3-none-any.whl", hash = "sha256:9eb33c12d56d68364adce424de3756f4c16ea176abf538bc04ecadbf94b624b1", size = 28296, upload-time = "2026-05-21T22:50:52.042Z" },
 ]
 
 [[package]]
@@ -3142,11 +3163,11 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-firehose"
-version = "1.43.0"
+version = "1.43.29"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/df/16/a75f2e312e31a5a41687267fbe57166f8f9b98b4be972a3c73eab19f93a9/mypy_boto3_firehose-1.43.0.tar.gz", hash = "sha256:df2f2e6cb33e5e4714c41c4db79414a1c0432efcd568063bde9a977c24abd667", size = 27444, upload-time = "2026-04-29T23:00:43.765Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/0c/90b63df16788ad957a6bf255a1e8648868e9fc327923a8c9e6853c4fb02b/mypy_boto3_firehose-1.43.29.tar.gz", hash = "sha256:4d253bd495a040277520d73f3ad02d0a4333b7557c2fbe46456131eb7d0a7cf2", size = 27444, upload-time = "2026-06-12T20:09:10.08Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/2e/ceac621a4e63cd9c055f30e6f844ad31d605ffdcfd5a75abec6975577816/mypy_boto3_firehose-1.43.0-py3-none-any.whl", hash = "sha256:71629903be188c8b005bda3b7bdd09948ae6ddc5eb901f8e1c46d88fa4b27c80", size = 31765, upload-time = "2026-04-29T23:00:41.638Z" },
+    { url = "https://files.pythonhosted.org/packages/80/af/69bdded2a377c091b6c760ca406783333a0e3b527f59ae7c53fbd91c800a/mypy_boto3_firehose-1.43.29-py3-none-any.whl", hash = "sha256:7dc5fdfbb6e3a58efa7330e96ca2c34f1458b641f9f1a2bc088a72b7a700282c", size = 31796, upload-time = "2026-06-12T20:09:07.285Z" },
 ]
 
 [[package]]
@@ -3223,11 +3244,11 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-gameliftstreams"
-version = "1.43.0"
+version = "1.43.14"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/37/f5/2233886e148607332e1182f6f674075ea6d8d153c20294643221bf9e4a47/mypy_boto3_gameliftstreams-1.43.0.tar.gz", hash = "sha256:56424329d65b8615e699cb0d51b3c316abff3143f37072a99734fa4d39dba609", size = 22683, upload-time = "2026-04-29T23:00:57.472Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/d4/31d9ab5a2a4b21a5bd4956a0e419821c0d261c8cbf3a46a7a82e7a123a22/mypy_boto3_gameliftstreams-1.43.14.tar.gz", hash = "sha256:b40fe184df138f19a9b237f1a9bf278224a57429e263e5355b0d434089a9c764", size = 22680, upload-time = "2026-05-22T20:48:19.985Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/60/db/b104d78cbc83ec3b234728536066c9c6a018484f847d5b76def2416adf88/mypy_boto3_gameliftstreams-1.43.0-py3-none-any.whl", hash = "sha256:90b52c5ec60e6f5f49354cc6ee02b84562ad76dadd7590ee2be7288ef87a5472", size = 32753, upload-time = "2026-04-29T23:00:54.974Z" },
+    { url = "https://files.pythonhosted.org/packages/12/1f/46803d9c5bf12cd9ab32a90fb6c847e108942aa5c2da013dc2c1710f8f4f/mypy_boto3_gameliftstreams-1.43.14-py3-none-any.whl", hash = "sha256:f5720deddc97603cf95bfccb45a7ac1922a179bb11e454ad7d875aa23486bcdc", size = 32766, upload-time = "2026-05-22T20:48:15.693Z" },
 ]
 
 [[package]]
@@ -3250,11 +3271,11 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-geo-routes"
-version = "1.43.3"
+version = "1.43.21"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ec/bc/d1080313e2280a17fabd84620207bb06d08a6e8df256b9342f2b0a2f31df/mypy_boto3_geo_routes-1.43.3.tar.gz", hash = "sha256:24f1993db90043e1692ae203be39e2dfa87915005009aec8057f78b40d6fcc56", size = 30517, upload-time = "2026-05-04T20:10:59.345Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/ee/8269ac5a232934f4c06929ea2908813a06d8aeef4d71d33e4fe866a4eeaa/mypy_boto3_geo_routes-1.43.21.tar.gz", hash = "sha256:63154bb84dc576aff9d7db0c924ecc62024d7aca9e9585111dc33b87c2e620eb", size = 35050, upload-time = "2026-06-03T10:08:55.582Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fe/bd/469dadc3e7f0a828779db1b734c6464e9d51ef364d7f2177cf1769410f26/mypy_boto3_geo_routes-1.43.3-py3-none-any.whl", hash = "sha256:1f1c34d8a38ebb7a08c75acc0aea53ea4c6015283587e1a0024dc0eede78a827", size = 36071, upload-time = "2026-05-04T20:10:55.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f3/e07293f4eded5b06b5bf73b8c0c09fd203ac1e0510942d462db30d66bd95/mypy_boto3_geo_routes-1.43.21-py3-none-any.whl", hash = "sha256:769e6100bf2dd2a28590bb372e7a4cc729ee5282437cc96099df1e622db8fc2f", size = 41556, upload-time = "2026-06-03T10:08:54.417Z" },
 ]
 
 [[package]]
@@ -3277,11 +3298,11 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-glue"
-version = "1.43.8"
+version = "1.43.29"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c2/a6/53ac30df6397a9712397ea9827fc57c472ecd5160efacf73578f8a116b4e/mypy_boto3_glue-1.43.8.tar.gz", hash = "sha256:08926f89eaaedea946aa3bcad29e19d7f30f1b45caea4ecb3340a439f8782c27", size = 139805, upload-time = "2026-05-14T20:17:19.784Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/dc/ed67cb6df63eb1bba54e1c7ecd75ad8bc00089eba0c8b1b44b1b67d8936c/mypy_boto3_glue-1.43.29.tar.gz", hash = "sha256:cbd44ef348009814d5532fd01de59f19c21532ca198c2e94b993c0dc1af59ff2", size = 141207, upload-time = "2026-06-12T20:09:11.843Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/86/e40bc7dd733aac33511f11e02949806a3242a14f5613bbf8ff74a0924617/mypy_boto3_glue-1.43.8-py3-none-any.whl", hash = "sha256:fc3f4402bfe8f1a41546a9ef36f856e66f7eb5275dc8a046f7f811e9cb4e6a24", size = 141390, upload-time = "2026-05-14T20:17:16.206Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/5a/9249a7b47c188c66467bbcb7f5cecb2c28bfc7a3b1b8540359d0fc5c87e2/mypy_boto3_glue-1.43.29-py3-none-any.whl", hash = "sha256:fb6b96eb0c288560f9ba33cc5f303b2688f713a9084ef2aae34262bf364423ac", size = 142772, upload-time = "2026-06-12T20:09:09.046Z" },
 ]
 
 [[package]]
@@ -3313,20 +3334,20 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-groundstation"
-version = "1.43.0"
+version = "1.43.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f7/48/9718a8c85ee328b1b94086d371d71c3aebbd1fb301c8fad5d999ade4c327/mypy_boto3_groundstation-1.43.0.tar.gz", hash = "sha256:9d328aeeaa9ad9aa7234ce3f53602984b1afa12a9e99529fa407228a5274a511", size = 34366, upload-time = "2026-04-29T23:01:12.672Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/e6/78ec6c091894ba754d48475fb1ede314441199946af6cc4a8b6ccc1e6498/mypy_boto3_groundstation-1.43.18.tar.gz", hash = "sha256:f830de0fd616a3df2678b654d8cceee401344bb1c583a91fc5e516521f577100", size = 34383, upload-time = "2026-05-29T20:08:07.808Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/7f/6e7925f6e51dd36099b4d75d632ba0e83cf782c8eea6f9f29b8d515de11f/mypy_boto3_groundstation-1.43.0-py3-none-any.whl", hash = "sha256:29e78fe8204a9cbd5155f07a45d3b22c6decd7dbbc6663643bedb0a3a6ddf034", size = 41474, upload-time = "2026-04-29T23:01:09.803Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/fa/3bfc5288dcd7643eaeaa4c32fc0235342ce67f9737629533dc1e6c7d07f6/mypy_boto3_groundstation-1.43.18-py3-none-any.whl", hash = "sha256:c92fd8e0db4d57be3738aaeb7932fdaaa6260a060f1561c67af0200329ed8213", size = 41497, upload-time = "2026-05-29T20:08:05.186Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-guardduty"
-version = "1.43.11"
+version = "1.43.23"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/86/16/c91f51763d0bae238a48a55c6cd055b3fecbfb657ef458de829e81ededfe/mypy_boto3_guardduty-1.43.11.tar.gz", hash = "sha256:3fc4176b815c6f27a1f669c587ee0e11bcba6a57a996c4a9a2d6730c2a3f3f07", size = 54552, upload-time = "2026-05-19T20:52:42.993Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/21/7b7726e7df0d6f814719beba158898b82d78a0fb8b8f9044cc9a9e2ad6b1/mypy_boto3_guardduty-1.43.23.tar.gz", hash = "sha256:f25a5d54e9f984f2a63934c2b442620afe1bb16857e8db44b71e1c82c28c0e9d", size = 54778, upload-time = "2026-06-04T21:04:37.957Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/1c/f9a53048ee946567d66fc9f1bbba74c53c19f5b5eb4d2eb38dcd5f563d21/mypy_boto3_guardduty-1.43.11-py3-none-any.whl", hash = "sha256:db40951a2d10d2960c39c87511ada163647c27c3c33d0efc5b3ad00922c2fe0c", size = 61882, upload-time = "2026-05-19T20:52:40.946Z" },
+    { url = "https://files.pythonhosted.org/packages/75/d6/9ed1ce918608ea0ad14d88521b74a08ab621bbe58ee05b2e834d528f5035/mypy_boto3_guardduty-1.43.23-py3-none-any.whl", hash = "sha256:195c15112de3f3363c399a515d87a51aacbd9f48117ae35f73967bf0a3f235e7", size = 62122, upload-time = "2026-06-04T21:04:35.23Z" },
 ]
 
 [[package]]
@@ -3340,20 +3361,20 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-healthlake"
-version = "1.43.0"
+version = "1.43.28"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/09/3631cf35bbd52df2cb447e0ec40dbce749df49bec252d76ac586ef933b6b/mypy_boto3_healthlake-1.43.0.tar.gz", hash = "sha256:61e7847d888cf19271726c64e9a9feb826a7f6c33360de125a20292da182cb3a", size = 18911, upload-time = "2026-04-29T23:01:17.263Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/bf/cd6b4e0ee91a9e78241f5d0bfe4ebe839df483a44114c713a73c5f9e39ef/mypy_boto3_healthlake-1.43.28.tar.gz", hash = "sha256:a919af80a21e95ad64dfc9ae08b30aac66c55a23a36a940f4b4a1743698f53eb", size = 19224, upload-time = "2026-06-11T20:36:37.748Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bb/c4/b5a650c647ffba800eb47dce361ec279ce239f817ad7113e4938cc97ec12/mypy_boto3_healthlake-1.43.0-py3-none-any.whl", hash = "sha256:cad285069781a8aeabac246aacd127b06433a82bd7a7efbafd4943adb95e0765", size = 25420, upload-time = "2026-04-29T23:01:14.289Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/31/36ec819cd217efc5782e1ff2cf46279e775afe467ea32bbd39c99cd8d71f/mypy_boto3_healthlake-1.43.28-py3-none-any.whl", hash = "sha256:0303fa4c7ef2a7694810e21f82334d64e5b86831be4bc006b4ddb41feda313ac", size = 26036, upload-time = "2026-06-11T20:36:35.498Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-iam"
-version = "1.43.2"
+version = "1.43.29"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8c/51/ac4c987c0e25c1a27430649dcde68b4775e68505cb71987b8d79c5c31ab4/mypy_boto3_iam-1.43.2.tar.gz", hash = "sha256:bb0325ab5e61c5a4627759ffe9fa6fbf4d227146f0b4858555f7a0289622f50a", size = 89320, upload-time = "2026-05-01T20:31:15.537Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/16/12/ddeb415e0465ebc8bbd439ba11d693eed3a4a894c6c37d662eb1de6333c3/mypy_boto3_iam-1.43.29.tar.gz", hash = "sha256:91c8a7147774409b7710bbd8478c66e28d63e8d67e8737c7034a591e00ef0940", size = 89344, upload-time = "2026-06-12T20:09:13.28Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/24/566fcba574dc1f38307a90cd84407da6e7097648d671c94148d508e87856/mypy_boto3_iam-1.43.2-py3-none-any.whl", hash = "sha256:64caf97b481c89ee4e5fea98af0c78097c7cf96344d179c8ebd41818244a0e59", size = 95086, upload-time = "2026-05-01T20:31:12.963Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/48/cd6093d60ae0d6ec4d704c02dc6e5183abbf6f4f11e1388da8d9570bbd73/mypy_boto3_iam-1.43.29-py3-none-any.whl", hash = "sha256:9dd57df92b4526598a5dfd677ff88ac8ecbb9fa053c7bf38bc001b554009abd8", size = 95116, upload-time = "2026-06-12T20:09:10.609Z" },
 ]
 
 [[package]]
@@ -3403,11 +3424,11 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-inspector2"
-version = "1.43.0"
+version = "1.43.22"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a6/f1/3bb56ab97201227a2530dd55ad779c779c73bec58de5b2471b70fce4f014/mypy_boto3_inspector2-1.43.0.tar.gz", hash = "sha256:75d17967707734c2a83354545854335104e704bef92309557af33f4766cef4e2", size = 53116, upload-time = "2026-04-29T23:01:25.634Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c5/17/f5fde77d1d69125d12b5cf3e0854de4c0b0ea9585d0e5567f7f9ce957857/mypy_boto3_inspector2-1.43.22.tar.gz", hash = "sha256:880fda8c1bc6455f8bdff3d9a1ab960eb91dfc556fb4ebf8f4ef3cc6d950064e", size = 53221, upload-time = "2026-06-03T21:49:51.28Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/0c/ab68c9a20ecbf2b600c23b57a93224ef9fa378456e12ed3fb3515ace4dfe/mypy_boto3_inspector2-1.43.0-py3-none-any.whl", hash = "sha256:1e8f8f2cff09ed289fbc6d35b8e76140a0dcb8527866a5c9d1e71e6e51b21453", size = 61832, upload-time = "2026-04-29T23:01:23.999Z" },
+    { url = "https://files.pythonhosted.org/packages/20/23/a134141be3e95097f51a417657df15ef08f8229273a08c4b36f5a8c3f001/mypy_boto3_inspector2-1.43.22-py3-none-any.whl", hash = "sha256:7f20131588f148ebfdbe4b10e87b09c66817eef717ac8494c2f67400f6f4be86", size = 62019, upload-time = "2026-06-03T21:49:48.449Z" },
 ]
 
 [[package]]
@@ -3430,29 +3451,29 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-invoicing"
-version = "1.43.6"
+version = "1.43.14"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9a/83/68f3c0cc1f28b26d9561c91d921cbfdea78e2feeca521ce3b68ae66a32da/mypy_boto3_invoicing-1.43.6.tar.gz", hash = "sha256:d5dc72a3d290fcf465d93d69765cceaf6a945b49800d37b4acb0f215136b9833", size = 20673, upload-time = "2026-05-07T21:15:24.036Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/48/21/ca18825ca74fd9550617855a9f6d7ac6b5c6512171e8144b9764079cbf99/mypy_boto3_invoicing-1.43.14.tar.gz", hash = "sha256:75650e8a02b232209935daf26fdf52336340a9d00bc9f58f9acd883d08336e5d", size = 20688, upload-time = "2026-05-22T20:48:22.537Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/31/0c/4ead1821c76816fb7d56def8ba23eb6d90257411163436f286f4aa8d3c91/mypy_boto3_invoicing-1.43.6-py3-none-any.whl", hash = "sha256:b6ab7c150bc50ea803983e5d2d626de483f97523fbd624dcdddc0dc83df0f112", size = 28707, upload-time = "2026-05-07T21:15:20.277Z" },
+    { url = "https://files.pythonhosted.org/packages/30/9a/582087bce44b90600b1b4bcc8497c9180f7aab455e52ab43978daa18c546/mypy_boto3_invoicing-1.43.14-py3-none-any.whl", hash = "sha256:fcda7b9ec128e9d15b106f917f275ff46fd9d4fdba93f3d82f5761decf100e54", size = 28725, upload-time = "2026-05-22T20:48:20.642Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-iot"
-version = "1.43.2"
+version = "1.43.20"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a4/5e/80452dba6209cdefe9fdf2fc15056895aa48d47091552fd7caa02006296f/mypy_boto3_iot-1.43.2.tar.gz", hash = "sha256:e3fa73c86cb730f0d989ecec1b236c918c8c67bb51fd9f30bd159d1f6198f2cf", size = 111027, upload-time = "2026-05-01T20:31:18.968Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/8b/361b79ae7eb10adc366bf77491f070e7c2e93ada4ffc5ef49f85ecdfd920/mypy_boto3_iot-1.43.20.tar.gz", hash = "sha256:6404480bac90544910d59b5b33c1e641bee61cb402ff7a353d22c20ff2ae0b8a", size = 111432, upload-time = "2026-06-02T22:17:18.805Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/55/ec20ccb3f48068eb50fa15a6cb22b9aa9fb0a3ebee75ef36c1b8d9cd2e91/mypy_boto3_iot-1.43.2-py3-none-any.whl", hash = "sha256:c2e2faa6972dd49399a8268262f6dbe942c31e3e686b0ce38e494ca3289429a0", size = 118733, upload-time = "2026-05-01T20:31:13.394Z" },
+    { url = "https://files.pythonhosted.org/packages/19/b8/349cef8edde40b1a3831241c81834bc89ba05e02ae2f13e2f5c679fb14cd/mypy_boto3_iot-1.43.20-py3-none-any.whl", hash = "sha256:5c6f0677047a099085b0d1f7f39a0b5684927d783967c0a043279d49d96de593", size = 119155, upload-time = "2026-06-02T22:17:15.245Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-iot-data"
-version = "1.43.0"
+version = "1.43.17"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/65/af/f90d2431ff5ccfe27fb9a1bbc0e94e0de4e28cbbff5feebd111a0cdff14a/mypy_boto3_iot_data-1.43.0.tar.gz", hash = "sha256:26ac6089d21cabda99ec2cc55884580bebd64e9cdb3acda7ff465f6133e47cf8", size = 16902, upload-time = "2026-04-29T23:01:34.903Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/e4/24dad9303cb2735fb71e9a6f8c87352b153a60b22dea40414560983853c9/mypy_boto3_iot_data-1.43.17.tar.gz", hash = "sha256:645a7a7f9d4957cc1393a08134b765e25364132e31034dbbcf17d841d08809ad", size = 17768, upload-time = "2026-05-28T21:21:00.317Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/53/d8/ca170aeeedd3a25b4052fa9b9eecf7b839fd3e27c0b4fdabedb6e881bb33/mypy_boto3_iot_data-1.43.0-py3-none-any.whl", hash = "sha256:8ab7a6b4a6a905cf6fd87a2ea504cc3ac55733bab0955a4683f205ac6ac7bd45", size = 22125, upload-time = "2026-04-29T23:01:32.101Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/d3/afc3663c05fb7763fc943884c3be3d1b6a0fafe05f02177148d9daf0092f/mypy_boto3_iot_data-1.43.17-py3-none-any.whl", hash = "sha256:24ebe4746189d4eaf276fd2ed048f459e91164a942e9e0d7eaa6c31d2162b435", size = 23592, upload-time = "2026-05-28T21:20:57.904Z" },
 ]
 
 [[package]]
@@ -3556,11 +3577,11 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-ivs"
-version = "1.43.10"
+version = "1.43.23"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c4/08/62fb56fdcd416df2a5f36059b5475dc7fd0fbc73b1a297d537ef2a79fa73/mypy_boto3_ivs-1.43.10.tar.gz", hash = "sha256:d90df22dbb8713fc7de91b45d595bc7c14ef41f9ae8cb0bd6715c699ce652428", size = 23027, upload-time = "2026-05-18T20:46:48.323Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/55/0a0a3f07cdaafc0fb4dfb721ecfd4f424720ab8117afc24ba9d12a106841/mypy_boto3_ivs-1.43.23.tar.gz", hash = "sha256:183ace16d01519e8992a71d4b3a272cb4470fb8a97eefba3ce59b0e98a2b7cde", size = 25682, upload-time = "2026-06-04T21:04:38.621Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/31/5a46b986e51016ff8ccf5d0a488a927ad2dc39375b8b3d4deefb961d636b/mypy_boto3_ivs-1.43.10-py3-none-any.whl", hash = "sha256:8ba164c59e8f1734fcb6e6f761dba064b3e45f70edc47f58d4bbb229bcd167af", size = 32101, upload-time = "2026-05-18T20:46:46.474Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/c9/9a9a2a69a2f214e8513f9488b9d730fc84b046b42c5d1b015b4eae37e6dd/mypy_boto3_ivs-1.43.23-py3-none-any.whl", hash = "sha256:af3c30e626c4dac156a81d8c8a4458ae830e6a18afb0d25b468e545fbfa31818", size = 32243, upload-time = "2026-06-04T21:04:35.845Z" },
 ]
 
 [[package]]
@@ -3601,11 +3622,11 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-kendra"
-version = "1.43.0"
+version = "1.43.23"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/88/8d/c2f905ae696d699ccd0f0241140e9da46a8e2d3800f664d64d98aca5501b/mypy_boto3_kendra-1.43.0.tar.gz", hash = "sha256:ef3c7bbb7921e8d881b8beced6795b834a310673d28751cc467c93adffc0c95f", size = 46550, upload-time = "2026-04-29T23:02:03.365Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/d9/8277f5e21314bbf5395d15b40aeca0e23474e25cb38bb175b73df3594660/mypy_boto3_kendra-1.43.23.tar.gz", hash = "sha256:ceb41040d7a3abfa352104e9c103b6ae86b94584de81d911c4fb2610464a0857", size = 46570, upload-time = "2026-06-04T21:04:39.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3e/b8/b1486a67b8a43e5fa4f8e8573d1c4dfe5d56344ed6f20e6be51a5a9b5109/mypy_boto3_kendra-1.43.0-py3-none-any.whl", hash = "sha256:967af1a00ba82031c1d659b2bbae8e14f00401824aa788afcdcd8a4e15a0bcf8", size = 50671, upload-time = "2026-04-29T23:02:00.2Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/39/9b71bb52a55d5b919cf47e1c754f5b76eb6b1e52ed2a300c9c6ef37e4853/mypy_boto3_kendra-1.43.23-py3-none-any.whl", hash = "sha256:e1676f31011a5739220c9ef10d0fab50f775970c6e4c6192692a10118a2b44c3", size = 50703, upload-time = "2026-06-04T21:04:36.294Z" },
 ]
 
 [[package]]
@@ -3628,11 +3649,11 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-keyspacesstreams"
-version = "1.43.0"
+version = "1.43.20"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/35/e7/56a49c320f74da41cea5de358b60951daf784614d5f7324ecde1baf43aad/mypy_boto3_keyspacesstreams-1.43.0.tar.gz", hash = "sha256:3974f2f47fe208dbeebe420e260f1d46205effcd84ab5dac30452d92e4395192", size = 17171, upload-time = "2026-04-29T23:02:06.472Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/3e/ea09ac03880dd261b9b262ab1d632e1b852f3a109452aa52e27432ed7923/mypy_boto3_keyspacesstreams-1.43.20.tar.gz", hash = "sha256:c37e5677d05f08444d5ea56b329ad8c643ce2f42ad78a0761034babefeaafe11", size = 17237, upload-time = "2026-06-02T22:17:19.369Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/31/27/157985b14317fd06f73d2ee0f6ee1e7fb64cb631cc0235b8c8d82c4ffddf/mypy_boto3_keyspacesstreams-1.43.0-py3-none-any.whl", hash = "sha256:5bc0155b65517dfd5838ea8e374607d1fd9e20ad8e40159e712aac210f32d282", size = 22981, upload-time = "2026-04-29T23:02:05.165Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/26/01d6394016a2d0f35a841f2885e53bd5b3b5d363bfabaf55d307393eae98/mypy_boto3_keyspacesstreams-1.43.20-py3-none-any.whl", hash = "sha256:9d819e40fcf5529d67f2551a9b81a7eee8dda8799158b7bdbb69999fc1b1c110", size = 23159, upload-time = "2026-06-02T22:17:15.907Z" },
 ]
 
 [[package]]
@@ -3727,11 +3748,11 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-lambda"
-version = "1.43.0"
+version = "1.43.20"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f8/d9/de2ca1f584ca9522ba94a7b3fd76ecde609d6a67ce3c598d2da705c1067f/mypy_boto3_lambda-1.43.0.tar.gz", hash = "sha256:a58de26b5c13be54deab31723ee9ab7aaa922be1dfbd093dc3a4ca12cc853157", size = 51934, upload-time = "2026-04-29T23:02:24.512Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/9c/a8a7d7feb5173764bc50b1d18d68308452b3d89ccd625eb924b471d8da6a/mypy_boto3_lambda-1.43.20.tar.gz", hash = "sha256:c1d628adf4809a50d51054654318ae8d6bbf3856eaea7280d9a66dd66bff8ac9", size = 52162, upload-time = "2026-06-02T22:17:22.776Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/2a/f7c67471c63314ef1ab68099d1137ba2337bbbde1e2166fb9e0b9556d894/mypy_boto3_lambda-1.43.0-py3-none-any.whl", hash = "sha256:847b8f12b74f881c743464cd0010a04e2b21201b39ac92b1040c6cd276bac4e6", size = 60308, upload-time = "2026-04-29T23:02:21.409Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ff/50085318196b560f20a37d143511623272944ff1ded35ce6e26856bff233/mypy_boto3_lambda-1.43.20-py3-none-any.whl", hash = "sha256:1e0e44e886045d822d7cac31a70692a89300a97028d0d6cb9486373cf91157d2", size = 60562, upload-time = "2026-06-02T22:17:20.077Z" },
 ]
 
 [[package]]
@@ -3808,11 +3829,11 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-lightsail"
-version = "1.43.7"
+version = "1.43.27"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4a/34/c5501e6cce68a7321c1f9c9ed664c18d90f6955c1c31fdfcfba51dbb8c99/mypy_boto3_lightsail-1.43.7.tar.gz", hash = "sha256:d6287042865304ad70f0007e2b7aad4993aa0d02d35e65cb8b8ed0a663a40aa5", size = 66045, upload-time = "2026-05-13T19:41:18.366Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/33/d308d54a7f706e5cc3439c68acb1bab36c26f7703220f47ff563829ff216/mypy_boto3_lightsail-1.43.27.tar.gz", hash = "sha256:6af209620aed280faaba4c776a86cc5e2780e7ae2809a025a9d4ade7c3c593e8", size = 66057, upload-time = "2026-06-10T19:56:09.739Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/db/17b33ac31f422e8370547f96217600ce22663a9919275349d4317d07fb73/mypy_boto3_lightsail-1.43.7-py3-none-any.whl", hash = "sha256:46967a8ea38a44a1b3043394c8e08f30e5c2481baccff66155d59a3620baa720", size = 74692, upload-time = "2026-05-13T19:41:14.757Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/62/c02832775143d2e34cd5db13300f1f3a290c13734abb7d8169d16f673a1f/mypy_boto3_lightsail-1.43.27-py3-none-any.whl", hash = "sha256:3f7143730c4a3abb41381e3d963d6ba29bee262bcf294c4d4be6d165eb1ba757", size = 74748, upload-time = "2026-06-10T19:56:05.832Z" },
 ]
 
 [[package]]
@@ -3898,11 +3919,11 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-marketplace-agreement"
-version = "1.43.4"
+version = "1.43.19"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/52/e3/937bb46a101adb4c6351df9d3f7cae68c95bb3752f8cea0176e0fb7a9f0d/mypy_boto3_marketplace_agreement-1.43.4.tar.gz", hash = "sha256:5dcc4d8536325f14b308754034253bcbd542fc6f35f841a7240c373e2852fb60", size = 27004, upload-time = "2026-05-05T19:53:16.492Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/42/e5/ace9b48c947adc1fbd072c2a428357853b612292958a9238006c5a5aa1ab/mypy_boto3_marketplace_agreement-1.43.19.tar.gz", hash = "sha256:0ca68e316956270db4b80f6e83bbb1dc4b375227fbe67ee2e2b6ceed291733a5", size = 27079, upload-time = "2026-06-01T20:03:11.165Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/5a/3c8888c87fc8c8d273c138ce962ba526143269fc1579baad3e57871cf8b5/mypy_boto3_marketplace_agreement-1.43.4-py3-none-any.whl", hash = "sha256:83629dd9f0fee8ec45af6b7d40de2b3ba5a9af4f6aa5d6f9ddb3514f440a2342", size = 34713, upload-time = "2026-05-05T19:53:12.595Z" },
+    { url = "https://files.pythonhosted.org/packages/33/ca/9990fa496b2b68753d70debb58618f6b52bae5fa95dd5d02861fc54c4ae3/mypy_boto3_marketplace_agreement-1.43.19-py3-none-any.whl", hash = "sha256:09269aca235fc16d2bb70b5af92ce9348fe9aaaabd6a27538b6cfc3c19717711", size = 34761, upload-time = "2026-06-01T20:03:09.554Z" },
 ]
 
 [[package]]
@@ -3961,29 +3982,29 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-mediaconnect"
-version = "1.43.0"
+version = "1.43.13"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/bc/3b/e566124dc8b3a7f49cec3ad6850878528f2d0ebb243c660b014e9cb21090/mypy_boto3_mediaconnect-1.43.0.tar.gz", hash = "sha256:393e1b197ec3693accbb311d2bbd467a669e5b33daecc6c3778f9b029b8f64bc", size = 48849, upload-time = "2026-04-29T23:03:01.491Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/fd/7d4c56062e88602b012a46095bc4d1fd5bc1555a9357d8fbfdf2f167c6f1/mypy_boto3_mediaconnect-1.43.13.tar.gz", hash = "sha256:e2104ccb88f719d49dabb332794f1ad561d8accd266f9e8e96a3de2a475bb7bc", size = 48950, upload-time = "2026-05-21T22:50:55.949Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8a/fe/59d97eedda6b955b997d2afcf33e6468e5c7631fc13119572010cfa0033f/mypy_boto3_mediaconnect-1.43.0-py3-none-any.whl", hash = "sha256:ada9662020ce7a0b3b6caf87ace6f265e405774e459f749f60b7f3dafb6f1a38", size = 56227, upload-time = "2026-04-29T23:02:58.572Z" },
+    { url = "https://files.pythonhosted.org/packages/af/01/d6051dd202639c47896934d090df1e1139bcd2aa917da1a49cd05525812d/mypy_boto3_mediaconnect-1.43.13-py3-none-any.whl", hash = "sha256:4eb2939b8ee0d14878a4cbc5f3a8d9a16105da20db072d8e8ea559475d8a518e", size = 56395, upload-time = "2026-05-21T22:50:52.954Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-mediaconvert"
-version = "1.43.0"
+version = "1.43.24"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/95/5a/d3cd33279e73f8b25eab1c3da2b2f338ceb86da398aa156a893656136242/mypy_boto3_mediaconvert-1.43.0.tar.gz", hash = "sha256:8e26267f449637458187a90946597098f320719c82c4f46e3f6183d836afa8a3", size = 80858, upload-time = "2026-04-29T23:03:03.971Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/12/ef/b3acb8ab7318fa05e66e70d9d1f78e30d98f0fc2a3ca6d389ab9f26d6520/mypy_boto3_mediaconvert-1.43.24.tar.gz", hash = "sha256:55a1b076a804453b337068a9e05cad22c9baafd9800e8ba2b69396566045064a", size = 81369, upload-time = "2026-06-05T20:45:25.746Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/67/48/7fd965657fff3b543bccb9774529d5a93a5a78d5ff88f4fc5e66764b3dc2/mypy_boto3_mediaconvert-1.43.0-py3-none-any.whl", hash = "sha256:030849bf760f6c76cefcd457d643697ea3de7fe08a227328ed2abdbc981d8ff6", size = 84577, upload-time = "2026-04-29T23:03:01.677Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/ba/89745b827cf8d4774ec33091e623342d51003d077706df34ed98c55de1a1/mypy_boto3_mediaconvert-1.43.24-py3-none-any.whl", hash = "sha256:3c430927680d663d3fe67fc6f3f53d8b7d4aca2016cc78ea6b4acb9326eb228f", size = 85091, upload-time = "2026-06-05T20:45:22.328Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-medialive"
-version = "1.43.3"
+version = "1.43.27"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/17/87/c1e39d75acb31b56b8abbb06de6982a558635eb55f140aaa7f2e2e65856b/mypy_boto3_medialive-1.43.3.tar.gz", hash = "sha256:e17f0fc39dbe7715f71410d9a70e25bb6523ed5a4e79c31cb9f16c23b85837c2", size = 108981, upload-time = "2026-05-04T20:11:04.252Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/42/d6/905662327c3c0e4d74ddf9bf3c36309dcda4b73c32278954af81ae6ac665/mypy_boto3_medialive-1.43.27.tar.gz", hash = "sha256:d0b9ed33b51fcca5343ded29793bd9c362e5e7d0cd35155a8eb07c2f94e1802b", size = 110023, upload-time = "2026-06-10T19:56:11.281Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/ef/7404a305604e5dc9f2a7b80605a72ac5f056e579645b0a497652f4771a4b/mypy_boto3_medialive-1.43.3-py3-none-any.whl", hash = "sha256:e4867e77b35f3c873eb1b6eb2752385c615ba28f503414128294fc076a15a02a", size = 112119, upload-time = "2026-05-04T20:11:01.322Z" },
+    { url = "https://files.pythonhosted.org/packages/63/94/4a57cc8251af6c5beefdfdcb56ccb36b755b1283327eea39afd253e01419/mypy_boto3_medialive-1.43.27-py3-none-any.whl", hash = "sha256:9972fa406a11b6dc35cc6ffea5d7a067f82399b40e7fa514e7b79fdcdabe3ab0", size = 113102, upload-time = "2026-06-10T19:56:06.705Z" },
 ]
 
 [[package]]
@@ -4006,11 +4027,11 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-mediapackagev2"
-version = "1.43.9"
+version = "1.43.25"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/04/e6/998e15e745bac32214ca519046cd95e275312b4005291e49e8d032b729fb/mypy_boto3_mediapackagev2-1.43.9.tar.gz", hash = "sha256:d524a32e02e8181d82ee7aa9009b72f815fde1cc08730a011a4d3794c3a03018", size = 27310, upload-time = "2026-05-15T20:09:48.001Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/39/31/4b5c36424ea6c09ab0810501bdbcc9d797fffcc2c8a2c09e0f5feae9a521/mypy_boto3_mediapackagev2-1.43.25.tar.gz", hash = "sha256:5f17bc500c7211ed04e1c426041e22935a38555b545a6061ac6a953b8d606605", size = 27406, upload-time = "2026-06-08T21:18:25.138Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/9d/f2462ee8281c7b3b867b0c50a5f9c685e403e1d578e165dc68a071ecb828/mypy_boto3_mediapackagev2-1.43.9-py3-none-any.whl", hash = "sha256:f67320c56693165b41f29fe79028af2da4427f1f9dd7e8cf5836cb323fde0ab5", size = 35595, upload-time = "2026-05-15T20:09:45.497Z" },
+    { url = "https://files.pythonhosted.org/packages/20/a3/eeaae82951a1d5a84ffda55aec56fe503e603c22f755b317442525da4250/mypy_boto3_mediapackagev2-1.43.25-py3-none-any.whl", hash = "sha256:f866962994bcae410c1078aa549633089dad65bd961d442c8744805e2ac62313", size = 35786, upload-time = "2026-06-08T21:18:23.76Z" },
 ]
 
 [[package]]
@@ -4078,11 +4099,11 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-mgn"
-version = "1.43.8"
+version = "1.43.25"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d9/1d/a17e73238c21e6d7f784d3573cd295e8046e5a1708dc2754525c120cb39e/mypy_boto3_mgn-1.43.8.tar.gz", hash = "sha256:a8bbecec5fc53ce2c7b159f3bc018ba8a45e75999dc7a39624d90fed048b13b4", size = 54701, upload-time = "2026-05-14T20:17:23.444Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/3a/4d8f8905de5772e98db89d835162332be87a9f2268d1a54104b8f7aca705/mypy_boto3_mgn-1.43.25.tar.gz", hash = "sha256:7cc71b4fcdd61d83262a01f929227999a48b8e461a5dd723ff1f305e118d4c09", size = 54743, upload-time = "2026-06-08T21:18:28.281Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/68/60/8b0629e702a4483345b37bb5618227c3b614f4f29bac066b6ef4af51daf4/mypy_boto3_mgn-1.43.8-py3-none-any.whl", hash = "sha256:2de1b14df5fd5100332875a85ed7cd2c44e70dab828d1da8a99b2349d3cb1e0d", size = 60371, upload-time = "2026-05-14T20:17:20.949Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/6e/5f88acddf1b059506a126595b3d298d364dbd7eff6735503849f3cacb75a/mypy_boto3_mgn-1.43.25-py3-none-any.whl", hash = "sha256:c5c052d7802607112b677c2667252541cbd4d93d713ed0bf7206768242ff7783", size = 60433, upload-time = "2026-06-08T21:18:25.681Z" },
 ]
 
 [[package]]
@@ -4168,11 +4189,11 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-neptune"
-version = "1.43.0"
+version = "1.43.28"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/90/e9/4a7f0ac1502c544b9a17b7cf1dfe0251380436a7343f3bc626b8cb053279/mypy_boto3_neptune-1.43.0.tar.gz", hash = "sha256:fbeb5a3cbbd7f665b3942047b6bde92d53d6513fd670576d083ef7a71a03aa36", size = 40568, upload-time = "2026-04-29T23:03:40.168Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/d7/1a4ae0c96948899bbb8b0161b4602e3b409d26a09dba2dbf523e12af4333/mypy_boto3_neptune-1.43.28.tar.gz", hash = "sha256:8a05a66e452a0224be902a07e4357bd926950f579a5feef45751dc6274c65dfc", size = 40657, upload-time = "2026-06-11T20:36:39.192Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/50/29/8ba57e7c46d33413e326de64a349c76e06df6c03db0eddf6684f97e97af0/mypy_boto3_neptune-1.43.0-py3-none-any.whl", hash = "sha256:d6dcea9e3c716ec46849b19bee794c7238cfe3b1f837c5a1686c5951d8cd2819", size = 46795, upload-time = "2026-04-29T23:03:38.121Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/10/acbfc53b67d4db309aa881abf22386fb1cb1eb638bee0e5a5c6bafcf6e73/mypy_boto3_neptune-1.43.28-py3-none-any.whl", hash = "sha256:b382c673807a4150b46dd633d16515090e7ffd8b7720cb8c0364cafaa10a0532", size = 46910, upload-time = "2026-06-11T20:36:36.132Z" },
 ]
 
 [[package]]
@@ -4267,56 +4288,56 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-observabilityadmin"
-version = "1.43.1"
+version = "1.43.25"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/40/33/2a86244d954b82f0ef05970df334e4a5ba74c8e97cb6e6f563343ed4fa43/mypy_boto3_observabilityadmin-1.43.1.tar.gz", hash = "sha256:661cace596854e06fc8c55213a9cd03bdf3d2bcc2c4c1bcad96a0b33bec03218", size = 27058, upload-time = "2026-04-30T21:16:21.58Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/d2/4d3b6f9d7ce22fbbab0b6a5188982cbf5783a95041429157c4bcdccb7bd8/mypy_boto3_observabilityadmin-1.43.25.tar.gz", hash = "sha256:7a518457b4ca4d42b8c664f633da4707e00d50b425d8d6418255e4b0742caee8", size = 27187, upload-time = "2026-06-08T21:18:28.999Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/06/4d09c7ae07589d51025e683f9595bba5549041dbe04a3876ec8ce4137471/mypy_boto3_observabilityadmin-1.43.1-py3-none-any.whl", hash = "sha256:18ee08b5ae431830eaad925e7199c2b90b66aed9b69eaabd31488759e2d12f48", size = 35152, upload-time = "2026-04-30T21:16:17.761Z" },
+    { url = "https://files.pythonhosted.org/packages/62/b6/ef152a423dbeec575da8e55c54b1882bac0a04b7b7a0aa89a4d66594dfad/mypy_boto3_observabilityadmin-1.43.25-py3-none-any.whl", hash = "sha256:0f24abaff317b24171649c773604e1de45bbec07374e4deee42e0385d2d5c875", size = 35313, upload-time = "2026-06-08T21:18:26.864Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-odb"
-version = "1.43.0"
+version = "1.43.26"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8d/b6/9b711991f94682d7ba6676b04955831d281dedfaed9ca23dbeb8846568ab/mypy_boto3_odb-1.43.0.tar.gz", hash = "sha256:b7c4144d502d0e04fe6c22da7bffad3889eb1cb6c481cca0246981f148e1796c", size = 33373, upload-time = "2026-04-29T23:03:54.199Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/90/236436881b18326ef9c27e4ca4d795173a1aab8eb9e06e27a86e1e259929/mypy_boto3_odb-1.43.26.tar.gz", hash = "sha256:91c49b7c4b7b649f5f48d8220c0255d725e8f54810b4c44d41c22e06269c58c5", size = 45678, upload-time = "2026-06-09T20:33:12.175Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/be/30df452bb2c5435980baf88a87a76984e2d0e0166d98384486281b05106d/mypy_boto3_odb-1.43.0-py3-none-any.whl", hash = "sha256:eecbfd7fbd02b0acdfacf49c367350e71d1eea4e20c1d75b94162bdce508f5bb", size = 38640, upload-time = "2026-04-29T23:03:52.414Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/10/ca660e87d5175800f89e99c49d897bc8bf9813ce9f44f691fc366e3d4813/mypy_boto3_odb-1.43.26-py3-none-any.whl", hash = "sha256:b747783e9f6f868564dac318c135fd5d766a333052ec226d84a11ea2840ef2ab", size = 52142, upload-time = "2026-06-09T20:33:08.615Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-omics"
-version = "1.43.0"
+version = "1.43.28"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ed/a4/70b3a3b67ac987c5b9b990bd63859146f62687eb33f58a1c7ceaaa85fd61/mypy_boto3_omics-1.43.0.tar.gz", hash = "sha256:6f2e6de71fafbbce2f8ea7b5efab45733d73843508b26528e9d1f97f73b258ec", size = 59321, upload-time = "2026-04-29T23:03:55.494Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/20/446ffc017084c2a4fb0ee41c8a0b3e4762b22604511b704e1630fd30f4dd/mypy_boto3_omics-1.43.28.tar.gz", hash = "sha256:7656581b433a1f56f74b2a1c98573e1d0627f4c5f57ebc8d268e9c22eea96810", size = 59400, upload-time = "2026-06-11T20:36:40.001Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/cc/215bc567d25a204b59fcb149d7281b38d72d7de3bdd56b4cac12f4546703/mypy_boto3_omics-1.43.0-py3-none-any.whl", hash = "sha256:1907e5841452cc94bdc400ff287169b86a00f6fb62241f2a38e159fd201d10c5", size = 65856, upload-time = "2026-04-29T23:03:53.477Z" },
+    { url = "https://files.pythonhosted.org/packages/08/00/26afcd7fd64000d086fcf9914acb5a045c04b1db78ef8fe65179337be988/mypy_boto3_omics-1.43.28-py3-none-any.whl", hash = "sha256:0d2858f2a6ccd57ea651055f2f86ada6ab2d52b0e8030dc16f90565d03485aff", size = 65975, upload-time = "2026-06-11T20:36:36.605Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-opensearch"
-version = "1.43.7"
+version = "1.43.16"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a3/40/6182dc2a6104038f963fda48cb5cf38631011b75bcff52f43bf438e8c175/mypy_boto3_opensearch-1.43.7.tar.gz", hash = "sha256:d523b85618fc18b10aef47ad60c08123fd1e3eb059802769c133da11cc25e733", size = 48753, upload-time = "2026-05-13T19:41:20.039Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/6a/bfcec88e3cf066112ecced24520c2f7e61bdd32351a913764a8dca2d6deb/mypy_boto3_opensearch-1.43.16.tar.gz", hash = "sha256:be8e056d39e6eef1cf8012a5bc697ba99fc7fedb91933addcf0048f367b07214", size = 48740, upload-time = "2026-05-27T19:38:12.744Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/16/d1a385b28cd8d06addc492d109bf6184b8ca79201361bf14ef744ca27de0/mypy_boto3_opensearch-1.43.7-py3-none-any.whl", hash = "sha256:c6e91ee025c8dc1c74c3f84d3069b6c43b7ae24330c877ffd4a27494685cde6b", size = 54826, upload-time = "2026-05-13T19:41:16.919Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f0/0ca78b72cfe1b63f9fc9dc385f185b12bfbd867f05f4421891bc44cbfb8f/mypy_boto3_opensearch-1.43.16-py3-none-any.whl", hash = "sha256:041a6fd1ce9e6e6920508fc27bde11bd3e3b307183c5e3fb4b58037ab97f9adf", size = 54837, upload-time = "2026-05-27T19:38:09.797Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-opensearchserverless"
-version = "1.43.0"
+version = "1.43.17"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0e/ed/82f352155f398a46c1d57019f5908ef231c58f9dcd9d733017815c8ab307/mypy_boto3_opensearchserverless-1.43.0.tar.gz", hash = "sha256:5eb0eecd6f697361f63d2de1eab23bf358fd9271be1114dd12f3a282e9ad66e8", size = 26712, upload-time = "2026-04-29T23:03:58.014Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/bc/160efff7501af2a42ec42ad59f99e29fbfce902c50913d06d07a74dfdd89/mypy_boto3_opensearchserverless-1.43.17.tar.gz", hash = "sha256:3517c07c396331b1676076948135cca1d2f92fd2cb64354c8c18ac4151d80b66", size = 27011, upload-time = "2026-05-28T21:21:07.137Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/96/2a/6b551bfb0934088e3533e2e42e32e3600276f492b0148718aad590e38da9/mypy_boto3_opensearchserverless-1.43.0-py3-none-any.whl", hash = "sha256:7379450f2459fd9e54dcd9fc69ec54e178883d587c436e3ed1fef26ef9657266", size = 29233, upload-time = "2026-04-29T23:03:55.974Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/b5/c8ea9391701a67e6f02344cac3dfb04c75afdc122a4409f372fc176c790a/mypy_boto3_opensearchserverless-1.43.17-py3-none-any.whl", hash = "sha256:1641882c9854a9b98c0ba00cc07de021201f82d698c99793c824572feabf07ce", size = 29736, upload-time = "2026-05-28T21:21:03.192Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-organizations"
-version = "1.43.0"
+version = "1.43.16"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/85/09/4079b10f0b13eb83aa211d802af7a71e23762551e259a949582b9ecb88c9/mypy_boto3_organizations-1.43.0.tar.gz", hash = "sha256:bfbd97f4a2444ca2bda69c7522df7ee72c3011db474510668fc19c489ace0427", size = 36176, upload-time = "2026-04-29T23:03:58.975Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/24/14cd32f2d9d0741bed3e212f1804aaa36213e2799519aaff021169624d37/mypy_boto3_organizations-1.43.16.tar.gz", hash = "sha256:952409a2a691eeb4f76773928053436db99f7037cd3e686a578680c82d51d7ec", size = 36189, upload-time = "2026-05-27T19:38:14.309Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/08/aa/3f1e16f5f7444a5c013f2b1eedbec5577376f6478d3741ff9bc068dfc7fb/mypy_boto3_organizations-1.43.0-py3-none-any.whl", hash = "sha256:a70c4e7de33080a0655e22188e98a0697a79156c8dc479f4152fb66e64cdc9a6", size = 42581, upload-time = "2026-04-29T23:03:56.506Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/4d/3da1101e75b85c604eee0386f912388c72348a161a625868637728f6f320/mypy_boto3_organizations-1.43.16-py3-none-any.whl", hash = "sha256:fd2202890b1bfcb355f6d53bf16e65ea23041a4dc5ba7838ce953bb94dbfb47b", size = 42589, upload-time = "2026-05-27T19:38:10.284Z" },
 ]
 
 [[package]]
@@ -4330,11 +4351,11 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-outposts"
-version = "1.43.0"
+version = "1.43.26"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a4/36/243c830e13c35feb2170c75fb0d748ee33fc8e8683449f8c65fba4885242/mypy_boto3_outposts-1.43.0.tar.gz", hash = "sha256:7d528d017ddcc7d8de0a775c418cb1a7d960a872fdd7214e83a757fe436fdbb4", size = 25432, upload-time = "2026-04-29T23:04:02.405Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/c0/41b430cc9b8701b00373bc00b88276af97a48c266ab974b96757c23974b2/mypy_boto3_outposts-1.43.26.tar.gz", hash = "sha256:196b19d516724edf00d383bdb351de6a40e15293a67464521a35f2da5217c4aa", size = 33182, upload-time = "2026-06-09T20:33:13.716Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/9e/ad06eb94c867b4dca7a3a381f013d639b317d199bf21346b62f57fd5e998/mypy_boto3_outposts-1.43.0-py3-none-any.whl", hash = "sha256:4f0309906d63775be6d52ad3789259ccf388d1280e7d65ebf7922de861703926", size = 36486, upload-time = "2026-04-29T23:04:00.136Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/19/9576c02911675a0c6e863c4ab9bf748766ee55bbbc2e03b204395e557acb/mypy_boto3_outposts-1.43.26-py3-none-any.whl", hash = "sha256:61260f0f3a085ca2bade5ff45ae9f6dfb2ed340c49fb66d22193a973899d7807", size = 40026, upload-time = "2026-06-09T20:33:09.237Z" },
 ]
 
 [[package]]
@@ -4384,11 +4405,11 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-payment-cryptography"
-version = "1.43.1"
+version = "1.43.24"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/91/f3/5b18a3e7b01e412534ed6df2bf0954682805864ff7330598240ea661d0dc/mypy_boto3_payment_cryptography-1.43.1.tar.gz", hash = "sha256:d0eebb2508f9f7e7ac256081195cd1363ef7c816e795d85acb6f2bc61ee794dd", size = 22843, upload-time = "2026-04-30T21:16:24.388Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/c5/27063c035bfb19c8e6918d6174ba0254587518c83c44b2c773d6786526b7/mypy_boto3_payment_cryptography-1.43.24.tar.gz", hash = "sha256:47ef4d842c9428e84c642c96965d648a56c11a570d7e9a845e0415b240e8fe75", size = 22868, upload-time = "2026-06-05T20:45:24.086Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d3/61/bc69c61ddd4661a522ffe157299c44c418dd3d9d6a6a752a1f3550dbbe66/mypy_boto3_payment_cryptography-1.43.1-py3-none-any.whl", hash = "sha256:5069d9ba3fdca7509054c6926df1051d9c0f64693f8272c7aa8b03f19541460a", size = 32903, upload-time = "2026-04-30T21:16:22.54Z" },
+    { url = "https://files.pythonhosted.org/packages/11/8b/fe983e06fb5e05b30b7751c6105b36967823fe4599d5d309d517fec18269/mypy_boto3_payment_cryptography-1.43.24-py3-none-any.whl", hash = "sha256:0c14b90199883200e37e50048a231ae6c818c879ab33639d25346387b5ecb193", size = 32933, upload-time = "2026-06-05T20:45:22.311Z" },
 ]
 
 [[package]]
@@ -4420,11 +4441,11 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-pcs"
-version = "1.43.7"
+version = "1.43.17"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/52/1e/228b88e61726abaa16027d0bbf24622ee3df8fda389186bfc55f69f25d7e/mypy_boto3_pcs-1.43.7.tar.gz", hash = "sha256:c013da8a5f86215bb44944eee3e393174827c7502dadd6f8c7f3afe8a66a9e13", size = 19821, upload-time = "2026-05-13T19:41:23.084Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9b/62/02ba3cebf2713ab22062a4ad0a59be6d7898eab83d9c7d598665bf8feb87/mypy_boto3_pcs-1.43.17.tar.gz", hash = "sha256:bccd831c218541b436254ae362f60ad4eaa564bf93e4c6d85951ca79f3d04803", size = 19845, upload-time = "2026-05-28T21:21:10.197Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b8/e5/9796ef7ed88abca7108950f81757fd6abe17ad696eb7478b3768ad372db3/mypy_boto3_pcs-1.43.7-py3-none-any.whl", hash = "sha256:1ad3ed47b389a15dece137cbafe6467519c0ab22dbef8157ff18417d974065ec", size = 26792, upload-time = "2026-05-13T19:41:20.616Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/25/683f8e8136069befb4f9c82bf66f04242041d3b0c96b47c7d95fa1b1fef0/mypy_boto3_pcs-1.43.17-py3-none-any.whl", hash = "sha256:049dc910dbff4df110f2baa6365e5e00bbf3c61d8811e540320f42d75df04c31", size = 26833, upload-time = "2026-05-28T21:21:07.831Z" },
 ]
 
 [[package]]
@@ -4456,11 +4477,11 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-pi"
-version = "1.43.0"
+version = "1.43.14"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/03/78/f406ffbd75cc68fce110f4dc33f44bce8bf2605a18404b3fd60c6b7754e7/mypy_boto3_pi-1.43.0.tar.gz", hash = "sha256:57ad5ea375cca83aaf6733e5b51ab624c8ca849527bf50213a7dbfc473d6084a", size = 17615, upload-time = "2026-04-29T23:04:22.667Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/6c/e44f996a6c39dab78c8847cba281c38747cc74def841508793fe3d413bb3/mypy_boto3_pi-1.43.14.tar.gz", hash = "sha256:f66352dcd2831ba7817222db05dfa6c1e78fec550b16397d48d2d6d6fac2d20a", size = 18629, upload-time = "2026-05-22T20:48:23.82Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/38/412684a9644b97b2a9a6e29fb5f045ac4d06fd671005969aa72beace54d8/mypy_boto3_pi-1.43.0-py3-none-any.whl", hash = "sha256:28987c6d11139dbd4dd04bb43d79cb8709e74910f0fcf906f1ac8c286e65fdf8", size = 22356, upload-time = "2026-04-29T23:04:20.528Z" },
+    { url = "https://files.pythonhosted.org/packages/39/22/ff1b00c5b59bca02fd46f7eb9a816ddce99d0f323eadcdfd69e8d75852f2/mypy_boto3_pi-1.43.14-py3-none-any.whl", hash = "sha256:6f59782d487baff3a30e8e8861e4e890a4dad7bde7ebe72611118a98184ac32b", size = 25067, upload-time = "2026-05-22T20:48:21.342Z" },
 ]
 
 [[package]]
@@ -4555,20 +4576,20 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-qconnect"
-version = "1.43.8"
+version = "1.43.14"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/52/4f/d46e8e1624a0fd2f3462102ed510ecc89c30f126289cee6182872f1b48d4/mypy_boto3_qconnect-1.43.8.tar.gz", hash = "sha256:3d88138f1eef43156643b108ec14b628e7185c4fd4f09a4990962bd23b380ae2", size = 60903, upload-time = "2026-05-14T20:17:24.3Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/38/0b4b48ee357ab7f4d9823034baf08f3575e0e939351cac338dd3a4a2332f/mypy_boto3_qconnect-1.43.14.tar.gz", hash = "sha256:10fc5e9ceada3e63fd71ca430b8b2c887d1d47e9f67e962fef364c6793578fe2", size = 61199, upload-time = "2026-05-22T20:48:24.557Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e8/42/01114364caa33b619dedb25eff00a6f3097b519368f200909b5c0eb27741/mypy_boto3_qconnect-1.43.8-py3-none-any.whl", hash = "sha256:5e4a7e7e8801474db97a12fb9f5acda52ba3ba4956a96cce8c857e24b81c31e3", size = 66443, upload-time = "2026-05-14T20:17:21.577Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/7b/4f0b1150a5212ab7a3ad27b7b04825411d4505bcb81e9ccec27b03c023a3/mypy_boto3_qconnect-1.43.14-py3-none-any.whl", hash = "sha256:b4e698eb6cdc372816dae4aad643cdf00f3c0c5336164995aa7feaab7dc2c573", size = 66829, upload-time = "2026-05-22T20:48:21.956Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-quicksight"
-version = "1.43.10"
+version = "1.43.24"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/13/fd/3d1d7e41a25e28395134a7ba8e6cf9f48e510bfcd7c2e40f6274a461a0dd/mypy_boto3_quicksight-1.43.10.tar.gz", hash = "sha256:23e276e1707c8518ee9251f9765600c937ce23a7fb70df8484a308d946051d0c", size = 195273, upload-time = "2026-05-18T20:46:52.541Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/9a/20e6e25573c39dae1011c81f6f345a5b10aafb0bfb45097cd313dd1e3a38/mypy_boto3_quicksight-1.43.24.tar.gz", hash = "sha256:f6a06a35254e47c5b5e176f390dd69afabf7a969a038820fa411c2e522978e5b", size = 208062, upload-time = "2026-06-05T20:45:29.191Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/68/90/4dc23c115cd9c0c90a5e02ade2833c2dc314bbb913e13af5e94ad646e2c2/mypy_boto3_quicksight-1.43.10-py3-none-any.whl", hash = "sha256:091ea2af5e34e03b0947de0b07542d40a333468078299875d9f61b34f496d607", size = 197254, upload-time = "2026-05-18T20:46:49.304Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/d8/4c2b0ebefe91ad53fddbe50f1f4be1aba87c5b939767d963a8dceabf4ccc/mypy_boto3_quicksight-1.43.24-py3-none-any.whl", hash = "sha256:4a214c9603a264772fa23702738a53db1834fd54433c6cb1504c7426b85a5b32", size = 209983, upload-time = "2026-06-05T20:45:26.315Z" },
 ]
 
 [[package]]
@@ -4600,11 +4621,11 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-rds-data"
-version = "1.43.0"
+version = "1.43.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/99/eb/2d35484786c8104259f9e53a13c6b3bad1e76d1fbcccc8fc9df7f22c8720/mypy_boto3_rds_data-1.43.0.tar.gz", hash = "sha256:b208c453b46aaee8855aa531c620edfe6c74b93245849431909b17be8e6561b9", size = 16653, upload-time = "2026-04-29T23:04:45.783Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/d5/e537b48e4a5ce7b7658b2fe563b6d0a1f068a00b35c53e86b1a9cee55a40/mypy_boto3_rds_data-1.43.18.tar.gz", hash = "sha256:7694e55a712ae7efa202c71c9f4263e02db2cafb3c0ace6d329879cb3a5b8dc7", size = 16646, upload-time = "2026-05-29T20:08:13.622Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/8a/6433d6dc165c6b25f6290f9600a607df2ae7a15a1051d7ed07084f58ffd0/mypy_boto3_rds_data-1.43.0-py3-none-any.whl", hash = "sha256:13b7d02bdc4e51e919d42f1ea40343a9adc6c5311f2674d8356665908135bac4", size = 20748, upload-time = "2026-04-29T23:04:43.619Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/48/71bf0c38fb9582312be11d4ba32febc6ad64c7a49e949d4528d11c7ccf77/mypy_boto3_rds_data-1.43.18-py3-none-any.whl", hash = "sha256:841376f36a55182359e1e51cfc88f151a436dd8e3ec8b736c6d92f372f984661", size = 20769, upload-time = "2026-05-29T20:08:10.162Z" },
 ]
 
 [[package]]
@@ -4662,6 +4683,15 @@ wheels = [
 ]
 
 [[package]]
+name = "mypy-boto3-resiliencehubv2"
+version = "1.43.17"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/40/ee/5ccd52a3fc9b69119de7c31c68d3e0fe3ddefbd67a87c2140cfc7d2c7159/mypy_boto3_resiliencehubv2-1.43.17.tar.gz", hash = "sha256:041e41cb47378f993240a92ead25b874c32a7593c57943bcdffdc09e8dd3a4b0", size = 38088, upload-time = "2026-05-28T21:21:15.644Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/bd/53d3e7bad71e24d4cfacb068343348d609ce3a6ac7c6b4b67fb50411a628/mypy_boto3_resiliencehubv2-1.43.17-py3-none-any.whl", hash = "sha256:3eea09a651d1114ffdb0627c04fd3ec5d0b587e652705e2670c109466820645d", size = 45779, upload-time = "2026-05-28T21:21:14.136Z" },
+]
+
+[[package]]
 name = "mypy-boto3-resource-explorer-2"
 version = "1.43.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4681,11 +4711,11 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-resourcegroupstaggingapi"
-version = "1.43.0"
+version = "1.43.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2b/3b/4e61fefeecb62c7f191bea20ed2ce0ab585641030471f9b622468102d302/mypy_boto3_resourcegroupstaggingapi-1.43.0.tar.gz", hash = "sha256:dcce5d616deb4b8d48fc15ba2a6f34af4b931201ba1affb5bdc147245d7d8b68", size = 18599, upload-time = "2026-04-29T23:04:59.145Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/0e/092a88d8914521607fbb97f48ed3ad8862eaffaa9b4be15057fcc675e857/mypy_boto3_resourcegroupstaggingapi-1.43.15.tar.gz", hash = "sha256:f16326161e44d7074299ff42219b1cc23ef6e283086b704d47e8705879c2e933", size = 18596, upload-time = "2026-05-26T21:14:59.65Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/a9/0a04dd2140430c9b08f958b8b4ee97ea22692cc372841dd3bfde36c45823/mypy_boto3_resourcegroupstaggingapi-1.43.0-py3-none-any.whl", hash = "sha256:7cc117d5a034eca4390a3a052f8e24d7818c122ac68d476ffd964a384cdf22ff", size = 25422, upload-time = "2026-04-29T23:04:57.667Z" },
+    { url = "https://files.pythonhosted.org/packages/48/25/277f8603419f654c8c30856d2f4909e4122da6fed8089d973e3dc074e30c/mypy_boto3_resourcegroupstaggingapi-1.43.15-py3-none-any.whl", hash = "sha256:53422dd3d4dd86a4c77b405290b226be9ab66fe7b92642e683e2ec6e4469ac8e", size = 25455, upload-time = "2026-05-26T21:14:56.398Z" },
 ]
 
 [[package]]
@@ -4762,11 +4792,11 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-route53resolver"
-version = "1.43.6"
+version = "1.43.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d3/09/94b0d1b87d48e9f7be094c1bbd6cd544b55e37c8fca3e6631e9515d1ffda/mypy_boto3_route53resolver-1.43.6.tar.gz", hash = "sha256:fca02504a3462cef8f2daa5d773e24496df29ac19cec17ffb65862215fcaf41b", size = 35676, upload-time = "2026-05-07T21:15:27.532Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/6f/e8582a1e8fa98fe988c675e0050a92fd2cfc118c607ee0f0a8e61adab54f/mypy_boto3_route53resolver-1.43.18.tar.gz", hash = "sha256:22822981163de21c6dbb491e6f62abaab2ff994998e02ba7d093cda5d115c05d", size = 37282, upload-time = "2026-05-29T20:08:16.664Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bc/2d/86fdc553e20dac45ac134339feeb64c8efa432869ad7106f75fe75240921/mypy_boto3_route53resolver-1.43.6-py3-none-any.whl", hash = "sha256:12a5a1196b152176baa11c04eb17370685779d222218a5a7012f97790285f6a0", size = 41495, upload-time = "2026-05-07T21:15:24.693Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/c0/31d74595f79335f13d0d04d8c5eda8d8d9ef69c4ecae3063d5105c46bc04/mypy_boto3_route53resolver-1.43.18-py3-none-any.whl", hash = "sha256:01bcf7c58e5acd062bde66869baca9276141e84dcfadc3b23d09e1e4befe61ed", size = 43209, upload-time = "2026-05-29T20:08:14.175Z" },
 ]
 
 [[package]]
@@ -4789,20 +4819,20 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-s3"
-version = "1.43.5"
+version = "1.43.14"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c8/f9/f6bb5e1b3d8d9087ab9e2142df640a1be853e371ec5e16ea519a60061b56/mypy_boto3_s3-1.43.5.tar.gz", hash = "sha256:ba67dbc3da825b6818839db3823722f3b12304dd116e94ed398eb7ade86b0f62", size = 77042, upload-time = "2026-05-06T20:47:46.655Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/2c/fc409f9ff5904a02cf4c2c1518c34d20cb56f22b2368b35fd0adda2926f3/mypy_boto3_s3-1.43.14.tar.gz", hash = "sha256:73d54c1d0999c73c403dc9a9a3da4a9722715aba116595af08c0d4675f8bc670", size = 77078, upload-time = "2026-05-22T20:48:28.251Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/db/02/f597a5c373fb755433e194a69885c78b2f0db7dcca7fac1247f586b59ec1/mypy_boto3_s3-1.43.5-py3-none-any.whl", hash = "sha256:7cd836cf3ec384b6a05b108047034ece03bb7dd0bd0890c527673eafc44907bb", size = 84262, upload-time = "2026-05-06T20:47:42.976Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/61/e8e74a3f4c729719efc8b1d00179bc16c302202eac32a1b56a842a997ed2/mypy_boto3_s3-1.43.14-py3-none-any.whl", hash = "sha256:ce77096d6c5f90020c45e34c83d2268ca2bb17726149ce5033751870f7fb4e97", size = 84277, upload-time = "2026-05-22T20:48:25.032Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-s3control"
-version = "1.43.0"
+version = "1.43.17"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fc/05/aea603caeefa9112effb183ea31223b08353d8e4f64c3e151c3358991af4/mypy_boto3_s3control-1.43.0.tar.gz", hash = "sha256:381c3da8f24fbfe4ebc92acd157a3e1822548dfe5fa93d74549ba39e68e60aaa", size = 45198, upload-time = "2026-04-29T23:05:17.583Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/cc/1dfe7c4066cc0c8290c662263ec6a10ca350dc4576c00ffe98648735a20b/mypy_boto3_s3control-1.43.17.tar.gz", hash = "sha256:7a0892071ee9c2e884568aa721717215af2f6703428aba21a184c8c0217b2fb7", size = 45158, upload-time = "2026-05-28T21:21:11.904Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/b3/b8125c194141e2495551d47e39b2864f0e4421bdd071f0bd645d4ed5813b/mypy_boto3_s3control-1.43.0-py3-none-any.whl", hash = "sha256:b8d60ed62b834e92bcaf1c46b853cac021bfdcda8438dca14dec584ce4469ea1", size = 50480, upload-time = "2026-04-29T23:05:15.002Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/d4/25f45a7082517e41668ec2946ccddfe643fb8a3d4870c7be9d5a3d821cba/mypy_boto3_s3control-1.43.17-py3-none-any.whl", hash = "sha256:abfd77ea6b3b6bd0e2e7c5df34cda0f24b81059e525b9a215d29b9b2f05c1028", size = 50511, upload-time = "2026-05-28T21:21:09.064Z" },
 ]
 
 [[package]]
@@ -4843,11 +4873,11 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-sagemaker"
-version = "1.43.11"
+version = "1.43.27"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3b/f4/6495e0c48441ffe346953726e7bb3ae0d98865e8c6946d60fefe0e45b576/mypy_boto3_sagemaker-1.43.11.tar.gz", hash = "sha256:7da8caf663880db7d87047ed46a6436e4b42d6738b6bdc562049cecd4c222d80", size = 239795, upload-time = "2026-05-19T20:52:46.78Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/8b/430b7e4d1bfd443c3648b0d592394f1a78caf6c64c2d5da853a62cfe47a2/mypy_boto3_sagemaker-1.43.27.tar.gz", hash = "sha256:5273498aa7c8ec6e613774244c8cca11c2f583024f56c4d481408071ede6982b", size = 242850, upload-time = "2026-06-10T19:56:15.655Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/65/7f87ef48a3d45221611fe66ee17e3ca40683a7d6afb1e845e6e8205d094a/mypy_boto3_sagemaker-1.43.11-py3-none-any.whl", hash = "sha256:aba02c9cbc9f7a3632486b38fe53ccce850a38f0a693dd3dbb3ab3a7297d523e", size = 244292, upload-time = "2026-05-19T20:52:43.983Z" },
+    { url = "https://files.pythonhosted.org/packages/59/e5/9cd755aea2b861dfbf2533b2feb748239d1ab981a4ea1e66d8d63303b9f7/mypy_boto3_sagemaker-1.43.27-py3-none-any.whl", hash = "sha256:54f7a82d690730c731f1e348fd973a43b548da5e8a260d6762df157d0f77e31a", size = 247334, upload-time = "2026-06-10T19:56:12.045Z" },
 ]
 
 [[package]]
@@ -4897,11 +4927,20 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-sagemaker-runtime"
-version = "1.43.0"
+version = "1.43.29"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/95/fe/de750e8b11eb5860150763241f85c0af3759704a1e07883a5998e9978d19/mypy_boto3_sagemaker_runtime-1.43.0.tar.gz", hash = "sha256:675442140ebfba6f7b1c76687480d7a1eb9b3252380c094e8bef8926aea73f86", size = 15702, upload-time = "2026-04-29T23:05:36.152Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/fd/4bf09a8de0ef440f699d41af52cfb20f9a3012d9c0005591124f410b58e0/mypy_boto3_sagemaker_runtime-1.43.29.tar.gz", hash = "sha256:368bbcc23242f1060200c0ff025b106087d6b7da8ef72b13dd14492a84067af6", size = 15744, upload-time = "2026-06-12T20:09:14.628Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/aa/9dd67e2936e43ff4784ffe2865395a1451e7f07ad0ab32b10d4112983458/mypy_boto3_sagemaker_runtime-1.43.0-py3-none-any.whl", hash = "sha256:8bda997081a2c9791cfb0d85a43e0ec0d931a4f5777be0c7486d88afbf757880", size = 19387, upload-time = "2026-04-29T23:05:32.288Z" },
+    { url = "https://files.pythonhosted.org/packages/13/b7/541055d2af82fc1ae1e35bdc9d32e618f06e493f9a5d2a13b5b4147e8c77/mypy_boto3_sagemaker_runtime-1.43.29-py3-none-any.whl", hash = "sha256:51ace8d2742642cf7f4feff138cc2e3d33ced8665f9de3145a2cceb75fe69963", size = 19433, upload-time = "2026-06-12T20:09:12.037Z" },
+]
+
+[[package]]
+name = "mypy-boto3-sagemakerjobruntime"
+version = "1.43.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/10/51d04e0bc7f72d055dea32e1d1e0f4763c4d757637c9b9980f22fa90d3a9/mypy_boto3_sagemakerjobruntime-1.43.20.tar.gz", hash = "sha256:dc2cc33beab1471296bb86a3173d3e487e0a87edec6894f5b74fe2938dfa2d5a", size = 15366, upload-time = "2026-06-02T22:17:25.93Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/b3/47796f4405c91639fbca797e8795999a543c132ecf55a99075ff9e5a1f68/mypy_boto3_sagemakerjobruntime-1.43.20-py3-none-any.whl", hash = "sha256:c1f3c8faa672457888a683109c050da306c465a99db09209e24497184f7695fa", size = 18900, upload-time = "2026-06-02T22:17:22.346Z" },
 ]
 
 [[package]]
@@ -4960,11 +4999,11 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-securityagent"
-version = "1.43.7"
+version = "1.43.14"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2c/66/763f3cad41295feaf8fc69067fa4b86ce0e8bd05d561e7584d7530312a41/mypy_boto3_securityagent-1.43.7.tar.gz", hash = "sha256:5ab2aa7f7ca951a853d484ec0f43872de805cfc46f90b7a284cccc7d8bd99218", size = 37041, upload-time = "2026-05-13T19:41:33.704Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/91/9daa51fb3b8d9104a1b313eaba2c1a562d27140382c8d04594336f082973/mypy_boto3_securityagent-1.43.14.tar.gz", hash = "sha256:edbe5c4528da2fdacc564e3e3f6b7ab0f1fec21918b0cc272fd109c06b5c5445", size = 37183, upload-time = "2026-05-22T20:48:29.437Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/9e/252217ff565365b4c3b84e9fa2bdc730638470846f62a54651ddd0300e75/mypy_boto3_securityagent-1.43.7-py3-none-any.whl", hash = "sha256:1f19bd657f6a0065adcec4588b8e37c3f3b1eeeafbaaa19bfad7368b95504052", size = 43053, upload-time = "2026-05-13T19:41:29.487Z" },
+    { url = "https://files.pythonhosted.org/packages/80/40/130dab11b05248c727c415b5ff0239a08b2e5cbaac1382e3835d87708016/mypy_boto3_securityagent-1.43.14-py3-none-any.whl", hash = "sha256:8fa2d0c771070e55a5a97c6094fde945b0a0d999da9056dfb44b29781eaa3d49", size = 43198, upload-time = "2026-05-22T20:48:25.792Z" },
 ]
 
 [[package]]
@@ -5041,11 +5080,11 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-sesv2"
-version = "1.43.0"
+version = "1.43.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/84/be/59eeb90773709d039db7d775811e24a4b9219d49ea4acc5a9d4e7c3760ae/mypy_boto3_sesv2-1.43.0.tar.gz", hash = "sha256:ac7b9377bef3f2c38bdb95b517e2da45a6d9a6a3a4bff27ea22725bc7be71ae7", size = 47277, upload-time = "2026-04-29T23:06:03.23Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/22/4f6b3e345d52e4a54d3deeb195349d5d25abf89161d32d24084909865e87/mypy_boto3_sesv2-1.43.18.tar.gz", hash = "sha256:db04563b8105ea51ffebda3c52f6af306e6d96ca8e48fe2176f1796f039c4b53", size = 47659, upload-time = "2026-05-29T20:08:17.911Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9c/88/10a4d6775e16d1001151603795169d9c92158e35d096a01bb8b42800ec5e/mypy_boto3_sesv2-1.43.0-py3-none-any.whl", hash = "sha256:8a96d7e42c0dfd7a64771219d5c19dd484eeb184ca2f4a8c0a89d68d46dcc64a", size = 52753, upload-time = "2026-04-29T23:05:59.472Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/fe/c78f3294016e9a8dd0acfd72a2ddc5eb5b96522f59e4892aff38531b674d/mypy_boto3_sesv2-1.43.18-py3-none-any.whl", hash = "sha256:62c32b858e20f28feba0461205eddb08424902889be60196729e07383413c144", size = 53176, upload-time = "2026-05-29T20:08:14.812Z" },
 ]
 
 [[package]]
@@ -5077,11 +5116,11 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-signin"
-version = "1.43.0"
+version = "1.43.27"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f6/a8/58ba30f77f3269a4571243da059af964dc335f323d3067820cbf46053381/mypy_boto3_signin-1.43.0.tar.gz", hash = "sha256:7ffdda1e9c45ddfc1e8af26066b6424dafe08e8b273657a92e762766caa0409f", size = 14884, upload-time = "2026-04-29T23:06:08.689Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d2/44/61c8b0c3797ff4caa785e53cd21ee7545e346927e25f3a5a9facc33b7d06/mypy_boto3_signin-1.43.27.tar.gz", hash = "sha256:ef8d283b439ea56eb5c1ca18e14a9c3ee39405b674bffab985586a11c9b99bdf", size = 16829, upload-time = "2026-06-10T19:56:13.677Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f1/f1/3eed6287ccac5ca9f784f9e348985eaef55ef2f5951e5a83f294193c8233/mypy_boto3_signin-1.43.0-py3-none-any.whl", hash = "sha256:c80feab774639e981981af391cfe773a7f6e9912afcc5d1dcd900e20b7f494c6", size = 17410, upload-time = "2026-04-29T23:06:06.984Z" },
+    { url = "https://files.pythonhosted.org/packages/64/01/66e9451f6c5f62d77f1ebd1b9010e7f0fc6afae5b5b4766e2ab8fe36d46b/mypy_boto3_signin-1.43.27-py3-none-any.whl", hash = "sha256:1bf1e24879cd054e21d6c322a47a8fb67de7e49be7cfb515020645fd49272a78", size = 21695, upload-time = "2026-06-10T19:56:12.273Z" },
 ]
 
 [[package]]
@@ -5122,20 +5161,20 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-sns"
-version = "1.43.0"
+version = "1.43.23"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/6b/dc934c8023ae5bc786122ecfda71cf06140b4cb1f561dfe89d72784d05b7/mypy_boto3_sns-1.43.0.tar.gz", hash = "sha256:2ad60f8e6c662e91b4c6f45439cbeb53f04ed2a764f0a611d75e4fa0fdfe4c41", size = 32710, upload-time = "2026-04-29T23:06:14.193Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/8d/21ec0b76b6097d49635a20b4d6ebc7cc66a5da1421220dac191f1cbd98db/mypy_boto3_sns-1.43.23.tar.gz", hash = "sha256:6f8a19b64c6abf1bd623ad91be7e76ce27f2396da1f1083058921d0de4176ad1", size = 32716, upload-time = "2026-06-04T21:04:42.802Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/8c/c20c52fd18ebb23f81e7f642175d817de8f48822711de8e16198bd19d52a/mypy_boto3_sns-1.43.0-py3-none-any.whl", hash = "sha256:a77ba63525f7b2a16ea8f93bf6be84693fdde81cf9937ab6cf37e1b6525caaa8", size = 40007, upload-time = "2026-04-29T23:06:11.64Z" },
+    { url = "https://files.pythonhosted.org/packages/99/60/6d827ba2a569fccd535b72af50966d1d2c34cd02368774c8bf119d46ad51/mypy_boto3_sns-1.43.23-py3-none-any.whl", hash = "sha256:9144245c5fecf865f3fb1b73bbb750d5284ec63c7dbfea9d270d35205eab0aa2", size = 40038, upload-time = "2026-06-04T21:04:40.8Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-socialmessaging"
-version = "1.43.7"
+version = "1.43.22"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/df/e2/db1a47c9fd4611155c60cfc3b38422bfd3ed6c9225d5304f976ed4c108f5/mypy_boto3_socialmessaging-1.43.7.tar.gz", hash = "sha256:67219f4f73a3300591f845ad35c5b6dcc361bd1455649ee984dc63fdb8939bf1", size = 20201, upload-time = "2026-05-13T19:41:35.195Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bc/77/5e259e0ffcd400691614593dfbc1be55e2da4a7b6e48d05e6258e6fec79f/mypy_boto3_socialmessaging-1.43.22.tar.gz", hash = "sha256:26158ea53deb690b5eb4ddc19a15a1201a5ad9e0a0f1b23a53c9cc70d854d4de", size = 22176, upload-time = "2026-06-03T21:49:52.124Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2b/c3/2fedbb6ff335884e106c2732683fb8b77e64f8003f7c790ad86b0436e2e8/mypy_boto3_socialmessaging-1.43.7-py3-none-any.whl", hash = "sha256:2eb6cc9a46f62bde35477d85ffc5aa0b168587120e6d826d60a1988049edfaf8", size = 28075, upload-time = "2026-05-13T19:41:31.188Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/45/bf2dbf3dd9cc4834583172fa6620108a43e11a3965558837c83124119387/mypy_boto3_socialmessaging-1.43.22-py3-none-any.whl", hash = "sha256:f44351df2c203b2bd1e747ea469b63d21413406444c315f2df0f96e5d1599a7a", size = 31434, upload-time = "2026-06-03T21:49:49.037Z" },
 ]
 
 [[package]]
@@ -5266,11 +5305,11 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-support"
-version = "1.43.0"
+version = "1.43.28"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ac/16/d6222a6c8d29238285cd0c14fd4f32f130085ca78dde46e367283ef056a4/mypy_boto3_support-1.43.0.tar.gz", hash = "sha256:7bac3b6c6b5b2166ff263d9149f116ba9fb32e338d3db60c52958bd28107830a", size = 18895, upload-time = "2026-04-29T23:06:39.051Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ab/14/cf9b1e07e656ab18f6f29bfcd9f5174b71ed547fb8b4b19b22798318560d/mypy_boto3_support-1.43.28.tar.gz", hash = "sha256:dac99df81bc5e2c35e260edd77f795cc4a8be885d2a7f898c8409ca9570ca45b", size = 18902, upload-time = "2026-06-11T20:36:42.905Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/c3/358101942428930e280a803a95a140f2ca92837d2aee190b09b1cefcefaf/mypy_boto3_support-1.43.0-py3-none-any.whl", hash = "sha256:c93c043a19527a2b641da5493e09eab6e850576b5c8fc68f8660b4921952361e", size = 25176, upload-time = "2026-04-29T23:06:36.884Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/06/3c280159c4d27c8805362fae2ebd1edfcfdca27617c6f50580dd39506c97/mypy_boto3_support-1.43.28-py3-none-any.whl", hash = "sha256:51bf2c17ee6b7d4cb9bff7c7261764cfa71e99676cce3e65ef427938f2f1ce75", size = 25205, upload-time = "2026-06-11T20:36:40.541Z" },
 ]
 
 [[package]]
@@ -5311,11 +5350,11 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-taxsettings"
-version = "1.43.0"
+version = "1.43.25"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/22/52/d9a83572a4285357b2c07b9b5957f6714f3a9586bc90c9277ff72f16e0e7/mypy_boto3_taxsettings-1.43.0.tar.gz", hash = "sha256:a7ac85f7d4a99975e5351f0a44d7bbfb5eb820c60db71586cde1f4a81210cd7b", size = 20558, upload-time = "2026-04-29T23:06:44.547Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/a5/14dddb7bd9ea8c6fb6fed9282134520458d2f5c6a40812ef2f29bc98d00c/mypy_boto3_taxsettings-1.43.25.tar.gz", hash = "sha256:97e979bd8b5dd73c4857d6eb4788835e52e84b4a8d18b21325c40c3c2b657dde", size = 20867, upload-time = "2026-06-08T21:18:31.42Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/89/206fedfd7bb3d3b4d620fa109cad12f3307179f878ab29c792a17c4ae3a9/mypy_boto3_taxsettings-1.43.0-py3-none-any.whl", hash = "sha256:eb7c398e1b3ed80ff7c2c5813c19aa7ef230888ba8ae539e3866a0c71012935c", size = 28335, upload-time = "2026-04-29T23:06:42.384Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/3b/b3c3eb6b83a2b8008b806da0875edded2e744a14d767a8c9f13add0cd870/mypy_boto3_taxsettings-1.43.25-py3-none-any.whl", hash = "sha256:cd7a9f444a3b90c1898de9843ed3e2eee03906a799e95ccd2a1181e83c8d6192", size = 28825, upload-time = "2026-06-08T21:18:29.543Z" },
 ]
 
 [[package]]
@@ -5365,11 +5404,11 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-transcribe"
-version = "1.43.0"
+version = "1.43.20"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6b/67/a6de88a3c8fa537c646380b56d341d17bd807979d0f52dadfc4cae2e6830/mypy_boto3_transcribe-1.43.0.tar.gz", hash = "sha256:d21c30d12496d376d492d342afcd5fe42e7a53deb51131fde869f5559c17d48c", size = 30680, upload-time = "2026-04-29T23:06:52.962Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/b4/e047c5520d8f1ddee365e9e765daad1c69aa7a9781be7d435ba6b0e2ecc7/mypy_boto3_transcribe-1.43.20.tar.gz", hash = "sha256:ce4eb62669414fa9e6458a136778fb4e181baa3a93bf450e2b703ebd96659111", size = 30752, upload-time = "2026-06-02T22:17:29.108Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cd/48/c838f1d913312b08f6962a05f17a1060a64c72c6fd0d395e20c52954ce9f/mypy_boto3_transcribe-1.43.0-py3-none-any.whl", hash = "sha256:f58461ac8bdbdcc35257a3e33ac3758ac011df9f8ca117432a880c3e41c9fad5", size = 35676, upload-time = "2026-04-29T23:06:51.098Z" },
+    { url = "https://files.pythonhosted.org/packages/39/1d/e730ceb1bbfc3308aad66c1f56cecdd7453aafa3a2f7b162cef61d5ec77f/mypy_boto3_transcribe-1.43.20-py3-none-any.whl", hash = "sha256:2d04ca5f5b9f6728bde3c7302398b2bc70b672b7b0383c7048a11d291af9b947", size = 35806, upload-time = "2026-06-02T22:17:26.656Z" },
 ]
 
 [[package]]
@@ -5410,11 +5449,11 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-verifiedpermissions"
-version = "1.43.0"
+version = "1.43.13"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f2/44/8ac22f08ed1c350895688611bbbbeb2d02b160a6c985c33379ad904c2292/mypy_boto3_verifiedpermissions-1.43.0.tar.gz", hash = "sha256:8ae38b7cbefe88900bd803b10e62fb68f506dcf1204c1f81b1dc1ea582936751", size = 25754, upload-time = "2026-04-29T23:07:00.916Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/61/1a44c94c2101e762224591a4a70c884b6673d9348513eec65db3034a7bfc/mypy_boto3_verifiedpermissions-1.43.13.tar.gz", hash = "sha256:4ed9dd62c2bb5386fd7f52d6b5769dc03dd2c913e4c77ba18d1206631c9b5b5b", size = 25809, upload-time = "2026-05-21T22:50:59.119Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/84/301627352301e8c66e103b31a8d69b01adb11113b2f25f80560d0e6678c2/mypy_boto3_verifiedpermissions-1.43.0-py3-none-any.whl", hash = "sha256:3eb7330ef54088c381306e6a080d05013d23896fd35106541e10e28b281f63fa", size = 32250, upload-time = "2026-04-29T23:06:58.146Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/1d/a1e2c36e2defef503b391b457530bea8ea8e87eeccafb8201922b190c104/mypy_boto3_verifiedpermissions-1.43.13-py3-none-any.whl", hash = "sha256:4e55f176dea68f4ebf06d15b91ccb683a68ab1123598ad8683c8033b32083df6", size = 32329, upload-time = "2026-05-21T22:50:57.037Z" },
 ]
 
 [[package]]
@@ -5473,11 +5512,11 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-wickr"
-version = "1.43.0"
+version = "1.43.23"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/de/af/c1cf5dd9e6975a7e5b02a75271517f68972bafa621af2d3dcff4649039a9/mypy_boto3_wickr-1.43.0.tar.gz", hash = "sha256:3b5cf4057f44149c97c87b4b54b876304964382f8afa801c0b816274e03b54b8", size = 30476, upload-time = "2026-04-29T23:07:11.205Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/1c/c54ec63a0a41c7ccc69b1bca3dc19ae556d88af83145d346032028ba739f/mypy_boto3_wickr-1.43.23.tar.gz", hash = "sha256:4c5a60c8a4106a97209d680edadad8a9e6b7f5b5f42165cfe5fbd5c2b71f0a49", size = 30914, upload-time = "2026-06-04T21:04:44.977Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/7b/13dc8ca6b8396fff2cb18f7e7664fd644b754b523e4cff3dd292c8b4e5a6/mypy_boto3_wickr-1.43.0-py3-none-any.whl", hash = "sha256:3dfd347d935bb9a175cde667c1e23b967b771af7358254f7175386ca31615a30", size = 34849, upload-time = "2026-04-29T23:07:08.959Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/e2/938a92236d2a65865f333d6a7e7529ccb9e2dd4f6e7dc9d394958cd93e6c/mypy_boto3_wickr-1.43.23-py3-none-any.whl", hash = "sha256:c8402cc4c80f534b8929dd21121f7946a756c586df2999092bd41f555da37411", size = 35004, upload-time = "2026-06-04T21:04:41.441Z" },
 ]
 
 [[package]]
@@ -5491,11 +5530,11 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-workdocs"
-version = "1.43.0"
+version = "1.43.23"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/38/24/5d95f8e35f2373ac4d9c37920c8947f9cc2acc67962e893a660c0a2f2be5/mypy_boto3_workdocs-1.43.0.tar.gz", hash = "sha256:4b09a3f0caf24cabe248c4fc92f03e2ebd583b11294ad3e10c246848a734893e", size = 28968, upload-time = "2026-04-29T23:07:13.813Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/a2/69f93ba7d54f5470d509850c82e2906c01c2be3d68bc65c57d83f37ff2d7/mypy_boto3_workdocs-1.43.23.tar.gz", hash = "sha256:9ae4208fe8ab079650c3eb48b165549549630bab964f90f604e5dc5cf7ff61ea", size = 28982, upload-time = "2026-06-04T21:04:47.055Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/e0/27f73c43ffc7b4a4b0143e3386491755f337b8f881aac4c658d223fd5ace/mypy_boto3_workdocs-1.43.0-py3-none-any.whl", hash = "sha256:5d0014de27c23f3bb34f138f5ca849b02f2f9c9b0b8d7d20d46efa0f9e98b8e8", size = 37395, upload-time = "2026-04-29T23:07:11.654Z" },
+    { url = "https://files.pythonhosted.org/packages/02/ff/24ac8ac733bdb320abc6e0ed3a350a0993dc89432e78d5888d4534397afa/mypy_boto3_workdocs-1.43.23-py3-none-any.whl", hash = "sha256:03e0f460328ccc5b5d272f1d020eddb33382bf59b501c252d3b8c70c20ff45af", size = 37430, upload-time = "2026-06-04T21:04:45.375Z" },
 ]
 
 [[package]]
@@ -5518,11 +5557,11 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-workspaces"
-version = "1.43.0"
+version = "1.43.23"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e6/5a/b9dde380c6e8a17288a4fec8a4ed07bdd7d9fc12789415b47723e41612fa/mypy_boto3_workspaces-1.43.0.tar.gz", hash = "sha256:d04480c76e91213c71138fe6c03482ed3c657ca39b8d4d50d2f4c9de980afbb9", size = 46283, upload-time = "2026-04-29T23:07:19.12Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/01/c81a2adacae6b609c1330e7fab4a1ffaf4bbc6e6411f0c27a460b5bc4fb6/mypy_boto3_workspaces-1.43.23.tar.gz", hash = "sha256:d011b4b7076af3f82161aba17291af512b3815e422756b8815b62a346d1d8bb1", size = 46286, upload-time = "2026-06-04T21:04:49.008Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3c/ca/64c505a1182b8669e4d9bf79268d745bffebbea35ff3b8596ec2b380b2e3/mypy_boto3_workspaces-1.43.0-py3-none-any.whl", hash = "sha256:746d6100f92baa70f0bb08af221c651cba77ef21e7c48198eb29d506c61659fc", size = 54050, upload-time = "2026-04-29T23:07:17.028Z" },
+    { url = "https://files.pythonhosted.org/packages/94/bd/2c0a9433073d8f283034ad43716b415b0514c85c4c552472f7c8ed7afc4f/mypy_boto3_workspaces-1.43.23-py3-none-any.whl", hash = "sha256:c62874d67e5c9d693c77cdc4f56a3f1dbe94828375d58cb41cae2b4bde214330", size = 54083, upload-time = "2026-06-04T21:04:45.957Z" },
 ]
 
 [[package]]
@@ -5572,31 +5611,31 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-api"
-version = "1.42.0"
+version = "1.42.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/86/ca/25288069c399be6769159d9fb7b1190b603537d82aad2fa2746a0cc2c8c6/opentelemetry_api-1.42.0.tar.gz", hash = "sha256:ea84c893ad177791d138e0349d6ceebd8d3bf006440900400ce220008dafc372", size = 72300, upload-time = "2026-05-19T09:46:29.885Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/1c/125e1c936c0873796771b7f04f6c93b9f1bf5d424cea90fda94a99f61da8/opentelemetry_api-1.42.1.tar.gz", hash = "sha256:56c63bea9f77b62856be8c47600474acad853b2924b99b1687c4cb6297166716", size = 72296, upload-time = "2026-05-21T16:32:49.335Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/0b/be5daf659b82b525338fde371dfcfab09b606a19bb5620c37076964710ec/opentelemetry_api-1.42.0-py3-none-any.whl", hash = "sha256:558d88f88192a973579910ef6f2c13db47a268d5ec2e53e83e50e74a39a02922", size = 61310, upload-time = "2026-05-19T09:46:06.561Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ca/9520cc1f3dfbbd03ac5903bbf55833e257bc64b1cf30fa8b0d6df374d821/opentelemetry_api-1.42.1-py3-none-any.whl", hash = "sha256:51a69edacadbc03a8950ace1c4c21099cacc538820ac2c9e36277e78cebba714", size = 61311, upload-time = "2026-05-21T16:32:28.822Z" },
 ]
 
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-common"
-version = "1.42.0"
+version = "1.42.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-proto" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/76/a9/1496f27ecdfc7d504eac80f5e16474ee9d47cd08cda1f2917b58cf1c299c/opentelemetry_exporter_otlp_proto_common-1.42.0.tar.gz", hash = "sha256:c7a1a61f3a4c4dfa83127353edb1c75b873289d9ee42379db46eb835963b72e3", size = 21430, upload-time = "2026-05-19T09:46:32.838Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0e/9c/216acfeaedadf2e1937f4373929b20f73197c5c4a2546d4f584b7fa63813/opentelemetry_exporter_otlp_proto_common-1.42.1.tar.gz", hash = "sha256:04f1f01fb597c4249dfcd7f8b861c902c2102369d376d9d346ff38de4469a2ee", size = 21433, upload-time = "2026-05-21T16:32:55.526Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/7b/1542eb6e3d941a7dd93648d485b7c8495bc2841a2bb7dd5f394f370cf607/opentelemetry_exporter_otlp_proto_common-1.42.0-py3-none-any.whl", hash = "sha256:92de67f096c9200770f16fbdb63b96fb6061d604b4bc266726d8355caeb864e8", size = 17328, upload-time = "2026-05-19T09:46:11.291Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/2375e7612e1121a4518c17603b6e0b03ad94f565aafad53f464dc5be2bf6/opentelemetry_exporter_otlp_proto_common-1.42.1-py3-none-any.whl", hash = "sha256:f48d395ab815b444da118868977e9798ea354c25737d5cf39578ae894011c140", size = 17327, upload-time = "2026-05-21T16:32:33.387Z" },
 ]
 
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-grpc"
-version = "1.42.0"
+version = "1.42.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -5607,14 +5646,14 @@ dependencies = [
     { name = "opentelemetry-sdk" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/01/6a/63812e4f67d3658b21e94bc890b67296951f3aa8f6950fdf735f763500e5/opentelemetry_exporter_otlp_proto_grpc-1.42.0.tar.gz", hash = "sha256:75eac4e9d0bd69bea8199d75dfeb585cce05a9baa8215d1f7aad9e3583bf5ef9", size = 27136, upload-time = "2026-05-19T09:46:33.594Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/87/87/ca7fc790dfdbcf4f9e9aab14a39ef1b7508ead13707e283de0b3131478d2/opentelemetry_exporter_otlp_proto_grpc-1.42.1.tar.gz", hash = "sha256:975c4461f167dd8ed8857d68d3b6b25f3d272eab896f6a9470d0f5b90e2faf15", size = 27140, upload-time = "2026-05-21T16:32:56.162Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/e9/308c4c03b536005a1443bee0d9f06de38aad8b94f59f58ac688ead7a8cf9/opentelemetry_exporter_otlp_proto_grpc-1.42.0-py3-none-any.whl", hash = "sha256:5d6d1691586f2e656fd14187f2f2f5fa06e94834e1acdce71edcbbe35730b31d", size = 19614, upload-time = "2026-05-19T09:46:12.331Z" },
+    { url = "https://files.pythonhosted.org/packages/89/2b/28ba5b128f47fe8c3bab541000d6feb4b5a9bd26623ca013406f01c0fb60/opentelemetry_exporter_otlp_proto_grpc-1.42.1-py3-none-any.whl", hash = "sha256:0ae1177e2038b18a929b3098215243631ef91136cba26b7e2b12790ceb7e87cc", size = 19617, upload-time = "2026-05-21T16:32:34.278Z" },
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation"
-version = "0.63b0"
+version = "0.63b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -5622,14 +5661,14 @@ dependencies = [
     { name = "packaging" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2a/2d/322d464f4105966fb8555f871a84f43e821ce9aaf64ecae9586e9691c6a2/opentelemetry_instrumentation-0.63b0.tar.gz", hash = "sha256:80a339ef030a8d0fd1962375a9801dd31954e5063d74c00bc3d4e6581f43bab1", size = 41083, upload-time = "2026-05-19T09:47:06.194Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/6d/4de72d97ff54db1ed270c7a59c9b904b917c0ac7af429c086c388b824ddb/opentelemetry_instrumentation-0.63b1.tar.gz", hash = "sha256:32368d6ae52c8de20aa790a6ad86b10a76f09956092337ae37d675773990e541", size = 41081, upload-time = "2026-05-21T16:36:14.206Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/45/a38e74da3f1b5c82c97289da91d978caa04321877f0ab170fc620a0753f2/opentelemetry_instrumentation-0.63b0-py3-none-any.whl", hash = "sha256:984b18763b652a881ac5a596098d89923f74cf53a658c2dde660387e018147ca", size = 35574, upload-time = "2026-05-19T09:46:07.257Z" },
+    { url = "https://files.pythonhosted.org/packages/35/a1/9314e621c143e4d82a5bf7a43c2ff7a745d31023506336857607c8c543cc/opentelemetry_instrumentation-0.63b1-py3-none-any.whl", hash = "sha256:f1986716d52cc316ea5f60189098726a9071d8ecc0eee96c9ed110be08bade9c", size = 35577, upload-time = "2026-05-21T16:34:56.818Z" },
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-asgi"
-version = "0.63b0"
+version = "0.63b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
@@ -5638,14 +5677,14 @@ dependencies = [
     { name = "opentelemetry-semantic-conventions" },
     { name = "opentelemetry-util-http" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b2/ba/dd540189230d211898ccc4df899874bc0d84f5c54a1e07a13a2bde606a57/opentelemetry_instrumentation_asgi-0.63b0.tar.gz", hash = "sha256:e201eed7616f7da0840adf8ab8c5ea64db7ab19b920373b38983e2bac8d3645d", size = 26154, upload-time = "2026-05-19T09:47:10.023Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a0/b5/7ea3a9fd1b80e89786c14250bfaecf32a753c3fd08232690f4da8dc16e29/opentelemetry_instrumentation_asgi-0.63b1.tar.gz", hash = "sha256:267b422416d768f3c7f4054883b41d9c3a7c943d86d20032b738c99a3dbb5862", size = 26151, upload-time = "2026-05-21T16:36:18.368Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ad/4f/caa793347febb9dae45f3d03d8bac04bf0752170a19c53016a0a91a214a0/opentelemetry_instrumentation_asgi-0.63b0-py3-none-any.whl", hash = "sha256:4e89555c110677226b9ca1734eda248360916bccf0ebadf8db8baf0015c9efca", size = 15907, upload-time = "2026-05-19T09:46:13.675Z" },
+    { url = "https://files.pythonhosted.org/packages/57/7e/83986f27b421de04fab1e1a84e892621dac42e6432a9c66779505f4d1381/opentelemetry_instrumentation_asgi-0.63b1-py3-none-any.whl", hash = "sha256:1a22453dfa965f14799b10a674b8acbcb897a8a75c79136060af54214cc7886e", size = 15906, upload-time = "2026-05-21T16:35:04.162Z" },
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-asyncio"
-version = "0.63b0"
+version = "0.63b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -5653,28 +5692,28 @@ dependencies = [
     { name = "opentelemetry-semantic-conventions" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/89/19/c01d0e320120069937aa191eca8408a0dfbc3d8a5ccb3d06f6b3e41e4794/opentelemetry_instrumentation_asyncio-0.63b0.tar.gz", hash = "sha256:623eaa77734578a89a6cecd13ec4f2dd0d6e3786caf9cdb52b9cf1494683fcea", size = 13941, upload-time = "2026-05-19T09:47:11.267Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/1a/206fcf577eee1a1e88b37a01d837e25fcad27af3514d4697b32a0f04c425/opentelemetry_instrumentation_asyncio-0.63b1.tar.gz", hash = "sha256:0ae623583dcbe0ae17d63c995906d02a64213652ff180875ace680d1e6c286ec", size = 13942, upload-time = "2026-05-21T16:36:20.271Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/db/e5/4c4e5885939d65824d7b6ddd151519fd3566599c0179f78fe794950f8120/opentelemetry_instrumentation_asyncio-0.63b0-py3-none-any.whl", hash = "sha256:792e3ad3dbfda9b35ed1a6aa30d81a986dd1bf8fa4ec25237ece4eb5fa722f27", size = 13101, upload-time = "2026-05-19T09:46:15.438Z" },
+    { url = "https://files.pythonhosted.org/packages/28/25/c98e90c803b3f9bcf1c1e8b1284d022f2894d45f2d350f8c64f75209523c/opentelemetry_instrumentation_asyncio-0.63b1-py3-none-any.whl", hash = "sha256:0baa80c9314569fbb868e07f0b8136da367203c2942df5813c184bde2537f44a", size = 13098, upload-time = "2026-05-21T16:35:06.83Z" },
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-asyncpg"
-version = "0.63b0"
+version = "0.63b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-instrumentation" },
     { name = "opentelemetry-semantic-conventions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/6a/04054aecad850eff479f344f0fda336199fcb486b87351f8a6a277e64366/opentelemetry_instrumentation_asyncpg-0.63b0.tar.gz", hash = "sha256:e9a7d5c836a0aa53b2832b2775491f95f9c39dc5803b95d58e088380c5acd25d", size = 8743, upload-time = "2026-05-19T09:47:11.869Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/52/86a5d3e287fb67a6ff4d6dde7653f52b5c18ecd5429809508b507a0988a0/opentelemetry_instrumentation_asyncpg-0.63b1.tar.gz", hash = "sha256:8459cd11e3c114a0b823feb99dc8bac4c55a5374c4287211d0c2cc98787c38e0", size = 8745, upload-time = "2026-05-21T16:36:20.943Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0f/58/936e28eb3f9158431a0538737b0fe63a74e0f47cb5f3103b8a9bcbc33aa2/opentelemetry_instrumentation_asyncpg-0.63b0-py3-none-any.whl", hash = "sha256:2852c04d0525d9835f434a6eda144ea27a43bb31913351388477a4b3c0b6490f", size = 9251, upload-time = "2026-05-19T09:46:16.368Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/09/62151650fe7bf76669130042fd2fc809e15b2c89489bfd4bb58d292a83f8/opentelemetry_instrumentation_asyncpg-0.63b1-py3-none-any.whl", hash = "sha256:ab3762e3d507e7a9bfab97a12fefa4c5b4048fcfbcbb3ae4887cf18bab364857", size = 9250, upload-time = "2026-05-21T16:35:08.22Z" },
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-dbapi"
-version = "0.63b0"
+version = "0.63b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -5682,14 +5721,14 @@ dependencies = [
     { name = "opentelemetry-semantic-conventions" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d7/90/4893f2a1339788de82f1a03788c74c62f5df53fd24a56e462e7f9547a69b/opentelemetry_instrumentation_dbapi-0.63b0.tar.gz", hash = "sha256:e4007ead8b1f5ed51bf92cef195974fdbeaee4fdd92e7aaa51a80c9ff5b24748", size = 19324, upload-time = "2026-05-19T09:47:17.872Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/bf/2bb8048a3ba5686bb70e5d3d7dd2aa2b3d838ccd324e88557780f86b7635/opentelemetry_instrumentation_dbapi-0.63b1.tar.gz", hash = "sha256:406978ed56bcfc5fd246fd918e6b36d0f5de26fa396c78cf63326a7b530597c8", size = 19323, upload-time = "2026-05-21T16:36:27.036Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/f6/0268658f5ccdd5307ff8c1a7389d68e289caf93382728959e0e0853af1d2/opentelemetry_instrumentation_dbapi-0.63b0-py3-none-any.whl", hash = "sha256:c750204c6ae744456adfb944472c4b743565ff9d097cf28a67eb894f064d5017", size = 14401, upload-time = "2026-05-19T09:46:24.575Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/71/c7476e07d8bef5dfe5c301d1650f3ce15c4e3b7f4ffd4bbf6a0e3ebf3836/opentelemetry_instrumentation_dbapi-0.63b1-py3-none-any.whl", hash = "sha256:1bc842ddcacb7ec3622ef306ffdb3c584bf97df79d381e03604ea6eb23c63781", size = 14401, upload-time = "2026-05-21T16:35:23.941Z" },
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-fastapi"
-version = "0.63b0"
+version = "0.63b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -5698,14 +5737,14 @@ dependencies = [
     { name = "opentelemetry-semantic-conventions" },
     { name = "opentelemetry-util-http" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/51/73/6e44cd21b17d4affd41a621804421d476940b1dab352254b1a9c08a08df6/opentelemetry_instrumentation_fastapi-0.63b0.tar.gz", hash = "sha256:5117df842d0ce47e1fb9eb3c2ad2a7594bd139b129de9f3fa1ce5b28e970c046", size = 25387, upload-time = "2026-05-19T09:47:20.726Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/32/d6/0c128fac2e34b7d526a8d3c6edc45b875a97f8a987861b00511151b6337d/opentelemetry_instrumentation_fastapi-0.63b1.tar.gz", hash = "sha256:cc42dff56c96d0a2921510c4abab2a4c2e27fe64b26dc1254727fb550df100ba", size = 25387, upload-time = "2026-05-21T16:36:32.071Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/2d/f869b45eddbb7332cce7a863a4d1e758d58a9c890db6dbf0fe6aedd3eda1/opentelemetry_instrumentation_fastapi-0.63b0-py3-none-any.whl", hash = "sha256:ed43d2358164df83d811a8d69a7578cad3ab66fde4db027296c1ee20f703e3f0", size = 12797, upload-time = "2026-05-19T09:46:28.885Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/3d/2eae63f13f36d7a8ab5bf03d06ecaf169c2069b524547f24947be6d92094/opentelemetry_instrumentation_fastapi-0.63b1-py3-none-any.whl", hash = "sha256:52ee2cde9a2ac094bdd45d79f85860e03a972928a2553006071fe61d94cf7281", size = 12795, upload-time = "2026-05-21T16:35:28.68Z" },
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-httpx"
-version = "0.63b0"
+version = "0.63b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -5714,14 +5753,14 @@ dependencies = [
     { name = "opentelemetry-util-http" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d3/22/21c1d745b82eb28c41c4f0635be1d7b9d9d77bbe0b6c718d7e7d7fcc6f20/opentelemetry_instrumentation_httpx-0.63b0.tar.gz", hash = "sha256:aafb9e336be48b4c0c19ae1f003621e23d75b3560797d42baa656dcc3a555266", size = 23556, upload-time = "2026-05-19T09:47:22.997Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/27/c2b4335bca030e893acbe5ff2b4f434868773bf94508be7e6bf5af981b24/opentelemetry_instrumentation_httpx-0.63b1.tar.gz", hash = "sha256:f41ec82f25c3abcdada621052db3e5fd648e3b43d55eec4b9c0c5d3ecb7b4ff4", size = 23557, upload-time = "2026-05-21T16:36:34.583Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/af/f1/0c9ba71e48129390a9db60ec92ab0149cf97d1a983c11a77e1a04ec5dc7b/opentelemetry_instrumentation_httpx-0.63b0-py3-none-any.whl", hash = "sha256:e4359d317a3313fa8607b7ab4c47088a428856349363c754013fbd595f60fb23", size = 16338, upload-time = "2026-05-19T09:46:32.015Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/b8/f536780996195c3b9f2354998554671e05a7a262df8c043f63fe9e5a6f0b/opentelemetry_instrumentation_httpx-0.63b1-py3-none-any.whl", hash = "sha256:14df6e99d81be9a8cd238f6639b6fa52404c4d3ce219058fcb5dc8c0f2211f86", size = 16336, upload-time = "2026-05-21T16:35:32.221Z" },
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-pika"
-version = "0.63b0"
+version = "0.63b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -5730,28 +5769,28 @@ dependencies = [
     { name = "packaging" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/01/54/b79ca4e47ae0c5df5aeed722dc9d11b5aaab6d6da67520f0420c59bf1c59/opentelemetry_instrumentation_pika-0.63b0.tar.gz", hash = "sha256:687b0ba6c0e2000f2f9831fd124625f574814f41ea5d26ad974fcc1e322302c9", size = 13245, upload-time = "2026-05-19T09:47:26.884Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/eb/088c98cf73ba357f052cdf17dc5846f940fcd50c7dbe5d9958dfea364aeb/opentelemetry_instrumentation_pika-0.63b1.tar.gz", hash = "sha256:c74e23b2370283890d8094bc07686731ba6a7a4bb89a26dc3d6c86ae988fd8d0", size = 13247, upload-time = "2026-05-21T16:36:39.273Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/c3/5805446b7d856ad4aba0056254f07bcb08e085e363f58bd3bc56f50ddfff/opentelemetry_instrumentation_pika-0.63b0-py3-none-any.whl", hash = "sha256:0f43235c0306d55222c58406e4a77f6616995829cb3faf5e5d1076aaa391efe8", size = 12681, upload-time = "2026-05-19T09:46:38.521Z" },
+    { url = "https://files.pythonhosted.org/packages/28/b3/57b63669cb47ec38575194e79dc3b3fc753646fd11e6cc925709aa9f81a9/opentelemetry_instrumentation_pika-0.63b1-py3-none-any.whl", hash = "sha256:14ab56ed06c0c8c922af72cf214eae6513da83be7b6987a17e4f10fa0820d7c2", size = 12681, upload-time = "2026-05-21T16:35:39.726Z" },
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-psycopg"
-version = "0.63b0"
+version = "0.63b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-instrumentation" },
     { name = "opentelemetry-instrumentation-dbapi" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bd/ee/898e54cc10cf2e242350643ea4d58a40b6de47b24064b47c096c21ac943c/opentelemetry_instrumentation_psycopg-0.63b0.tar.gz", hash = "sha256:ec0d2d71ade9bdb7f73c81293d3f4bcc06f9e23b937ff37fa27b9dc369f70f18", size = 11734, upload-time = "2026-05-19T09:47:27.514Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d9/5d/4c3a1be7e68f07c8e4491411e17e646139e32212ebe8a493a6c4d6dbd1bf/opentelemetry_instrumentation_psycopg-0.63b1.tar.gz", hash = "sha256:86819f4cccea21a47920807826495797b7261cc1893c8e855415e76fb7b8e2e8", size = 11737, upload-time = "2026-05-21T16:36:39.962Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/09/83/7d196ae62486354d5c25744d5617a52a0603ce1be0747bd17d1d56ee294e/opentelemetry_instrumentation_psycopg-0.63b0-py3-none-any.whl", hash = "sha256:b5e9a3212d53265dcb7902fe4cc2e360fbaa6d9cd204d11071deb3ba70ec9910", size = 10859, upload-time = "2026-05-19T09:46:39.375Z" },
+    { url = "https://files.pythonhosted.org/packages/76/40/be335cad9028a04ca6025d6f311a76ebd200156cdee985138992895d84e1/opentelemetry_instrumentation_psycopg-0.63b1-py3-none-any.whl", hash = "sha256:4d74ec2dda8e54ead9bd71f134af984792f77e1d8809591ae53edadddd4c8fc0", size = 10857, upload-time = "2026-05-21T16:35:40.784Z" },
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-sqlalchemy"
-version = "0.63b0"
+version = "0.63b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -5760,57 +5799,57 @@ dependencies = [
     { name = "packaging" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/36/72/0def937531c0e7a423af06cbffaf235caea7af0275082c6bca13a25701ec/opentelemetry_instrumentation_sqlalchemy-0.63b0.tar.gz", hash = "sha256:b854ac9fd5707a8f79dc9b252cdec6873217e5a6e7e5fdb43dca6858a26342cb", size = 18007, upload-time = "2026-05-19T09:47:34.518Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cb/97/e5cb3ad027aebf7128faadeefe4d4cb0fc07ed32ef95e8fc9d828a077a85/opentelemetry_instrumentation_sqlalchemy-0.63b1.tar.gz", hash = "sha256:621f9eb800ea24a98b4eda968373e3909bfede0ff47f77b96f8b8a18bc2a2a1a", size = 18006, upload-time = "2026-05-21T16:36:46.855Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/98/eb7430900f683fd6cec4745736bc69ca7260442b6b20ad05194abe97a187/opentelemetry_instrumentation_sqlalchemy-0.63b0-py3-none-any.whl", hash = "sha256:6a31bf004798f8eabb74f75e1d90cf081c7d470933867be6a5c8c985925ddb3e", size = 14410, upload-time = "2026-05-19T09:46:49.328Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/bc/c0984c4c51da64cc2c37ce031b4fb7fab61d223f2188a6bc6b5f18035ae3/opentelemetry_instrumentation_sqlalchemy-0.63b1-py3-none-any.whl", hash = "sha256:d417414f6517963e9c1ee91ec971b94938b46904499114d035a43937bd62b6a1", size = 14410, upload-time = "2026-05-21T16:35:53.342Z" },
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "1.42.0"
+version = "1.42.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/71/2c/7c56a19498b46da4c54dc4e765c95d17f8fec2ba86bec1817b41ae635360/opentelemetry_proto-1.42.0.tar.gz", hash = "sha256:5d56a9067b631ea931a135d7b86428ae99649f591d4db69b9fc8c8e0465fce65", size = 45841, upload-time = "2026-05-19T09:46:42.058Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/55/63eac3e1089b768ba014091fdd2ae8a9a440c821ef5e2b786909c94c8836/opentelemetry_proto-1.42.1.tar.gz", hash = "sha256:c6a51e6b4f05ae63565f3a113217f3d2bfaec68f78c02d7a6c85f9010d1cfca6", size = 45839, upload-time = "2026-05-21T16:33:03.937Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2d/ad/ff5f619a04cddb4936ead0dd8f590c5b373c5b4b9f2eef555e9d3d951ccb/opentelemetry_proto-1.42.0-py3-none-any.whl", hash = "sha256:2c0716a37e5c12efef37cbd01906d649b7fb85c85ac687518d0bd28527c6498e", size = 71779, upload-time = "2026-05-19T09:46:24.536Z" },
+    { url = "https://files.pythonhosted.org/packages/41/9d/171c02c84a76940b7e601805b3bb536985aded9168fbcc9ba52f0a730fa2/opentelemetry_proto-1.42.1-py3-none-any.whl", hash = "sha256:dedb74cba2886c59c7789b227a7a670613025a07489040050aedff6e5c0fb43c", size = 71782, upload-time = "2026-05-21T16:32:44.867Z" },
 ]
 
 [[package]]
 name = "opentelemetry-sdk"
-version = "1.42.0"
+version = "1.42.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-semantic-conventions" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b7/c9/dabaaf1c754a57b82b5a36aeca3806d92c1877ccfb12a697b65f88bf027c/opentelemetry_sdk-1.42.0.tar.gz", hash = "sha256:2479e462cc69357825c2c847ce4a601bc1b17e1279aa7f80d3490f0ae614d0e5", size = 239072, upload-time = "2026-05-19T09:46:42.992Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/40/f7/b390bd9bfd703bf98a68fea1f27786c6872331fd617164a54b8a59bdc008/opentelemetry_sdk-1.42.1.tar.gz", hash = "sha256:8c834e8f8c9ba4171d4ec843d0cb8a67e4c7394d3f9e9297e582cbd9456ddbf7", size = 239262, upload-time = "2026-05-21T16:33:04.641Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/7d/16bf9a9d42ebbd1679e0cda018d57a0712f3b6f6f1e7ae5ef3c7ee5927c0/opentelemetry_sdk-1.42.0-py3-none-any.whl", hash = "sha256:ec4a4f69e15220b3d7bccd93217aac745682bb6435b9381f7bb44cb7e07b4f2b", size = 170879, upload-time = "2026-05-19T09:46:25.871Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/6b/4287766cfbde577ae2272e8884abac325aeaac0d64f41c61d5b8cc595105/opentelemetry_sdk-1.42.1-py3-none-any.whl", hash = "sha256:083cd4bbfaa5aa7b5a9e552430d9951219967cfb27aa61feb13a77aba1fc839d", size = 170907, upload-time = "2026-05-21T16:32:45.894Z" },
 ]
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.63b0"
+version = "0.63b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/20/f8/be4625838aae098c2f9fbdc062a1b3128ebb9e799b891b654ee8cad94897/opentelemetry_semantic_conventions-0.63b0.tar.gz", hash = "sha256:cfea295264654fa324fcef24aa56fb1836fdc0da27db128645dc6aa76115cc6c", size = 148333, upload-time = "2026-05-19T09:46:44.01Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/93/99/4d7dd6df64795951413ce6e815f8cf1eb191daf7196ae86574589643d5f3/opentelemetry_semantic_conventions-0.63b1.tar.gz", hash = "sha256:3daf963611334b365e98a57438183eb012d3bfb40b2d931a9af613476b8701a9", size = 148340, upload-time = "2026-05-21T16:33:05.455Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8f/6f/8d0ce225b8fdbb72c97cf4130107d861eafcb3d8e5c3f5891e8556177316/opentelemetry_semantic_conventions-0.63b0-py3-none-any.whl", hash = "sha256:1f3962732b04f43e4fef28173c9a3615b8847b4b2d6386fdc085361b29875ab9", size = 203712, upload-time = "2026-05-19T09:46:27.569Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/7a/7fe66f5f3682b1dd47d88cc4e11f1c6c0966b737de2d16671146e23c39a5/opentelemetry_semantic_conventions-0.63b1-py3-none-any.whl", hash = "sha256:dfe5ef4dee82586b746f522b818ceb298d00b3d59f660042bd79404bff8d0682", size = 203713, upload-time = "2026-05-21T16:32:47.016Z" },
 ]
 
 [[package]]
 name = "opentelemetry-util-http"
-version = "0.63b0"
+version = "0.63b1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/21/cf/0b53c5fe1113fb01e23c6c88b66d8289f979e61cece444576b286a3415fd/opentelemetry_util_http-0.63b0.tar.gz", hash = "sha256:401ddd686cd943ef801b9384b0722b904250f6bf3906951ce4f27bb6b63b04a3", size = 11101, upload-time = "2026-05-19T09:47:42.885Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/d8/7bf5e4cec0578ac3c28c18eb7b88f34279139cbc8c568d6aa02b9c5ae53e/opentelemetry_util_http-0.63b1.tar.gz", hash = "sha256:ba1268f00922ee522dba2ae38458060f99486e7385a8056985901ca9685adfff", size = 11102, upload-time = "2026-05-21T16:36:56.675Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/8c/7fd6f06139cca88a6341bebf2b01f3e97bb8fd8d12e7d3ad3d2ad88b8c49/opentelemetry_util_http-0.63b0-py3-none-any.whl", hash = "sha256:80536361b6348e57503cdae8c1b1be79574d14c30e879367336c5a076fd4f673", size = 8209, upload-time = "2026-05-19T09:47:01.712Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/34e047e8f6a3c67e5220acf1af7b9f62868c25d77791bca74457bd2180a6/opentelemetry_util_http-0.63b1-py3-none-any.whl", hash = "sha256:6284194028c59cd439f8acfe388145069a6127f11dc077e1344a2094adacc3f8", size = 8205, upload-time = "2026-05-21T16:36:09.736Z" },
 ]
 
 [[package]]
@@ -5836,11 +5875,11 @@ wheels = [
 
 [[package]]
 name = "platformdirs"
-version = "4.9.6"
+version = "4.10.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/47/e4501f49c178ae1d9f4a75073fda4204f52647993f075a9db4d14930e0c5/platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7", size = 31224, upload-time = "2026-05-28T03:32:53.587Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
+    { url = "https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a", size = 22743, upload-time = "2026-05-28T03:32:52.175Z" },
 ]
 
 [[package]]
@@ -6078,46 +6117,46 @@ rsa = [
 
 [[package]]
 name = "pyright"
-version = "1.1.409"
+version = "1.1.410"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nodeenv" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/51/4e/3aa27f74211522dba7e9cbc3e74de779c6d4b654c54e50a4840623be8014/pyright-1.1.409.tar.gz", hash = "sha256:986ee05beca9e077c165758ad123667c679e050059a2546aa02473930394bc93", size = 4430434, upload-time = "2026-04-23T11:02:03.799Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/10/53/e4d8ea1391bd4355231be6f91bf239479aa0014260ed3fb5526eeb12a1f2/pyright-1.1.410.tar.gz", hash = "sha256:07a073b8ba6749826773c1269773efa11b93440d9a6aa60419d9a3172d6dc488", size = 4062013, upload-time = "2026-06-01T17:35:48.894Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/16/6b/330d8ebae582b30c2959a1ef4c3bc344ebde48c2ff0c3f113c4710735e11/pyright-1.1.409-py3-none-any.whl", hash = "sha256:aa3ea228cab90c845c7a60d28db7a844c04315356392aa09fafcee98c8c22fb3", size = 6438161, upload-time = "2026-04-23T11:02:01.309Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/33/288b5868fa00846dacf249633719d747893e54aebd196b9968ac1878a5d3/pyright-1.1.410-py3-none-any.whl", hash = "sha256:5e961bed37cacf96b3f7cd7b1da39b350a9239aa2e69138d0e88f728cfaf296c", size = 6082448, upload-time = "2026-06-01T17:35:46.387Z" },
 ]
 
 [[package]]
 name = "pyroscope-io"
-version = "1.0.8"
+version = "1.0.11"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/12/1d/2875113464e4d71c8823ead5050f2284c0f3e68a29e2d88124834258e935/pyroscope_io-1.0.8.tar.gz", hash = "sha256:993f40a7e220a016186b00cf9877efdce46893ea5436f10d7dfe0905095bfed0", size = 31901, upload-time = "2026-05-11T01:41:28.885Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/59/df63f73be956389ba425b0d4fc835a792df199ba731b8bf1508f68519098/pyroscope_io-1.0.11.tar.gz", hash = "sha256:8579b1c013e5bcaaccab922219e11bcd1c996953e80467555f4759bd6780dd0f", size = 31069, upload-time = "2026-06-01T12:25:52.474Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b1/83/fb226cbc68d61208bfe37b536ff177e2dc80d89b8300b44e5b7004e9178f/pyroscope_io-1.0.8-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:b0e6b8a71b9bc29be0cbf1a5dd60e7d606a9eeffcdb8793b3a09f434b2795f0e", size = 3620316, upload-time = "2026-05-11T01:41:18.682Z" },
-    { url = "https://files.pythonhosted.org/packages/25/cd/4d36fa640eb34d9ff3832e5854723c0188454d3cab16c98d7e73a569762f/pyroscope_io-1.0.8-cp310-abi3-macosx_11_0_x86_64.whl", hash = "sha256:5d30f6061e6fc30043e811f046e51b240829ac490a43d62ff2b3ed1975a71de8", size = 3837204, upload-time = "2026-05-11T01:41:20.707Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/23/05f557058a29786a2283b67c4a79d264ce3433c8cbb16004619b36a60dde/pyroscope_io-1.0.8-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:839f9068ef5636602cff2dada45033e0b429e1380765e0b7f363dfab712846d0", size = 6860450, upload-time = "2026-05-11T01:41:22.065Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/06/745bedc9fefe543b5053db39c2c870786ca2ef62b5fcd9d75da5cfa9ac47/pyroscope_io-1.0.8-cp310-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6820ea80ed2c307bc804cc572e94ccb664c243610a6f016c0933caa0cb5bd3f2", size = 6743075, upload-time = "2026-05-11T01:41:23.87Z" },
-    { url = "https://files.pythonhosted.org/packages/74/f7/2389738421c150ab4c073067073c39acc1cd61c734b1ef1b9cbf449a6001/pyroscope_io-1.0.8-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9f3d468adcbdd3380d7429c842ffc771796f5c63ab24d71b08ec249b7d9793c0", size = 6978316, upload-time = "2026-05-11T01:41:25.587Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/31/783483d1689980b5af3d42c0e7b1a3224f6965b907ef5c2835975fa8821c/pyroscope_io-1.0.8-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:83bcd92f11fbecb1b39c6de978a650ef81a352d348c367f520639b2e54d85ac1", size = 6909708, upload-time = "2026-05-11T01:41:27.486Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/ec/c8ec90b2814a82bf3890d5b6fdce58005e786734b782cb8f1e95663cc521/pyroscope_io-1.0.11-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:e15e1f7d2f1a58a8168c08dd51d75f8ad28490adcc524cb7f5f0a8fe24848acb", size = 3532948, upload-time = "2026-06-01T12:25:42.135Z" },
+    { url = "https://files.pythonhosted.org/packages/90/50/39c0cd5e0c04ad2c6583027fee84605a693347dab77d1fb5da0b47b11319/pyroscope_io-1.0.11-cp310-abi3-macosx_11_0_x86_64.whl", hash = "sha256:45e5c26b0d4edd79bbf1651b1d572bacc02c2e5aa9a14b388aadec214dfb0eb5", size = 3746621, upload-time = "2026-06-01T12:25:43.795Z" },
+    { url = "https://files.pythonhosted.org/packages/51/78/154bf5c56053be59a0e31cc2f09ad945be3e59c31c97ff28c4d7350594e2/pyroscope_io-1.0.11-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0d91bbc9b8e1a38287028e767e97749a949170017bd76bbb7b3cdbf180def81a", size = 6770016, upload-time = "2026-06-01T12:25:45.979Z" },
+    { url = "https://files.pythonhosted.org/packages/76/b4/f0374b31484fb4eabe844f8748ea7952e4ae2e6fdafd97e04c0b83593dbc/pyroscope_io-1.0.11-cp310-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fa5fb4d34c1f2720d49f5d3a6c1c7845c1f7f1622750008e6db6616f27f6f19d", size = 6441723, upload-time = "2026-06-01T12:25:47.751Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/ef/4e9b513325c5cb67439d05e567c68a5d40cf75a4dfe2cec44b595467a02e/pyroscope_io-1.0.11-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:655d24f0a4907a6a54a7cd0d67b46983acb058cc908e10e338b3820927a9164f", size = 6908508, upload-time = "2026-06-01T12:25:49.124Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/c4/6cb083d3ad2d22f372eaec7ae178ec41a8e08bda4653fca7bba0679b335f/pyroscope_io-1.0.11-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6aea9752bc62df77934301df7f22b7575aead75d3a0e1994505519dd670a8e0e", size = 6799029, upload-time = "2026-06-01T12:25:51.059Z" },
 ]
 
 [[package]]
 name = "pyroscope-otel"
-version = "1.0.0"
+version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-sdk" },
     { name = "pyroscope-io" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d9/86/a3a65272005b72610ebc6019090e7dabbdd26d075864acdd58536040c2ce/pyroscope_otel-1.0.0.tar.gz", hash = "sha256:43de0314e8d146de3378e6add2d80f2aa118b56974e8cb99f17a50ce76573546", size = 13625, upload-time = "2026-02-24T02:35:18.945Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/ed/e7aab94f86a208431f3680e34b9feb079ab5cc27fa059ab243ff1a77ac70/pyroscope_otel-1.0.1.tar.gz", hash = "sha256:6e491dc3c8065bc47e7304dc074f724ea011926be0ec5f69696b99da62cc54a2", size = 13610, upload-time = "2026-06-01T11:29:51.278Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/eb/e8858a7c302a8305ff40121ba7f62d6f17dea8b7011a6de7ae9573774be3/pyroscope_otel-1.0.0-py3-none-any.whl", hash = "sha256:b4282af41cfbb7211acfe3ce21f76cb34681694d210f1a97ac941ad60ef0f35c", size = 11619, upload-time = "2026-02-24T02:35:18.033Z" },
+    { url = "https://files.pythonhosted.org/packages/46/05/40b89c2f8291501d71157ac2d2d91a130a3391e926ed8cc5058f931cc3d2/pyroscope_otel-1.0.1-py3-none-any.whl", hash = "sha256:c517f788758458fcecf31b8f805543e92c1f4a3288900013b781eaf074059398", size = 11618, upload-time = "2026-06-01T11:29:50.165Z" },
 ]
 
 [[package]]
@@ -6138,16 +6177,16 @@ wheels = [
 
 [[package]]
 name = "pytest-aiohttp"
-version = "1.1.0"
+version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/72/4b/d326890c153f2c4ce1bf45d07683c08c10a1766058a22934620bc6ac6592/pytest_aiohttp-1.1.0.tar.gz", hash = "sha256:147de8cb164f3fc9d7196967f109ab3c0b93ea3463ab50631e56438eab7b5adc", size = 12842, upload-time = "2025-01-23T12:44:04.465Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/4d/c6621fc79022f6c84a806e23d9b7eca24fae4f3ee779219bbe524339d666/pytest_aiohttp-1.1.1.tar.gz", hash = "sha256:3aa9c9fe26e543eaccc7eb0add381c685ba3ed3e2fed0af74540f63bcd31458d", size = 13704, upload-time = "2026-06-07T23:56:34.173Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ba/0f/e6af71c02e0f1098eaf7d2dbf3ffdf0a69fc1e0ef174f96af05cef161f1b/pytest_aiohttp-1.1.0-py3-none-any.whl", hash = "sha256:f39a11693a0dce08dd6c542d241e199dd8047a6e6596b2bcfa60d373f143456d", size = 8932, upload-time = "2025-01-23T12:44:03.27Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/b0/5056ed4c3f68a4db2b4a39fb0ec61b1e4cf1d89ee14effe5261cc587264c/pytest_aiohttp-1.1.1-py3-none-any.whl", hash = "sha256:f293441ad4f8446a1e12257130c26c7de03a615c2a5572a8cb046e5b3b4e5211", size = 9007, upload-time = "2026-06-07T23:56:33.333Z" },
 ]
 
 [[package]]
@@ -6241,15 +6280,15 @@ wheels = [
 
 [[package]]
 name = "python-discovery"
-version = "1.3.1"
+version = "1.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
     { name = "platformdirs" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/48/60/e88788207d81e46362cfbef0d4aaf4c0f49efc3c12d4c3fa3f542c34ebec/python_discovery-1.3.1.tar.gz", hash = "sha256:62f6db28064c9613e7ca76cb3f00c38c839a07c31c00dfe7ed0986493d2150a6", size = 68011, upload-time = "2026-05-12T20:53:36.336Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/1a/cbbaf13b730abb0a16b964d984e19f2fe520c21a4dc664051359a3f5a9e7/python_discovery-1.4.2.tar.gz", hash = "sha256:8f3746c4b4968d22afbb97d36e1a0e5b66e6c0f297290f2e95f05b9b8bf18690", size = 70277, upload-time = "2026-06-11T16:10:42.383Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/6f/a05a317a66fee0aad270011461f1a63a453ed12471249f172f7d2e2bc7b4/python_discovery-1.3.1-py3-none-any.whl", hash = "sha256:ed188687ebb3b82c01a17cd5ac62fc94d9f6487a7f1a0f9dfe89753fec91039c", size = 33185, upload-time = "2026-05-12T20:53:34.969Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/82/a70006589557f267f15bd384c0642ad49f0d97b690c3a05b166b9dcbad3b/python_discovery-1.4.2-py3-none-any.whl", hash = "sha256:475803f53b7b2ed6e490e27373f9d8340f7d2eebf9acdaf645d7d714c97bb500", size = 33886, upload-time = "2026-06-11T16:10:41.192Z" },
 ]
 
 [[package]]
@@ -6272,12 +6311,12 @@ wheels = [
 
 [[package]]
 name = "pywin32"
-version = "311"
+version = "312"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
-    { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/2b/1f3cded5822fd49c02f40544cbb5f58c7cfd6b1694869fd476cb6170ee97/pywin32-312-cp314-cp314-win32.whl", hash = "sha256:a77a90fbb6881238d2ca9c6fd797b25817f3768fe78d214a90137ff055a75f5b", size = 6468928, upload-time = "2026-06-04T07:49:43.188Z" },
+    { url = "https://files.pythonhosted.org/packages/21/82/3bf86d2e2808902013132e1ce905a7da0da53790f3836c64bf44d55e24f3/pywin32-312-cp314-cp314-win_amd64.whl", hash = "sha256:a4dd3a848290ef724347b19f301045831d8e802fa4464f491b98b1e0a081432e", size = 7024157, upload-time = "2026-06-04T07:49:45.34Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/0e/73f6d6800b4f27655abd9e9f6aaeaefcddb2b946e4674efa2bab184a7f7b/pywin32-312-cp314-cp314-win_arm64.whl", hash = "sha256:9fce94568364e0155e6dfb781ac5d95903be8baf28670632beab1b523f300daa", size = 6839598, upload-time = "2026-06-04T07:49:47.613Z" },
 ]
 
 [[package]]
@@ -6428,27 +6467,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.13"
+version = "0.15.17"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/24/21/a7d5c126d5b557715ef81098f3db2fe20f622a039ff2e626af28d674ab80/ruff-0.15.13.tar.gz", hash = "sha256:f9d89f17f7ba7fb2ed42921f0df75da797a9a5d71bc39049e2c687cf2baf44b7", size = 4678180, upload-time = "2026-05-14T13:44:37.869Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/a9/3abdf488f1bf3d24c699415e454ed554a6350d5d89ce183be1ee0a3361ac/ruff-0.15.17.tar.gz", hash = "sha256:2ec446937fd16c8c4de2674a209cc5af64d9c6f17d21fbf1151054fa0bcf5219", size = 4743346, upload-time = "2026-06-11T17:54:47.663Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c6/61/11d458dc6ac22504fd8e237b29dfd40504c7fbbcc8930402cfe51a8e63ed/ruff-0.15.13-py3-none-linux_armv6l.whl", hash = "sha256:444b580fc72fd6887e650acd3e575e18cdc79dbcf42fb4030b491057921f61f8", size = 10738279, upload-time = "2026-05-14T13:44:18.7Z" },
-    { url = "https://files.pythonhosted.org/packages/86/ca/caa871ee7be718c45256fada4e16a218ee3e33f0c4a46b729a60a24912e6/ruff-0.15.13-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:6590d009e7cb7ebf36f83dbdd44a3fa48a0994ff6f1cdc1b08006abe58f98dc7", size = 11124798, upload-time = "2026-05-14T13:44:06.427Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/19/43f5f2e568dddde567fc41f8471f9432c09563e19d3e617a48cfa52f8f0a/ruff-0.15.13-py3-none-macosx_11_0_arm64.whl", hash = "sha256:1c26d2f66163deeb6e08d8b39fbbe983ce3c71cea06a6d7591cfd1421793c629", size = 10460761, upload-time = "2026-05-14T13:44:04.375Z" },
-    { url = "https://files.pythonhosted.org/packages/99/df/cf938cd6de3003178f03ad7c1ea2a6c099468c03a35037985070b37e76be/ruff-0.15.13-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9dbd6f94b434f896308e4d57fb7bfde0d02b99f7a64b3bdab0fdfa6a864203a5", size = 10804451, upload-time = "2026-05-14T13:44:25.221Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/7d/5d0973129b154ded2225729169d7068f26b467760b146493fde138415f23/ruff-0.15.13-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bf3259f3be4d181bda591da5db2571aed6853c6a048157756448020bc6c5cd22", size = 10534285, upload-time = "2026-05-14T13:44:08.888Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/e3/6b999bbc66cd51e5f073842bc2a3995e99c5e0e72e16b15e7261f7abf57a/ruff-0.15.13-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ae9c17e5eb4430c154e76abc25d79a318190f5a997f38fb6b114416c5319ffc9", size = 11312063, upload-time = "2026-05-14T13:44:11.274Z" },
-    { url = "https://files.pythonhosted.org/packages/af/5a/642639e9f5db04f1e97fbd6e091c6fd20725bdf072fb114d00eefb9e6eb8/ruff-0.15.13-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2e2e39bff6c341f4b577a21b801326fab0b11847f48fcaa83f00a113c9b3cb55", size = 12183079, upload-time = "2026-05-14T13:44:01.634Z" },
-    { url = "https://files.pythonhosted.org/packages/19/4c/7585735f6b53b0f12de13618b2f7d250a844f018822efc899df2e7b8295f/ruff-0.15.13-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e8d9a8e08013542e94d3220bc5b62cc3e5ef87c5f74bff367d3fac14fab013e6", size = 11440833, upload-time = "2026-05-14T13:43:59.043Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/31/bf1a0803d077e679cfeee5f2f67290a0fa79c7385b5d9a8c17b9db2c48f0/ruff-0.15.13-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cc411dfebe5eebe55ce041c6ae080eb7668955e866daa2fbb16692a784f1c4ca", size = 11434486, upload-time = "2026-05-14T13:44:27.761Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/4e/62c9b999875d4f14db80f277c030578f5e249c9852d65b7ac7ad0b43c041/ruff-0.15.13-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:768494eb08b9cee54e2fd27969966f74db5a57f6eaa7a90fcb3306af34dfc4bd", size = 11385189, upload-time = "2026-05-14T13:44:13.704Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/89/7e959047a104df3eb12863447c110140191fc5b6c4f379ea2e803fcdb0e4/ruff-0.15.13-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:fb75f9a3a7e42ffe117d734494e6c5e5cb3565d66e12612cb63d0e572a41a5b6", size = 10781380, upload-time = "2026-05-14T13:43:56.734Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/52/5fd18f3b88cab63e88aa11516b3b4e1e5f720e5c330f8dbe5c26210f41f8/ruff-0.15.13-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8cb74dd33bb2f6613faf7fc03b660053b5ac4f80e706d5788c6335e2a8048d51", size = 10540605, upload-time = "2026-05-14T13:44:20.748Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/e0/9e35f338990d3e41a82875ff7053ffe97541dae81c9d02143177f381d572/ruff-0.15.13-py3-none-musllinux_1_2_i686.whl", hash = "sha256:7ef823f817fcd191dc934e984be9cf4094f808effa16f2542ad8e821ba02bbf2", size = 11036554, upload-time = "2026-05-14T13:44:16.256Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/13/070fb048c24080fba188f66371e2a92785be257ad02242066dc7255ac6e9/ruff-0.15.13-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:f345a13937bd7f09f6f5d19fa0721b0c103e00e7f62bc67089a8e5e037719e0b", size = 11528133, upload-time = "2026-05-14T13:44:22.808Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/8c/b1e1666aef7fc6555094d73ae6cd981701781ae85b97ceefc0eebd0b4668/ruff-0.15.13-py3-none-win32.whl", hash = "sha256:4044f94208b3b05ba0fc4a4abd0558cf4d6459bd18325eead7fd8cc66f909b41", size = 10721455, upload-time = "2026-05-14T13:44:35.697Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/a6/870a3e8a50590bb92be184ad928c2922f088b00d9dc5c5ec7b924ee08c22/ruff-0.15.13-py3-none-win_amd64.whl", hash = "sha256:7064884d442b7d477b4e7473d12da7f08851d2b1982763c5d3f388a19468a1a4", size = 11900409, upload-time = "2026-05-14T13:44:30.389Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/36/9c015cd052fca743dae8cb2aeb16b551444787467db42ceab0fc968865af/ruff-0.15.13-py3-none-win_arm64.whl", hash = "sha256:2471da9bd1068c8c064b5fd9c0c4b6dddffd6369cb1cd68b29993b1709ff1b21", size = 11179336, upload-time = "2026-05-14T13:44:33.026Z" },
+    { url = "https://files.pythonhosted.org/packages/db/4d/e11259f5da07cb6afb2d074c31bf09da9671993f7329d4f15d2fdc458301/ruff-0.15.17-py3-none-linux_armv6l.whl", hash = "sha256:d9feddb927fc68bd295f5eebc587a7e42cfaf9b65f60ca4a2386febff575da8f", size = 10856677, upload-time = "2026-06-11T17:54:49.533Z" },
+    { url = "https://files.pythonhosted.org/packages/29/3e/772d679e1a0dc058e58875bd2c0cb713a0530877b4a76fee3c7966df0d49/ruff-0.15.17-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:25805a226d741c47d274a35ad5c10a7dde175fcddfa511d7cf3da0a21eb3eab7", size = 11223443, upload-time = "2026-06-11T17:55:00.573Z" },
+    { url = "https://files.pythonhosted.org/packages/68/58/bd41f7688b2fd5623012605130ed70e60aa7f2244baa3d5066bdd61530c8/ruff-0.15.17-py3-none-macosx_11_0_arm64.whl", hash = "sha256:f6ad73b14c2d18a3bf8ad7cb6974294d7f613a7898604826058e6ac64918ef4d", size = 10566458, upload-time = "2026-06-11T17:55:07.52Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/5b/733371013fcf1ec339e477ece6ab42bfe10bdd9bba8ee88a9516aa56bfc0/ruff-0.15.17-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6ba0c1e4f95bcb3869d0d30cbd5917071ef2e28665abfec970cdab0492c713ed", size = 10914483, upload-time = "2026-06-11T17:55:05.501Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/cc/6f24251cc0252f7239391ccb85833f320efad14ebe5b443943f37ced6332/ruff-0.15.17-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:81647960f10bff57d2e51cadd0c3950fe598400c852863a038720ef5b8cca91e", size = 10647497, upload-time = "2026-06-11T17:54:57.733Z" },
+    { url = "https://files.pythonhosted.org/packages/68/dd/0d10c17ce1a1624d6fc3156309c3f834fdb5dfaad026ec90c85684f3990e/ruff-0.15.17-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0e01a84ddbc8c16c23055ba3924476850f1bbc1917cebbb9376665a63e74260d", size = 11416967, upload-time = "2026-06-11T17:54:51.461Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/91/556bfb156f6144f355e831c23db00b2fc4120f86b3ce81cc5f7fd2df51f3/ruff-0.15.17-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:84fe9f653152f8f294f9f7e03bf3a453d8b4a27f7a59c78c8666167f2b17b96c", size = 12335770, upload-time = "2026-06-11T17:54:45.793Z" },
+    { url = "https://files.pythonhosted.org/packages/88/82/8b5999aa13355e926f06d9f42a32dcca862f623bf0363785ff89d607dffd/ruff-0.15.17-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c0fe88a7676e7a05b73174d4d4a59cb2ac21ff8263583f87a81a6018475a978", size = 11575441, upload-time = "2026-06-11T17:54:32.661Z" },
+    { url = "https://files.pythonhosted.org/packages/11/93/f10377bb04109ca0e8cbc483ff1982c54b6d418210041776f93e8cdc7fa9/ruff-0.15.17-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ecfc3c7878fff94633ab0348524e093f9ce3243080416dd7d14f8ba400174719", size = 11557614, upload-time = "2026-06-11T17:54:34.698Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/a6/eeeae7f7d5493df41649ab3db92f086b2d0a30199e4efdf8e3dd7a033f24/ruff-0.15.17-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:b8461180b22420b1bdc289909410930761629fddf2a5aaf60fae1ab26cedc4c4", size = 11544450, upload-time = "2026-06-11T17:54:39.042Z" },
+    { url = "https://files.pythonhosted.org/packages/32/88/5991ce565129a24dd4a00db1254b3b5db2e53018cbe4018ea5a89738e727/ruff-0.15.17-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:6eccbe50a038b503e7140b441aa9c7fc8c1f36edf23ebef9f4165c2f28f568b7", size = 10892524, upload-time = "2026-06-11T17:55:09.432Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/1d/0fdd248313425f55223968af04b0a42125466a8d88d21c1d99c6af0a51e8/ruff-0.15.17-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:382fc0521025f5a8ad447d8bdd523545d0d7646adb718eb1c2dac5065ec27c0f", size = 10659573, upload-time = "2026-06-11T17:54:36.824Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/0e/072e8260deb9461062ce9311ced27a8e541229a6ffd483013dd37661e43e/ruff-0.15.17-py3-none-musllinux_1_2_i686.whl", hash = "sha256:456d41fcd1b2777ad63f09a6e7121d43f7b688bbc76a800c10f7f8fb1f912c3f", size = 11127818, upload-time = "2026-06-11T17:55:03.124Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/b4/55060a34163121498014696b5f656db5b8c6963768f227dbf0d76b311073/ruff-0.15.17-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:b1a04bcc94ae6194e9db05d16ad31f298a7194bfbcb08258bbe589cee1d587b8", size = 11655901, upload-time = "2026-06-11T17:54:53.562Z" },
+    { url = "https://files.pythonhosted.org/packages/49/71/9b29d6b87cef468d697f43c6a91e3fae4a80185779d7d5a4ef27d173439f/ruff-0.15.17-py3-none-win32.whl", hash = "sha256:596065960ab1ff593f744220c9fe6580eda00a95003cffa9f4048bb5b1bf0392", size = 10925574, upload-time = "2026-06-11T17:54:55.723Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/b2/8fc77f3723228836fa5d12497eb71c808f83782e10d058d2b15cfa14640b/ruff-0.15.17-py3-none-win_amd64.whl", hash = "sha256:6769e5fa1710b179b92e0bfa5a51735b35baea9013dadb06d5f44cbcf9547084", size = 12058788, upload-time = "2026-06-11T17:54:41.042Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/c7/c53e8dbff9c9dc4b7928773421ae294a5d28fcb8dcda1a089579d3a7e510/ruff-0.15.17-py3-none-win_arm64.whl", hash = "sha256:f3be1fbb34bcdfd146240d8fb92a709d4c2c8191348580a3c044ec60fa0b4456", size = 11355275, upload-time = "2026-06-11T17:54:43.635Z" },
 ]
 
 [[package]]
@@ -6483,28 +6522,29 @@ wheels = [
 
 [[package]]
 name = "sqlalchemy"
-version = "2.0.49"
+version = "2.0.50"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/09/45/461788f35e0364a8da7bda51a1fe1b09762d0c32f12f63727998d85a873b/sqlalchemy-2.0.49.tar.gz", hash = "sha256:d15950a57a210e36dd4cec1aac22787e2a4d57ba9318233e2ef8b2daf9ff2d5f", size = 9898221, upload-time = "2026-04-03T16:38:11.704Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/da/6fbf010c8ebb347679d0d100b22fe9ba5e13fd04046c5df7280d2f0bf706/sqlalchemy-2.0.50.tar.gz", hash = "sha256:af5607d11ef90fd6a5c0549fe0045dce1663d427426bcfb506dcb5346a85a3b9", size = 9907424, upload-time = "2026-05-24T19:20:04.018Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/55/33/bf28f618c0a9597d14e0b9ee7d1e0622faff738d44fe986ee287cdf1b8d0/sqlalchemy-2.0.49-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:233088b4b99ebcbc5258c755a097aa52fbf90727a03a5a80781c4b9c54347a2e", size = 2156356, upload-time = "2026-04-03T16:53:09.914Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/a7/5f476227576cb8644650eff68cc35fa837d3802b997465c96b8340ced1e2/sqlalchemy-2.0.49-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:57ca426a48eb2c682dae8204cd89ea8ab7031e2675120a47924fabc7caacbc2a", size = 3276486, upload-time = "2026-04-03T17:07:46.9Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/84/efc7c0bf3a1c5eef81d397f6fddac855becdbb11cb38ff957888603014a7/sqlalchemy-2.0.49-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:685e93e9c8f399b0c96a624799820176312f5ceef958c0f88215af4013d29066", size = 3281479, upload-time = "2026-04-03T17:12:32.226Z" },
-    { url = "https://files.pythonhosted.org/packages/91/68/bb406fa4257099c67bd75f3f2261b129c63204b9155de0d450b37f004698/sqlalchemy-2.0.49-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9e0400fa22f79acc334d9a6b185dc00a44a8e6578aa7e12d0ddcd8434152b187", size = 3226269, upload-time = "2026-04-03T17:07:48.678Z" },
-    { url = "https://files.pythonhosted.org/packages/67/84/acb56c00cca9f251f437cb49e718e14f7687505749ea9255d7bd8158a6df/sqlalchemy-2.0.49-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a05977bffe9bffd2229f477fa75eabe3192b1b05f408961d1bebff8d1cd4d401", size = 3248260, upload-time = "2026-04-03T17:12:34.381Z" },
-    { url = "https://files.pythonhosted.org/packages/56/19/6a20ea25606d1efd7bd1862149bb2a22d1451c3f851d23d887969201633f/sqlalchemy-2.0.49-cp314-cp314-win32.whl", hash = "sha256:0f2fa354ba106eafff2c14b0cc51f22801d1e8b2e4149342023bd6f0955de5f5", size = 2118463, upload-time = "2026-04-03T17:05:47.093Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/4f/8297e4ed88e80baa1f5aa3c484a0ee29ef3c69c7582f206c916973b75057/sqlalchemy-2.0.49-cp314-cp314-win_amd64.whl", hash = "sha256:77641d299179c37b89cf2343ca9972c88bb6eef0d5fc504a2f86afd15cd5adf5", size = 2144204, upload-time = "2026-04-03T17:05:48.694Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/33/95e7216df810c706e0cd3655a778604bbd319ed4f43333127d465a46862d/sqlalchemy-2.0.49-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c1dc3368794d522f43914e03312202523cc89692f5389c32bea0233924f8d977", size = 3565474, upload-time = "2026-04-03T16:58:35.128Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/a4/ed7b18d8ccf7f954a83af6bb73866f5bc6f5636f44c7731fbb741f72cc4f/sqlalchemy-2.0.49-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7c821c47ecfe05cc32140dcf8dc6fd5d21971c86dbd56eabfe5ba07a64910c01", size = 3530567, upload-time = "2026-04-03T17:06:04.587Z" },
-    { url = "https://files.pythonhosted.org/packages/73/a3/20faa869c7e21a827c4a2a42b41353a54b0f9f5e96df5087629c306df71e/sqlalchemy-2.0.49-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9c04bff9a5335eb95c6ecf1c117576a0aa560def274876fd156cfe5510fccc61", size = 3474282, upload-time = "2026-04-03T16:58:37.131Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/50/276b9a007aa0764304ad467eceb70b04822dc32092492ee5f322d559a4dc/sqlalchemy-2.0.49-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:7f605a456948c35260e7b2a39f8952a26f077fd25653c37740ed186b90aaa68a", size = 3480406, upload-time = "2026-04-03T17:06:07.176Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/c3/c80fcdb41905a2df650c2a3e0337198b6848876e63d66fe9188ef9003d24/sqlalchemy-2.0.49-cp314-cp314t-win32.whl", hash = "sha256:6270d717b11c5476b0cbb21eedc8d4dbb7d1a956fd6c15a23e96f197a6193158", size = 2149151, upload-time = "2026-04-03T17:02:07.281Z" },
-    { url = "https://files.pythonhosted.org/packages/05/52/9f1a62feab6ed368aff068524ff414f26a6daebc7361861035ae00b05530/sqlalchemy-2.0.49-cp314-cp314t-win_amd64.whl", hash = "sha256:275424295f4256fd301744b8f335cff367825d270f155d522b30c7bf49903ee7", size = 2184178, upload-time = "2026-04-03T17:02:08.623Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/30/8519fdde58a7bdf155b714359791ad1dc018b47d60269d5d160d311fdc36/sqlalchemy-2.0.49-py3-none-any.whl", hash = "sha256:ec44cfa7ef1a728e88ad41674de50f6db8cfdb3e2af84af86e0041aaf02d43d0", size = 1942158, upload-time = "2026-04-03T16:53:44.135Z" },
+    { url = "https://files.pythonhosted.org/packages/df/32/10ac51b4be7cdecd7e93d069251c86dfbf70b7adbd7c67b48ccea6c49e1c/sqlalchemy-2.0.50-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c966932507a4d7d0a37314927dbfcd89720e3f37d2a1e3352e7ae7939fa8e8a0", size = 2158519, upload-time = "2026-05-24T19:27:56.472Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/76/e703d2f7681d7d66c4c891af3f07c7ccf4c76ad7f18351de035b5eda007a/sqlalchemy-2.0.50-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:faffef4bcc20a1892e65e155293d99d60855bbbc79250ab712819cfd56a8e6bb", size = 3282063, upload-time = "2026-05-24T20:09:38.57Z" },
+    { url = "https://files.pythonhosted.org/packages/31/26/ef168b184a25701f9995e8fb7e503fafd7a99c1c77cda1bc1a26ea2ed486/sqlalchemy-2.0.50-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c206aec519a2e7bd08abbfb33436e325fd22c632d9c21a9047e376ce241646e", size = 3287069, upload-time = "2026-05-24T20:17:21.942Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/15/765acc2bc693bccc43ca4a95d5b69750da8aaf6db1b5c616536e087f8920/sqlalchemy-2.0.50-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:bef4ac756363227ef6402a75fee025a4bc690f92328e825868939b3b3a446a6d", size = 3230453, upload-time = "2026-05-24T20:09:40.398Z" },
+    { url = "https://files.pythonhosted.org/packages/63/61/08e03c3adbf5db0087a0b6816746fec8f3032fb2f7fc899a9bb9b2a48ce4/sqlalchemy-2.0.50-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:96fbee6b19c19cd1556c8bf9419447cf2ec149ffcab7ab64348c23e54ef8547f", size = 3252413, upload-time = "2026-05-24T20:17:24.067Z" },
+    { url = "https://files.pythonhosted.org/packages/03/0c/370a1f2db38436c615e10134c8a37de3688e74084792380695f3f5083860/sqlalchemy-2.0.50-cp314-cp314-win32.whl", hash = "sha256:8f00e3eb43ba30eb1b238ee03a8a62309486d1321eda3328bb611e0340033ad8", size = 2120063, upload-time = "2026-05-24T19:50:11.08Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/a0/fe92bb9817863bc13ba093bda931979a26cc2ca69f8e8f26d07add3d7c6f/sqlalchemy-2.0.50-cp314-cp314-win_amd64.whl", hash = "sha256:15708c613cd5005b7dffe1f66ee6a63ee8f5e46799f71c70ebad74178c676a39", size = 2145830, upload-time = "2026-05-24T19:50:12.452Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/ff/e5640a98a0b2f491eb8fde10fb6c773621a2e44340de231fafcc9370f4a9/sqlalchemy-2.0.50-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:3699dac4be410e97049a1658e9480da9cde956594aa0f3aebc60b88f21c5ba70", size = 2178435, upload-time = "2026-05-24T19:42:58.889Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/85/337116e186f1236375b5fb70c21cfac98e8e8ab0d3a47be838dc47a59e08/sqlalchemy-2.0.50-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f96233858e3df43932ac11589e22520da6e8aeb624b03fedfeebb0e8ea213086", size = 3566059, upload-time = "2026-05-24T20:01:20.848Z" },
+    { url = "https://files.pythonhosted.org/packages/96/34/bb0e190e161c3c2c24314a65add57218be14a4a9486886b7f5047c1ff7c8/sqlalchemy-2.0.50-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c4e70c46fad30c3bcc6a4708bc0130a3173e11a5b25f0ea4a9d8911b450f1f52", size = 3535366, upload-time = "2026-05-24T20:03:56.768Z" },
+    { url = "https://files.pythonhosted.org/packages/df/5a/a7f759f97e4fd499c5d4e4488c760d5a7fbecf3028b465a04274fcd52384/sqlalchemy-2.0.50-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1918a3cf564d16d95bca7301005f41ab2ad50b07cd3b9da50d3ed986db148d6a", size = 3474879, upload-time = "2026-05-24T20:01:23.058Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/d9/2907ea38eb60687d297bf9c39e5ee58053c87b57fe8a9cae97090cecbf10/sqlalchemy-2.0.50-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:b00098cdbdbd38c7be3d568b0c9c3122b8c0ec62b911b57cd5e6e0254d60a76d", size = 3486117, upload-time = "2026-05-24T20:03:59.052Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/e3/5aa06f167559f8c0bdae487e297d23ba548150ab016a3418265d617a4985/sqlalchemy-2.0.50-cp314-cp314t-win32.whl", hash = "sha256:1fbd55a969d7ac44a98e3dec75016074f809fa08f871585ace58dde110d1bf3e", size = 2150823, upload-time = "2026-05-24T20:08:58.644Z" },
+    { url = "https://files.pythonhosted.org/packages/65/9b/112fb8f977582d7489d036e409e3723948bcf5320b3ac465f3c481bbe8f9/sqlalchemy-2.0.50-cp314-cp314t-win_amd64.whl", hash = "sha256:c5c3cdb753a9004183e1ccb634b41611654c989e61bc68617ce878e46d6f1e51", size = 2185794, upload-time = "2026-05-24T20:09:00.319Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/10/f7220e9b784d295d241c86ed99aeb537f92afcd469a64861f2717e9bb077/sqlalchemy-2.0.50-py3-none-any.whl", hash = "sha256:92064363517a3ff8212b5a93b8c62876579d8dfd1ca5b561335f30152d884fa9", size = 1943861, upload-time = "2026-05-24T19:59:01.119Z" },
 ]
 
 [package.optional-dependencies]
@@ -6514,14 +6554,14 @@ asyncio = [
 
 [[package]]
 name = "starlette"
-version = "1.0.0"
+version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
 ]
 
 [[package]]
@@ -6600,11 +6640,11 @@ wheels = [
 
 [[package]]
 name = "types-awscrt"
-version = "0.31.3"
+version = "0.34.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/76/26/0aa563e229c269c528a3b8c709fc671ac2a5c564732fab0852ac6ee006cf/types_awscrt-0.31.3.tar.gz", hash = "sha256:09d3eaf00231e0f47e101bd9867e430873bc57040050e2a3bd8305cb4fc30865", size = 18178, upload-time = "2026-03-08T02:31:14.569Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3e/59/44409a8fc06b444ab1a6f71dcb29d49a6e17e02424345eb51b051bebb345/types_awscrt-0.34.1.tar.gz", hash = "sha256:559aa04250f6a419a617dfb788f3e10903aaf74700ef23e521b64a411b83b803", size = 19062, upload-time = "2026-06-05T04:40:10.689Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3e/e5/47a573bbbd0a790f8f9fe452f7188ea72b212d21c9be57d5fc0cbc442075/types_awscrt-0.31.3-py3-none-any.whl", hash = "sha256:e5ce65a00a2ab4f35eacc1e3d700d792338d56e4823ee7b4dbe017f94cfc4458", size = 43340, upload-time = "2026-03-08T02:31:13.38Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/b1/214b12162b452ed6acd230065e6c587cde6b96871e3ce6d653f40888f8df/types_awscrt-0.34.1-py3-none-any.whl", hash = "sha256:20c752b6031544d8f694803c35174aee129f1be5ddf886ae46d22f7ffd9b7d75", size = 45688, upload-time = "2026-06-05T04:40:09.198Z" },
 ]
 
 [[package]]
@@ -6747,7 +6787,7 @@ wheels = [
 
 [[package]]
 name = "virtualenv"
-version = "21.3.3"
+version = "21.4.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
@@ -6755,9 +6795,9 @@ dependencies = [
     { name = "platformdirs" },
     { name = "python-discovery" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/15/ba/1f6e8c957e4932be060dcdc482d339c12e0216351478add3645cdaa53c05/virtualenv-21.3.3.tar.gz", hash = "sha256:f5bda277e553b1c2b3c1a8debfc30496e1288cc93ce6b7b71b3280047e317328", size = 7613784, upload-time = "2026-05-13T18:01:30.19Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/50/7564c805bb8966d9771caaba8a143fa5e57c848ce4e7fdf2d55a1feb2ead/virtualenv-21.4.3.tar.gz", hash = "sha256:938ff0fd3f4e0f0d3a025f67a3d2f25e3c3aabbcd5857ea6170619138d72d141", size = 7644454, upload-time = "2026-06-11T16:47:04.843Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/34/a9dbe051de88a63eb7408ea66630bac38e72f7f6077d4be58737106860d9/virtualenv-21.3.3-py3-none-any.whl", hash = "sha256:7d5987d8369e098e41406efb780a3d4ca79280097293899e351a6407ee153ab3", size = 7594554, upload-time = "2026-05-13T18:01:27.815Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/8d/84b0d07c6b5f685f85ddf6c87a59d3a8a895a3dfd89e759666fabe951b94/virtualenv-21.4.3-py3-none-any.whl", hash = "sha256:75f4127d4067397c64f38579ce918fec6bf9ca2cd4f48685e82952cc3c035840", size = 7625544, upload-time = "2026-06-11T16:47:01.78Z" },
 ]
 
 [[package]]
@@ -6844,33 +6884,33 @@ wheels = [
 
 [[package]]
 name = "wrapt"
-version = "2.1.2"
+version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2e/64/925f213fdcbb9baeb1530449ac71a4d57fc361c053d06bf78d0c5c7cd80c/wrapt-2.1.2.tar.gz", hash = "sha256:3996a67eecc2c68fd47b4e3c564405a5777367adfd9b8abb58387b63ee83b21e", size = 81678, upload-time = "2026-03-06T02:53:25.134Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/9f/06263fcd8ad6c405f05a3905fd7a84dd3176eb5ad46e44bccc0cd16348bb/wrapt-2.2.1.tar.gz", hash = "sha256:6744f504375775d7609c82c8d3d94af1c9a6f05586984536905908ba905277b9", size = 127620, upload-time = "2026-05-22T14:49:43.056Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/25/e7ea0b417db02bb796182a5316398a75792cd9a22528783d868755e1f669/wrapt-2.1.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1370e516598854e5b4366e09ce81e08bfe94d42b0fd569b88ec46cc56d9164a9", size = 61418, upload-time = "2026-03-06T02:53:55.706Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/0f/fa539e2f6a770249907757eaeb9a5ff4deb41c026f8466c1c6d799088a9b/wrapt-2.1.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6de1a3851c27e0bd6a04ca993ea6f80fc53e6c742ee1601f486c08e9f9b900a9", size = 61914, upload-time = "2026-03-06T02:52:53.37Z" },
-    { url = "https://files.pythonhosted.org/packages/53/37/02af1867f5b1441aaeda9c82deed061b7cd1372572ddcd717f6df90b5e93/wrapt-2.1.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:de9f1a2bbc5ac7f6012ec24525bdd444765a2ff64b5985ac6e0692144838542e", size = 120417, upload-time = "2026-03-06T02:54:30.74Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/b7/0138a6238c8ba7476c77cf786a807f871672b37f37a422970342308276e7/wrapt-2.1.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:970d57ed83fa040d8b20c52fe74a6ae7e3775ae8cff5efd6a81e06b19078484c", size = 122797, upload-time = "2026-03-06T02:54:51.539Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/ad/819ae558036d6a15b7ed290d5b14e209ca795dd4da9c58e50c067d5927b0/wrapt-2.1.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3969c56e4563c375861c8df14fa55146e81ac11c8db49ea6fb7f2ba58bc1ff9a", size = 117350, upload-time = "2026-03-06T02:54:37.651Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/2d/afc18dc57a4600a6e594f77a9ae09db54f55ba455440a54886694a84c71b/wrapt-2.1.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:57d7c0c980abdc5f1d98b11a2aa3bb159790add80258c717fa49a99921456d90", size = 121223, upload-time = "2026-03-06T02:54:35.221Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/5b/5ec189b22205697bc56eb3b62aed87a1e0423e9c8285d0781c7a83170d15/wrapt-2.1.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:776867878e83130c7a04237010463372e877c1c994d449ca6aaafeab6aab2586", size = 116287, upload-time = "2026-03-06T02:54:19.654Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/2d/f84939a7c9b5e6cdd8a8d0f6a26cabf36a0f7e468b967720e8b0cd2bdf69/wrapt-2.1.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:fab036efe5464ec3291411fabb80a7a39e2dd80bae9bcbeeca5087fdfa891e19", size = 119593, upload-time = "2026-03-06T02:54:16.697Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/fe/ccd22a1263159c4ac811ab9374c061bcb4a702773f6e06e38de5f81a1bdc/wrapt-2.1.2-cp314-cp314-win32.whl", hash = "sha256:e6ed62c82ddf58d001096ae84ce7f833db97ae2263bff31c9b336ba8cfe3f508", size = 58631, upload-time = "2026-03-06T02:53:06.498Z" },
-    { url = "https://files.pythonhosted.org/packages/65/0a/6bd83be7bff2e7efaac7b4ac9748da9d75a34634bbbbc8ad077d527146df/wrapt-2.1.2-cp314-cp314-win_amd64.whl", hash = "sha256:467e7c76315390331c67073073d00662015bb730c566820c9ca9b54e4d67fd04", size = 60875, upload-time = "2026-03-06T02:53:50.252Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/c0/0b3056397fe02ff80e5a5d72d627c11eb885d1ca78e71b1a5c1e8c7d45de/wrapt-2.1.2-cp314-cp314-win_arm64.whl", hash = "sha256:da1f00a557c66225d53b095a97eace0fc5349e3bfda28fa34ffae238978ee575", size = 59164, upload-time = "2026-03-06T02:53:59.128Z" },
-    { url = "https://files.pythonhosted.org/packages/71/ed/5d89c798741993b2371396eb9d4634f009ff1ad8a6c78d366fe2883ea7a6/wrapt-2.1.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:62503ffbc2d3a69891cf29beeaccdb4d5e0a126e2b6a851688d4777e01428dbb", size = 63163, upload-time = "2026-03-06T02:52:54.873Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/8c/05d277d182bf36b0a13d6bd393ed1dec3468a25b59d01fba2dd70fe4d6ae/wrapt-2.1.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c7e6cd120ef837d5b6f860a6ea3745f8763805c418bb2f12eeb1fa6e25f22d22", size = 63723, upload-time = "2026-03-06T02:52:56.374Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/27/6c51ec1eff4413c57e72d6106bb8dec6f0c7cdba6503d78f0fa98767bcc9/wrapt-2.1.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3769a77df8e756d65fbc050333f423c01ae012b4f6731aaf70cf2bef61b34596", size = 152652, upload-time = "2026-03-06T02:53:23.79Z" },
-    { url = "https://files.pythonhosted.org/packages/db/4c/d7dd662d6963fc7335bfe29d512b02b71cdfa23eeca7ab3ac74a67505deb/wrapt-2.1.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a76d61a2e851996150ba0f80582dd92a870643fa481f3b3846f229de88caf044", size = 158807, upload-time = "2026-03-06T02:53:35.742Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/4d/1e5eea1a78d539d346765727422976676615814029522c76b87a95f6bcdd/wrapt-2.1.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6f97edc9842cf215312b75fe737ee7c8adda75a89979f8e11558dfff6343cc4b", size = 146061, upload-time = "2026-03-06T02:52:57.574Z" },
-    { url = "https://files.pythonhosted.org/packages/89/bc/62cabea7695cd12a288023251eeefdcb8465056ddaab6227cb78a2de005b/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4006c351de6d5007aa33a551f600404ba44228a89e833d2fadc5caa5de8edfbf", size = 155667, upload-time = "2026-03-06T02:53:39.422Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/99/6f2888cd68588f24df3a76572c69c2de28287acb9e1972bf0c83ce97dbc1/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:a9372fc3639a878c8e7d87e1556fa209091b0a66e912c611e3f833e2c4202be2", size = 144392, upload-time = "2026-03-06T02:54:22.41Z" },
-    { url = "https://files.pythonhosted.org/packages/40/51/1dfc783a6c57971614c48e361a82ca3b6da9055879952587bc99fe1a7171/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3144b027ff30cbd2fca07c0a87e67011adb717eb5f5bd8496325c17e454257a3", size = 150296, upload-time = "2026-03-06T02:54:07.848Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/38/cbb8b933a0201076c1f64fc42883b0023002bdc14a4964219154e6ff3350/wrapt-2.1.2-cp314-cp314t-win32.whl", hash = "sha256:3b8d15e52e195813efe5db8cec156eebe339aaf84222f4f4f051a6c01f237ed7", size = 60539, upload-time = "2026-03-06T02:54:00.594Z" },
-    { url = "https://files.pythonhosted.org/packages/82/dd/e5176e4b241c9f528402cebb238a36785a628179d7d8b71091154b3e4c9e/wrapt-2.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:08ffa54146a7559f5b8df4b289b46d963a8e74ed16ba3687f99896101a3990c5", size = 63969, upload-time = "2026-03-06T02:54:39Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/99/79f17046cf67e4a95b9987ea129632ba8bcec0bc81f3fb3d19bdb0bd60cd/wrapt-2.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:72aaa9d0d8e4ed0e2e98019cea47a21f823c9dd4b43c7b77bba6679ffcca6a00", size = 60554, upload-time = "2026-03-06T02:53:14.132Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/c7/8528ac2dfa2c1e6708f647df7ae144ead13f0a31146f43c7264b4942bf12/wrapt-2.1.2-py3-none-any.whl", hash = "sha256:b8fd6fa2b2c4e7621808f8c62e8317f4aae56e59721ad933bac5239d913cf0e8", size = 43993, upload-time = "2026-03-06T02:53:12.905Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/a3/11d7f34ebbf3231bc907a3e6d5ee051b14d034c1bc7b65a97d5cc00516df/wrapt-2.2.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:6f56a647e4eaf5f0ca40330fb070f566bdf9f7b0db89a1af20d71c28dcd7a0ab", size = 80879, upload-time = "2026-05-22T14:48:51.802Z" },
+    { url = "https://files.pythonhosted.org/packages/13/3c/b74cfd984cef560b900fb1a727af20352d89e1f06bf2e1114dd3f00f5f5a/wrapt-2.2.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:64b7deeda4b70408e382328d8bbe52a256fe9bc63ae3db86d804608367e5422c", size = 81462, upload-time = "2026-05-22T14:48:53.18Z" },
+    { url = "https://files.pythonhosted.org/packages/15/a3/7c8f704b8dc07dfe0a5d01c2edbfd88317aa8e5e3fa7c743eb7a085ae767/wrapt-2.2.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b9cf53ba90717db2e292401de290776c498d4bbfb0d4a559ca2895db8b9dcb5c", size = 167251, upload-time = "2026-05-22T14:48:54.562Z" },
+    { url = "https://files.pythonhosted.org/packages/80/85/a34d1888d97247da6c2ff6118c3a721c73ed8cc4dd198c00208bb73b6f80/wrapt-2.2.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cf3638274ab9d9b724c9baa0b4c04e132cd6faefb78b4dd3dd1a02a4bdaad41e", size = 166316, upload-time = "2026-05-22T14:48:56.065Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d7/72ffaeb01eebc704afe3fb99e840480f4bda45f0fa66e3381b6a39251c8f/wrapt-2.2.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aed9658797d0b45d6c49adcfc6b41f66e6f2d0c6de3ec79e16cf4b1855df240f", size = 157952, upload-time = "2026-05-22T14:48:57.924Z" },
+    { url = "https://files.pythonhosted.org/packages/24/5b/36f5d6b024e4edfdd90b140742d11ebcf7836daf5c9daf326c55c24db412/wrapt-2.2.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:1d676ee388bc42a04d56dd7deb5605244dac2e35cc2fadbb43c9fa25bbd93508", size = 166130, upload-time = "2026-05-22T14:48:59.384Z" },
+    { url = "https://files.pythonhosted.org/packages/81/06/9296d9e97bfdef5483dfcc859d57b095b257144b2bc5300ab521e06f4bc7/wrapt-2.2.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e395f7bc31851ef9b612050368cb446e9bc14cd7454b025018980349caf25ae5", size = 156604, upload-time = "2026-05-22T14:49:00.921Z" },
+    { url = "https://files.pythonhosted.org/packages/53/37/16953929ed6776175720e58fc966e779926d8d71e2c7b2273230590ca71f/wrapt-2.2.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5f1845c2a8cc1180ccccfa45785dd06f562730d19ef75be180334254012b6283", size = 166007, upload-time = "2026-05-22T14:49:02.332Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/73/20ee58c0612dae7c31131a7095345812ed2c7b389019e175f68cde34e5b4/wrapt-2.2.1-cp314-cp314-win32.whl", hash = "sha256:436addbc4bb4fc0a88c702577f51195d7d73683a7f3e0e5b253d8404d7847243", size = 78327, upload-time = "2026-05-22T14:49:03.722Z" },
+    { url = "https://files.pythonhosted.org/packages/22/b3/ef7c3295d02e0448a71c639a36a057f46d524d057c9486291a7a3039e65c/wrapt-2.2.1-cp314-cp314-win_amd64.whl", hash = "sha256:50972a1d974ea07725a7f6b1cec5f8759008afd030a0024843ebe7d52de47f2b", size = 81144, upload-time = "2026-05-22T14:49:05.093Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/dc/7bdf336953f99f4ceb0a584bb8870e42c8f26f93ea10c87834dad62f1668/wrapt-2.2.1-cp314-cp314-win_arm64.whl", hash = "sha256:1c9934ea5d92957e3cd0adbc0845539dccfd62710ebe16195a8c66c53954db36", size = 79569, upload-time = "2026-05-22T14:49:06.413Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/6d/6dfae80150ff1919c356d1dd528f049bcdfaae29b4d284bc957e022caef4/wrapt-2.2.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:17de18fc12cea55b8a9587314cb830573e37fb33b247a7515696350863714188", size = 82892, upload-time = "2026-05-22T14:49:07.925Z" },
+    { url = "https://files.pythonhosted.org/packages/82/7b/4e34766a7d7804ffce9e71befe47e9b3225dc350c49c94493c4ab39fd3a5/wrapt-2.2.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a9dec1aca52dddde7df94818310fa2fe79739c8f385b2014c4cb1035f5508199", size = 83333, upload-time = "2026-05-22T14:49:09.257Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/57/0b34db3e8de44ccfece62d7b337abd1631dd810f5adc5f3db571727836b5/wrapt-2.2.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:69f2e9244542cb34dd59c7f073445b9e54ad9f3fce8d93606c368a1b499fc413", size = 202899, upload-time = "2026-05-22T14:49:10.572Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/45/ac0c459f154b99d92789a6cba7ca727185b83513b986f8ec7fe2aacddcbf/wrapt-2.2.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2d83966dc7f4f45e8b97b5933685ac2e6e67fc0e19246ea314bceb9a8970c956", size = 209986, upload-time = "2026-05-22T14:49:12.229Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/e4/77e37ff33ad018fa81ade52c25fa327b80b56f81d734279a63614fcb4cbc/wrapt-2.2.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:78b0aa6bfb7be8deed0ab23e7aa028cc5210c29bc2d32a04d52b50e517a7307e", size = 194893, upload-time = "2026-05-22T14:49:14.139Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/9d/7ea651d1ab032fc5fa222fbec91d0f8a1397f6ae04ebb93fa7219aa921d7/wrapt-2.2.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:05d5cb74d1b232ec8cfa130a8f900708699ff2491d97b8f85a4cdc5996294b85", size = 205636, upload-time = "2026-05-22T14:49:15.714Z" },
+    { url = "https://files.pythonhosted.org/packages/09/af/8e88031a701275b9085c54e64bc88c0b1cd55c77eadd400691c371cd76c4/wrapt-2.2.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f6518b94edb9150452e9aba08027d4cc293433753ec1fbefb4629a21cbc74181", size = 192267, upload-time = "2026-05-22T14:49:17.283Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/a8/e657ca876b06710194f243d81c4b0896ade646e244bdbec2d87c8c56a8bd/wrapt-2.2.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ed55af48b3eb28f43228ca2306788892bcb629eb2b5c4876e2a3659872c2f17a", size = 198378, upload-time = "2026-05-22T14:49:18.785Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/59/822efe4ea722a3961331bfa35b7d90937790d2c20f0616de1997ccc3aebd/wrapt-2.2.1-cp314-cp314t-win32.whl", hash = "sha256:2e08688ab16525897da6589d56d0aebaf417bbe91c2d8e3b96203b1efa596e85", size = 80226, upload-time = "2026-05-22T14:49:20.264Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/31/2a7dc5f6abb2fca0b6e1610e120419f603650aceb4f1d3ac4cae0354e162/wrapt-2.2.1-cp314-cp314t-win_amd64.whl", hash = "sha256:fd0135d34387f5fd087d9be368ea77ea89cf2451dc1cd1c622d35021bcb3ab50", size = 83835, upload-time = "2026-05-22T14:49:21.634Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/c0/782b86e28d1ceebeb74cccea12d2cd3d2ba0bd68e3dec20b1bc5873f6127/wrapt-2.2.1-cp314-cp314t-win_arm64.whl", hash = "sha256:f70db64e8266d7c45d3b735f2e08eeb434b5e03da9a479ae42b2e2e486a21a00", size = 80722, upload-time = "2026-05-22T14:49:23.59Z" },
+    { url = "https://files.pythonhosted.org/packages/53/46/29ac9daf11a86c22a8c38cd9236c62928ccae83f7ceb06bd3b0467cf9d05/wrapt-2.2.1-py3-none-any.whl", hash = "sha256:3aafea2975caef8ca49400640dde02cc7426e798f24870ed01f490bc3cffd32f", size = 61000, upload-time = "2026-05-22T14:49:41.593Z" },
 ]
 
 [[package]]
@@ -6932,15 +6972,21 @@ wheels = [
 
 [[package]]
 name = "zope-interface"
-version = "8.4"
+version = "8.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9f/65/34a6e6e4dfa260c4c55ee02bb2fc53625e126ff0181485286cf0c9d453d6/zope_interface-8.4.tar.gz", hash = "sha256:9dbee7925a23aa6349738892c911019d4095a96cff487b743482073ecbc174a8", size = 257736, upload-time = "2026-04-25T07:22:10.439Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/dc/50550cfcbb2ea3cbca5f1d7ed05c8aa840f831a0f2d63aec0a953f7c590e/zope_interface-8.5.tar.gz", hash = "sha256:7a3ba1c5877f0f3e3906b02ddf793abed2becc2948116414ce0e1dd820b68d6d", size = 257957, upload-time = "2026-05-26T06:50:14.574Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/d5/ca60c8b404b303d9490e1417430a5198a77557dbeb17c1cb31616e432318/zope_interface-8.4-cp314-cp314-macosx_10_9_x86_64.whl", hash = "sha256:7cbb887fdbfaacb4c362dbb487033551646e28013ad5ffe72e96eb260003a1a1", size = 212012, upload-time = "2026-04-25T07:28:36.88Z" },
-    { url = "https://files.pythonhosted.org/packages/83/64/6bb9f54250c817e24b39e986f173b6cd21ff658bec6c6cc0baad05d761e4/zope_interface-8.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a5638c6be715116d3453e6d099c299c6844d54810de7445ce116424e905ede06", size = 212071, upload-time = "2026-04-25T07:28:38.742Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/cf/42851262e102723058019dc7d0b48210b85a935f79ae32ce60ddccc2e8fb/zope_interface-8.4-cp314-cp314-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:b8147b40bfcd53803870a9519e0879ff066aeecc2fcff8295663c1b17fc38dc2", size = 266075, upload-time = "2026-04-25T07:28:41.084Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/a7/e48c79b836f6f0a2c219288e2ec343517f90e95c93de5435a8a23918bf20/zope_interface-8.4-cp314-cp314-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:049ba3c7b38cc400ae08e011617635706e0f442e1d075db1b015246fcbf6091e", size = 269127, upload-time = "2026-04-25T07:28:42.868Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/40/0e26f24d3a2f34f0de2cfeaab6458a865284d9d1fa317ab78913aa1f7322/zope_interface-8.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9c4ac009c2c8e43283842f80387c4d4b41bcbc293391c3b9ab71532ae1ccc301", size = 269446, upload-time = "2026-04-25T07:28:44.97Z" },
-    { url = "https://files.pythonhosted.org/packages/91/d5/20310601450367fc35fa28b0544c98d0347b8cc25eaf106a2c4cc36841e1/zope_interface-8.4-cp314-cp314-win_amd64.whl", hash = "sha256:4713bf651ec36e7eea49d2ace4f0e89bec2b33a339674874b1121f2537edc62a", size = 215199, upload-time = "2026-04-25T07:28:47.146Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/00/0d22ce75126e31f81baa5889e2a40aad37c8e34d1220cf8b18d744f2b5d9/zope_interface-8.4-cp314-cp314-win_arm64.whl", hash = "sha256:d934497c4b72d5f528d2b5ebe9b8b5a7004b5877948ebd4ea00c2432fb27178f", size = 213178, upload-time = "2026-04-25T07:28:48.868Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/19/5032e954827fdf02db2d2f49737ac4378bb9cfc2cd95a8f2e2a5ae2ec01a/zope_interface-8.5-cp314-cp314-macosx_10_9_x86_64.whl", hash = "sha256:ffaecf013251a89d0de6feb49a46eba48ad8cbbf8a40aeb6045e459e7bec6784", size = 212597, upload-time = "2026-05-26T06:49:51.63Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/53/3ef644012cf8a6a234a2d6134aab5a5c65ac5467c86296865501d4fbc406/zope_interface-8.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:126fa9d1c52295ae076d4cf968634f0a1826afa408a20808b57ff72877b8f69f", size = 212626, upload-time = "2026-05-26T06:49:53.236Z" },
+    { url = "https://files.pythonhosted.org/packages/32/67/bc8b4f465d388039255003e230c284a175cedf1203c692f23cb7bff64efe/zope_interface-8.5-cp314-cp314-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:3090e3a663d20194756a59a272e0c8508b889341e31d5894223331fe6b4f9b21", size = 266827, upload-time = "2026-05-26T06:49:54.873Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/eb/37d05b935ede53d79690fecc8d201440084418e590bcfc05f384451c7593/zope_interface-8.5-cp314-cp314-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9342fb74e2afefdb081bf1df727d209ea56995c6e13f5a0540e6d7aff4beafb8", size = 270139, upload-time = "2026-05-26T06:49:57.116Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/0b/fd0c54579e2ce8dc6cf1a757903f3374bc6fbda929a46af9e0f53cb0e5f0/zope_interface-8.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6c54725d818f1b57a7efb8b16528326e1f3c257b602b32393fd255c45af8799d", size = 270338, upload-time = "2026-05-26T06:49:58.698Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/1d/c420dcd777bb761067ea92879ac766694a5ca78608185f1aecea64cbfc11/zope_interface-8.5-cp314-cp314-win_amd64.whl", hash = "sha256:29d74febbae1afeb6834c4ccbf42e242a673c860060f09e53142825270456140", size = 215789, upload-time = "2026-05-26T06:50:00.405Z" },
+    { url = "https://files.pythonhosted.org/packages/62/94/50b5eb8f94e527edceac14f9955e58917424ea79bb572ddc18548561cbc2/zope_interface-8.5-cp314-cp314-win_arm64.whl", hash = "sha256:633c8c49396f38df030340797c533e9fe460d1b5d1e42d88e55e938e525f548c", size = 213757, upload-time = "2026-05-26T06:50:01.973Z" },
+    { url = "https://files.pythonhosted.org/packages/17/6f/5d5f32c4dfcdb16ce2ec5363da686840f13c13e1a1214cb70b49e1cd6d9f/zope_interface-8.5-cp314-cp314t-macosx_10_9_x86_64.whl", hash = "sha256:133999820fdbae513c36c03d6f29ef87317aaa3edef39112222b155083664714", size = 213591, upload-time = "2026-05-26T06:50:03.529Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/55/de0c3459ff717fce3342f9a29464c281fdeb0d36c3171ee88d119d5f0650/zope_interface-8.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8bd75c96966e573232f0599deaff717564828031c7f05563ccc1ac35c5ee0304", size = 213733, upload-time = "2026-05-26T06:50:05.101Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/95/d97430abd5ae9677e8b9295b58720c0064a5b557dbb6b8bf5928484cf0d8/zope_interface-8.5-cp314-cp314t-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:14b0e9799351d4c34fe99afd67f0cdd76e55ba15c66a98699d5fc22ea8241e08", size = 294905, upload-time = "2026-05-26T06:50:07.384Z" },
+    { url = "https://files.pythonhosted.org/packages/41/ec/a0f8f3dad6e74992f4654bdd94802be0929eabca7b871cac3b6fbb5e961b/zope_interface-8.5-cp314-cp314t-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0cd6a732ac84b94eb1ef9222a117347a27efd294ee16810ffdf7ecd307677ed5", size = 300885, upload-time = "2026-05-26T06:50:08.997Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/da/6881b48803a0ee8d23eb5efa30fce3ed218a2bd9de5758ce489d224fee81/zope_interface-8.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:798b7c87d0e59a7d5d086d642208d0d8700ff0d55c4029134b3c479c3bfb110f", size = 304672, upload-time = "2026-05-26T06:50:10.563Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/0e/b4c01320859ff1d585438bc231fd60bd258d096359bccf6654fecdf0cffb/zope_interface-8.5-cp314-cp314t-win_amd64.whl", hash = "sha256:0fc3a9d45f114d27eaa1e53beeb144533689edca8a9f66505b1e8e8b3f075e42", size = 217241, upload-time = "2026-05-26T06:50:12.171Z" },
 ]


### PR DESCRIPTION
## 📌 Description

Add a uv `exclude-newer` setting to avoid resolving packages newer than 7 days, refresh `uv.lock`, and add a Pyright helper stub for `fastapi.testclient.TestClient` so type checking passes with the latest Starlette.

## ✅ Related Issues

None

## 🔄 Changes

- Added `[tool.uv] exclude-newer = "7 days"` to `pyproject.toml`.
- Updated `uv.lock` with the refreshed dependency resolution.
- Kept `starlette` on the latest resolved version.
- Added `typings/fastapi/testclient.pyi` to provide stable `httpx.Response` return types for `TestClient` request methods.
- Verified `make typecheck` passes.

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.