### PR TITLE
Bump Ubuntu base image to 26.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/astral-sh/uv:0.11.26@sha256:3d868e555f8f1dbc324afa005066cd11e1053fc4743b9808ca8025283e65efa5 AS uv
 
-FROM ubuntu:24.04@sha256:786a8b558f7be160c6c8c4a54f9a57274f3b4fb1491cf65146521ae77ff1dc54 AS builder
+FROM ubuntu:26.04@sha256:b7f48194d4d8b763a478a621cdc81c27be222ba2206ca3ca6bc42b49685f3d9e AS builder
 
 ENV PYTHON_VERSION=3.14.6
 ENV UV_COMPILE_BYTECODE=1
@@ -68,7 +68,7 @@ RUN cd /app/ibet-Wallet-API \
  && rm -f /app/ibet-Wallet-API/uv.lock \
  && rm -rf /app/ibet-Wallet-API/tests/
 
-FROM ubuntu:24.04@sha256:786a8b558f7be160c6c8c4a54f9a57274f3b4fb1491cf65146521ae77ff1dc54 AS runner
+FROM ubuntu:26.04@sha256:b7f48194d4d8b763a478a621cdc81c27be222ba2206ca3ca6bc42b49685f3d9e AS runner
 
 # make application directory
 RUN mkdir -p /app

--- a/tests/Dockerfile_unittest
+++ b/tests/Dockerfile_unittest
@@ -1,6 +1,6 @@
 FROM ghcr.io/astral-sh/uv:0.11.26@sha256:3d868e555f8f1dbc324afa005066cd11e1053fc4743b9808ca8025283e65efa5 AS uv
 
-FROM ubuntu:24.04@sha256:786a8b558f7be160c6c8c4a54f9a57274f3b4fb1491cf65146521ae77ff1dc54 AS builder
+FROM ubuntu:26.04@sha256:b7f48194d4d8b763a478a621cdc81c27be222ba2206ca3ca6bc42b49685f3d9e AS builder
 
 ENV PYTHON_VERSION=3.14.6
 ENV UV_COMPILE_BYTECODE=1
@@ -65,7 +65,7 @@ RUN cd /app/ibet-Wallet-API \
  && rm -rf "$PYTHON_ROOT"/lib/python*/site-packages/pip "$PYTHON_ROOT"/lib/python*/site-packages/pip-*.dist-info \
  && rm -rf /home/apl/.cache/uv
 
-FROM ubuntu:24.04@sha256:786a8b558f7be160c6c8c4a54f9a57274f3b4fb1491cf65146521ae77ff1dc54 AS runner
+FROM ubuntu:26.04@sha256:b7f48194d4d8b763a478a621cdc81c27be222ba2206ca3ca6bc42b49685f3d9e AS runner
 
 # make application directory
 RUN mkdir -p /app


### PR DESCRIPTION
## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->

This pull request updates the base images used in both the main `Dockerfile` and the unit test Dockerfile to use Ubuntu 26.04 instead of Ubuntu 24.04. 

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
None

## 🔄 Changes

<!-- List the major changes in this PR. -->

**Docker base image updates:**

* Updated the `builder` and `runner` stages in `Dockerfile` to use `ubuntu:26.04` instead of `ubuntu:24.04`. 
* Updated the `builder` and `runner` stages in `tests/Dockerfile_unittest` to use `ubuntu:26.04` instead of `ubuntu:24.04`. 

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
