### PR TITLE
Add transfer source_event indexes

### DIFF
--- a/app/model/db/idx_transfer.py
+++ b/app/model/db/idx_transfer.py
@@ -57,6 +57,7 @@ class IDXTransfer(Base):
     __tablename__ = "transfer"
     __table_args__ = (
         Index("ix_transfer_token_address_id", "token_address", "id"),
+        Index("ix_transfer_source_event_id", "source_event", "id"),
         Index("ix_transfer_transaction_hash_id", "transaction_hash", "id"),
         Index("ix_transfer_from_address_id", "from_address", "id"),
         Index("ix_transfer_to_address_id", "to_address", "id"),
@@ -64,6 +65,12 @@ class IDXTransfer(Base):
             "ix_transfer_token_address_transaction_hash_id",
             "token_address",
             "transaction_hash",
+            "id",
+        ),
+        Index(
+            "ix_transfer_token_address_source_event_id",
+            "token_address",
+            "source_event",
             "id",
         ),
         Index(

--- a/migrations/versions/0c1e4f2d9a7b_v26_9_0_feature_1858_2.py
+++ b/migrations/versions/0c1e4f2d9a7b_v26_9_0_feature_1858_2.py
@@ -1,0 +1,46 @@
+"""v26_9_0_feature_1858_2
+
+Revision ID: 0c1e4f2d9a7b
+Revises: c7b40745b8d9
+Create Date: 2026-08-24 00:00:00.000000
+"""
+
+from alembic import op
+
+from app.database import get_db_schema
+
+# revision identifiers, used by Alembic.
+revision = "0c1e4f2d9a7b"
+down_revision = "c7b40745b8d9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index(
+        op.f("ix_transfer_source_event_id"),
+        "transfer",
+        ["source_event", "id"],
+        unique=False,
+        schema=get_db_schema(),
+    )
+    op.create_index(
+        op.f("ix_transfer_token_address_source_event_id"),
+        "transfer",
+        ["token_address", "source_event", "id"],
+        unique=False,
+        schema=get_db_schema(),
+    )
+
+
+def downgrade():
+    op.drop_index(
+        op.f("ix_transfer_token_address_source_event_id"),
+        table_name="transfer",
+        schema=get_db_schema(),
+    )
+    op.drop_index(
+        op.f("ix_transfer_source_event_id"),
+        table_name="transfer",
+        schema=get_db_schema(),
+    )


### PR DESCRIPTION
## 📌 Description

Improve transfer history search performance when the amount of transfer data increases.

## ✅ Related Issues

- Related to #1858

## 🔄 Changes

- Add composite indexes for `source_event` filtering:
  - `(source_event, id)`
  - `(token_address, source_event, id)`

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
