### PR TITLE
Relax Python patch version requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "26.6"
 description = "RPC services that provides utility functions for building a wallet system on ibet-Network."
 authors = [{ name = "BOOSTRY Co., Ltd.", email = "dev@boostry.co.jp" }]
 license = { text = "Apache License, Version 2.0" }
-requires-python = "==3.14.6"
+requires-python = "==3.14.*"
 dependencies = [
     "boto3~=1.42.18",
     "eth-keyfile==0.8.1",

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 3
-requires-python = "==3.14.6"
+requires-python = "==3.14.*"
 
 [options]
 exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.


### PR DESCRIPTION
## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->

This pull request makes a minor update to the Python version requirement in the `pyproject.toml` file, allowing any patch version of Python 3.14 instead of only 3.14.6.

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
Related to #1839 

## 🔄 Changes

<!-- List the major changes in this PR. -->

- Relaxed the `requires-python` specification in `pyproject.toml` from `==3.14.6` to `==3.14.*`, permitting any Python 3.14 patch version to be used.

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
