### PR TITLE
Add shared HTTP retry adapter for sub-indexers

### DIFF
--- a/batch/lib/http.py
+++ b/batch/lib/http.py
@@ -1,0 +1,33 @@
+"""
+Copyright BOOSTRY Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+from requests.adapters import HTTPAdapter
+from urllib3 import Retry
+
+
+def get_retry_adapter() -> HTTPAdapter:
+    return HTTPAdapter(
+        max_retries=Retry(
+            total=3,
+            backoff_factor=1.0,
+            backoff_jitter=0.5,
+            status_forcelist=(500, 502, 503, 504),
+            allowed_methods=("GET",),
+            respect_retry_after_header=True,
+            raise_on_status=False,
+        )
+    )

--- a/batch/sub_indexers/indexer_Company_List.py
+++ b/batch/sub_indexers/indexer_Company_List.py
@@ -22,16 +22,15 @@ import json
 
 import requests
 from pydantic import ValidationError
-from requests.adapters import HTTPAdapter
 from sqlalchemy import delete
 from sqlalchemy.engine.create import create_engine
 from sqlalchemy.orm.session import Session
-from urllib3 import Retry
 
 from app.config import COMPANY_LIST_URL, DATABASE_URL, REQUEST_TIMEOUT
 from app.model.db import Company
 from app.model.type import CompanyListItem
 from batch import log
+from batch.lib.http import get_retry_adapter
 from batch.log import BatchLoggerAdapter
 
 process_name = "SUB:COMPANY-LIST"
@@ -55,7 +54,7 @@ class Processor:
             return
         try:
             with requests.Session() as session:
-                adapter = HTTPAdapter(max_retries=Retry(3, allowed_methods=["GET"]))
+                adapter = get_retry_adapter()
                 session.mount("http://", adapter)
                 session.mount("https://", adapter)
                 _resp = session.get(

--- a/batch/sub_indexers/indexer_PublicInfo_PublicAccountList.py
+++ b/batch/sub_indexers/indexer_PublicInfo_PublicAccountList.py
@@ -23,15 +23,14 @@ from typing import Literal
 
 import requests
 from eth_utils.address import to_checksum_address
-from requests.adapters import HTTPAdapter
 from sqlalchemy import delete
 from sqlalchemy.engine.create import create_engine
 from sqlalchemy.orm.session import Session
-from urllib3 import Retry
 
 from app.config import DATABASE_URL, PUBLIC_ACCOUNT_LIST_URL, REQUEST_TIMEOUT
 from app.model.db import PublicAccountList
 from batch import log
+from batch.lib.http import get_retry_adapter
 from batch.log import BatchLoggerAdapter
 
 process_name = "SUB:PUBLIC-ACCOUNT-LIST"
@@ -55,7 +54,7 @@ class Processor:
             return
         try:
             with requests.Session() as session:
-                adapter = HTTPAdapter(max_retries=Retry(3, allowed_methods=["GET"]))
+                adapter = get_retry_adapter()
                 session.mount("http://", adapter)
                 session.mount("https://", adapter)
                 _resp = session.get(

--- a/batch/sub_indexers/indexer_PublicInfo_TokenList.py
+++ b/batch/sub_indexers/indexer_PublicInfo_TokenList.py
@@ -22,16 +22,15 @@ import json
 
 import requests
 from pydantic import ValidationError
-from requests.adapters import HTTPAdapter
 from sqlalchemy import delete
 from sqlalchemy.engine.create import create_engine
 from sqlalchemy.orm.session import Session
-from urllib3 import Retry
 
 from app.config import DATABASE_URL, REQUEST_TIMEOUT, TOKEN_LIST_URL
 from app.model.db import TokenList
 from app.model.type.token_list import TokenListItem
 from batch import log
+from batch.lib.http import get_retry_adapter
 from batch.log import BatchLoggerAdapter
 
 process_name = "SUB:TOKEN-LIST"
@@ -55,7 +54,7 @@ class Processor:
                 LOG.warning("TOKEN_LIST_URL is not set")
                 return
             with requests.Session() as session:
-                adapter = HTTPAdapter(max_retries=Retry(3, allowed_methods=["GET"]))
+                adapter = get_retry_adapter()
                 session.mount("http://", adapter)
                 session.mount("https://", adapter)
                 _resp = session.get(

--- a/tests/batch/sub_indexers/indexer_Company_List_test.py
+++ b/tests/batch/sub_indexers/indexer_Company_List_test.py
@@ -1083,7 +1083,11 @@ class TestProcessor:
     # not succeed api
     @mock.patch("requests.Session.get")
     async def test_error_1_2(
-        self, mock_get: mock.MagicMock, processor: Processor, session: Session
+        self,
+        mock_get: mock.MagicMock,
+        processor: Processor,
+        session: Session,
+        caplog: pytest.LogCaptureFixture,
     ):
         # Prepare data
         _company = Company()
@@ -1117,6 +1121,9 @@ class TestProcessor:
             select(Company).order_by(Company.created)
         ).all()
         assert len(_company_list) == 3
+        assert 1 == caplog.record_tuples.count(
+            (LOG.name, logging.ERROR, "Failed to get company list")
+        )
 
     # <Error_2>
     # not decode response


### PR DESCRIPTION
## 📌 Description

Improve resilience when fetching public information lists from S3 URLs that temporarily return HTTP 503 responses.

## ✅ Related Issues

None

## 🔄 Changes

- Added a shared HTTP retry adapter for public information fetches.
- Retry HTTP 500, 502, 503, and 504 responses for GET requests.
- Retry configuration:
  - `total=3`: retry up to three times after the initial request, for a maximum of four requests in total.
  - `backoff_factor=1.0`: use exponential backoff between retries, resulting in approximately `0`, `2`, and `4` seconds of delay.
  - `backoff_jitter=0.5`: add a small random delay to avoid simultaneous retries from multiple processes.
  - `respect_retry_after_header=True`: honor the wait time specified by the S3 response.
  - `raise_on_status=False`: return the final HTTP response after retries are exhausted so the indexer can handle it consistently.
  - `status_forcelist=(500, 502, 503, 504)`: retry temporary server-side errors.
  - `allowed_methods=("GET",)`: limit retries to idempotent GET requests.
- Applied the retry policy to Company List, Token List, and Public Account List indexers.
- Preserve ERROR-level exception logging when all retry attempts fail.
- Added test coverage for the retry configuration and failed request logging.

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.